### PR TITLE
Add interactive pan/zoom camera controls

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,6 +68,14 @@ F = "F-F++F-F"          # each F is replaced by this string each iteration
 Whitespace inside `axiom` and rule strings is stripped before processing, so
 you can break long rules across lines for readability.
 
+### Controls
+
+| Input | Action |
+|-------|--------|
+| Drag (left button) | Pan |
+| Scroll wheel | Zoom in / out toward the cursor |
+| `F` | Reset view to fit the fractal |
+
 ### Bundled presets
 
 | File | Name | Description |
@@ -140,6 +148,8 @@ crates/
     src/
       main.rs               native entry point — loads a preset, runs the event loop
       renderer.rs           wgpu render state, pipeline, and winit ApplicationHandler
+      camera.rs             Camera (pan/zoom state) and Transform uniform
+      input.rs              mouse drag and cursor tracking
       shader.wgsl           WGSL vertex + fragment shaders (LineList topology)
       lib.rs                wasm-bindgen entry point (web, rendering TBD)
 

--- a/crates/lsystem-app/src/camera.rs
+++ b/crates/lsystem-app/src/camera.rs
@@ -1,0 +1,217 @@
+use bytemuck::{Pod, Zeroable};
+
+#[repr(C)]
+#[derive(Copy, Clone, Pod, Zeroable)]
+pub struct Transform {
+    pub scale: [f32; 2],
+    pub offset: [f32; 2],
+}
+
+pub struct Camera {
+    pan: [f32; 2],
+    zoom: f32,
+}
+
+impl Camera {
+    pub fn new() -> Self {
+        Self {
+            pan: [0.0, 0.0],
+            zoom: 1.0,
+        }
+    }
+
+    pub fn reset(&mut self) {
+        self.pan = [0.0, 0.0];
+        self.zoom = 1.0;
+    }
+
+    fn px_per_unit(
+        &self,
+        bounds_min: [f32; 2],
+        bounds_max: [f32; 2],
+        width: u32,
+        height: u32,
+    ) -> f32 {
+        let geom_w = (bounds_max[0] - bounds_min[0]).max(1.0);
+        let geom_h = (bounds_max[1] - bounds_min[1]).max(1.0);
+        let base = (width as f32 / geom_w).min(height as f32 / geom_h) * 0.9;
+        base * self.zoom
+    }
+
+    pub fn compute_transform(
+        &self,
+        bounds_min: [f32; 2],
+        bounds_max: [f32; 2],
+        width: u32,
+        height: u32,
+    ) -> Transform {
+        let cx = (bounds_min[0] + bounds_max[0]) * 0.5;
+        let cy = (bounds_min[1] + bounds_max[1]) * 0.5;
+        let ppu = self.px_per_unit(bounds_min, bounds_max, width, height);
+        let sx = ppu * 2.0 / width as f32;
+        let sy = ppu * 2.0 / height as f32;
+        Transform {
+            scale: [sx, sy],
+            offset: [(-cx + self.pan[0]) * sx, (-cy + self.pan[1]) * sy],
+        }
+    }
+
+    pub fn pan_by_pixels(
+        &mut self,
+        screen_dx: f32,
+        screen_dy: f32,
+        bounds_min: [f32; 2],
+        bounds_max: [f32; 2],
+        width: u32,
+        height: u32,
+    ) {
+        let ppu = self.px_per_unit(bounds_min, bounds_max, width, height);
+        self.pan[0] += screen_dx / ppu;
+        // screen Y increases downward, world Y increases upward
+        self.pan[1] -= screen_dy / ppu;
+    }
+
+    /// Zoom by `factor` keeping the world point under `cursor_px` fixed in screen space.
+    pub fn zoom_toward_cursor(
+        &mut self,
+        factor: f32,
+        cursor_px: [f32; 2],
+        bounds_min: [f32; 2],
+        bounds_max: [f32; 2],
+        width: u32,
+        height: u32,
+    ) {
+        if factor <= 0.0 {
+            return;
+        }
+        let ppu = self.px_per_unit(bounds_min, bounds_max, width, height);
+        let sx = ppu * 2.0 / width as f32;
+        let sy = ppu * 2.0 / height as f32;
+        let ndc_x = cursor_px[0] / width as f32 * 2.0 - 1.0;
+        let ndc_y = 1.0 - cursor_px[1] / height as f32 * 2.0;
+        // Derived from: world_under_cursor = ndc / scale_old + center - pan
+        // After zoom: ndc = (world_under_cursor - center + pan_new) * scale_new
+        // → pan_new = pan_old - ndc / scale_old * (1 - 1/factor)
+        let clamped = (self.zoom * factor).clamp(1e-4, 1e4);
+        let actual = clamped / self.zoom;
+        self.pan[0] -= ndc_x / sx * (1.0 - 1.0 / actual);
+        self.pan[1] -= ndc_y / sy * (1.0 - 1.0 / actual);
+        self.zoom = clamped;
+    }
+}
+
+impl Default for Camera {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    const EPS: f32 = 1e-5;
+
+    fn close(a: f32, b: f32) -> bool {
+        (a - b).abs() < EPS
+    }
+
+    #[test]
+    fn transform_square_geo_square_viewport() {
+        let t = Camera::new().compute_transform([-1.0, -1.0], [1.0, 1.0], 100, 100);
+        assert!(close(t.scale[0], 0.9), "scale x = {}", t.scale[0]);
+        assert!(close(t.scale[1], 0.9), "scale y = {}", t.scale[1]);
+        assert!(close(t.offset[0], 0.0));
+        assert!(close(t.offset[1], 0.0));
+    }
+
+    #[test]
+    fn transform_center_maps_to_ndc_origin() {
+        let t = Camera::new().compute_transform([1.0, 0.0], [5.0, 4.0], 200, 200);
+        assert!(close(3.0 * t.scale[0] + t.offset[0], 0.0));
+        assert!(close(2.0 * t.scale[1] + t.offset[1], 0.0));
+    }
+
+    #[test]
+    fn transform_width_constrained_fills_horizontal() {
+        let t = Camera::new().compute_transform([0.0, 0.0], [4.0, 1.0], 100, 100);
+        assert!(close(4.0 * t.scale[0], 1.8));
+        assert!(1.0 * t.scale[1] < 0.9);
+    }
+
+    #[test]
+    fn transform_height_constrained_fills_vertical() {
+        let t = Camera::new().compute_transform([0.0, 0.0], [1.0, 4.0], 100, 100);
+        assert!(close(4.0 * t.scale[1], 1.8));
+        assert!(1.0 * t.scale[0] < 0.9);
+    }
+
+    #[test]
+    fn transform_preserves_aspect_ratio_in_landscape_viewport() {
+        let t = Camera::new().compute_transform([-1.0, -1.0], [1.0, 1.0], 200, 100);
+        let px_per_unit_x = t.scale[0] * 100.0;
+        let px_per_unit_y = t.scale[1] * 50.0;
+        assert!(close(px_per_unit_x, px_per_unit_y));
+    }
+
+    #[test]
+    fn transform_degenerate_point_geometry_stays_finite() {
+        let t = Camera::new().compute_transform([5.0, 3.0], [5.0, 3.0], 100, 100);
+        assert!(t.scale[0].is_finite() && t.scale[0] > 0.0);
+        assert!(t.scale[1].is_finite() && t.scale[1] > 0.0);
+        assert!(close(5.0 * t.scale[0] + t.offset[0], 0.0));
+        assert!(close(3.0 * t.scale[1] + t.offset[1], 0.0));
+    }
+
+    #[test]
+    fn zoom_doubles_scale() {
+        let bounds_min = [-1.0f32, -1.0];
+        let bounds_max = [1.0f32, 1.0];
+        let (w, h) = (100u32, 100u32);
+        let mut cam = Camera::new();
+        let t_before = cam.compute_transform(bounds_min, bounds_max, w, h);
+        cam.zoom_toward_cursor(2.0, [50.0, 50.0], bounds_min, bounds_max, w, h);
+        let t_after = cam.compute_transform(bounds_min, bounds_max, w, h);
+        assert!(close(t_after.scale[0], t_before.scale[0] * 2.0));
+        assert!(close(t_after.scale[1], t_before.scale[1] * 2.0));
+    }
+
+    #[test]
+    fn zoom_preserves_world_point_under_cursor() {
+        let bounds_min = [-1.0f32, -1.0];
+        let bounds_max = [1.0f32, 1.0];
+        let (w, h) = (200u32, 200u32);
+        // Cursor at top-right: pixel (150, 50) → NDC (0.5, 0.5)
+        let cursor = [150.0f32, 50.0];
+        let ndc_x = cursor[0] / w as f32 * 2.0 - 1.0;
+        let ndc_y = 1.0 - cursor[1] / h as f32 * 2.0;
+
+        let mut cam = Camera::new();
+        let t_before = cam.compute_transform(bounds_min, bounds_max, w, h);
+        // World point currently under cursor
+        let wp_x = (ndc_x - t_before.offset[0]) / t_before.scale[0];
+        let wp_y = (ndc_y - t_before.offset[1]) / t_before.scale[1];
+
+        cam.zoom_toward_cursor(2.0, cursor, bounds_min, bounds_max, w, h);
+        let t_after = cam.compute_transform(bounds_min, bounds_max, w, h);
+
+        // Same world point should map to the same cursor NDC
+        let ndc_x_after = wp_x * t_after.scale[0] + t_after.offset[0];
+        let ndc_y_after = wp_y * t_after.scale[1] + t_after.offset[1];
+        assert!(close(ndc_x_after, ndc_x), "x: {ndc_x_after} != {ndc_x}");
+        assert!(close(ndc_y_after, ndc_y), "y: {ndc_y_after} != {ndc_y}");
+    }
+
+    #[test]
+    fn pan_right_moves_geometry_right() {
+        let bounds_min = [-1.0f32, -1.0];
+        let bounds_max = [1.0f32, 1.0];
+        let (w, h) = (100u32, 100u32);
+        let mut cam = Camera::new();
+        cam.pan_by_pixels(10.0, 0.0, bounds_min, bounds_max, w, h);
+        let t = cam.compute_transform(bounds_min, bounds_max, w, h);
+        // Geometry center (world 0,0) maps to positive NDC x (shifted right)
+        let ndc_center = 0.0 * t.scale[0] + t.offset[0];
+        assert!(ndc_center > 0.0, "ndc center x = {ndc_center}");
+    }
+}

--- a/crates/lsystem-app/src/input.rs
+++ b/crates/lsystem-app/src/input.rs
@@ -1,0 +1,40 @@
+pub struct InputState {
+    pub cursor_pos: [f32; 2],
+    drag_active: bool,
+    last_drag_pos: [f32; 2],
+}
+
+impl InputState {
+    pub fn new() -> Self {
+        Self {
+            cursor_pos: [0.0; 2],
+            drag_active: false,
+            last_drag_pos: [0.0; 2],
+        }
+    }
+
+    /// Returns the screen-space drag delta `[dx, dy]` if a drag is in progress.
+    pub fn on_cursor_moved(&mut self, x: f32, y: f32) -> Option<[f32; 2]> {
+        self.cursor_pos = [x, y];
+        if self.drag_active {
+            let delta = [x - self.last_drag_pos[0], y - self.last_drag_pos[1]];
+            self.last_drag_pos = [x, y];
+            Some(delta)
+        } else {
+            None
+        }
+    }
+
+    pub fn on_left_button(&mut self, pressed: bool) {
+        if pressed {
+            self.last_drag_pos = self.cursor_pos;
+        }
+        self.drag_active = pressed;
+    }
+}
+
+impl Default for InputState {
+    fn default() -> Self {
+        Self::new()
+    }
+}

--- a/crates/lsystem-app/src/main.rs
+++ b/crates/lsystem-app/src/main.rs
@@ -1,3 +1,5 @@
+mod camera;
+mod input;
 mod renderer;
 
 use lsystem_core::Config;

--- a/crates/lsystem-app/src/renderer.rs
+++ b/crates/lsystem-app/src/renderer.rs
@@ -4,42 +4,18 @@ use bytemuck::{Pod, Zeroable};
 use lsystem_core::Geometry;
 use wgpu::util::DeviceExt;
 use winit::application::ApplicationHandler;
-use winit::event::WindowEvent;
+use winit::event::{ElementState, MouseButton, MouseScrollDelta, WindowEvent};
 use winit::event_loop::ActiveEventLoop;
+use winit::keyboard::Key;
 use winit::window::{Window, WindowId};
+
+use crate::camera::{Camera, Transform};
+use crate::input::InputState;
 
 #[repr(C)]
 #[derive(Copy, Clone, Pod, Zeroable)]
 struct Vertex {
     position: [f32; 2],
-}
-
-#[repr(C)]
-#[derive(Copy, Clone, Pod, Zeroable)]
-struct Transform {
-    scale: [f32; 2],
-    offset: [f32; 2],
-}
-
-fn compute_transform(
-    bounds_min: [f32; 2],
-    bounds_max: [f32; 2],
-    width: u32,
-    height: u32,
-) -> Transform {
-    let geom_w = (bounds_max[0] - bounds_min[0]).max(1.0);
-    let geom_h = (bounds_max[1] - bounds_min[1]).max(1.0);
-    let cx = (bounds_min[0] + bounds_max[0]) * 0.5;
-    let cy = (bounds_min[1] + bounds_max[1]) * 0.5;
-
-    let px_per_unit = (width as f32 / geom_w).min(height as f32 / geom_h) * 0.9;
-    let sx = px_per_unit * 2.0 / width as f32;
-    let sy = px_per_unit * 2.0 / height as f32;
-
-    Transform {
-        scale: [sx, sy],
-        offset: [-cx * sx, -cy * sy],
-    }
 }
 
 struct GpuState {
@@ -52,17 +28,10 @@ struct GpuState {
     vertex_count: u32,
     uniform_buffer: wgpu::Buffer,
     bind_group: wgpu::BindGroup,
-    bounds_min: [f32; 2],
-    bounds_max: [f32; 2],
 }
 
 impl GpuState {
-    async fn new(
-        window: Arc<Window>,
-        vertices: &[Vertex],
-        bounds_min: [f32; 2],
-        bounds_max: [f32; 2],
-    ) -> Self {
+    async fn new(window: Arc<Window>, vertices: &[Vertex], initial_transform: &Transform) -> Self {
         let size = window.inner_size();
 
         let instance = wgpu::Instance::default();
@@ -105,15 +74,9 @@ impl GpuState {
             source: wgpu::ShaderSource::Wgsl(include_str!("shader.wgsl").into()),
         });
 
-        let transform = compute_transform(
-            bounds_min,
-            bounds_max,
-            size.width.max(1),
-            size.height.max(1),
-        );
         let uniform_buffer = device.create_buffer_init(&wgpu::util::BufferInitDescriptor {
             label: None,
-            contents: bytemuck::bytes_of(&transform),
+            contents: bytemuck::bytes_of(initial_transform),
             usage: wgpu::BufferUsages::UNIFORM | wgpu::BufferUsages::COPY_DST,
         });
 
@@ -193,9 +156,16 @@ impl GpuState {
             vertex_count: vertices.len() as u32,
             uniform_buffer,
             bind_group,
-            bounds_min,
-            bounds_max,
         }
+    }
+
+    fn size(&self) -> (u32, u32) {
+        (self.surface_config.width, self.surface_config.height)
+    }
+
+    fn upload_transform(&self, transform: &Transform) {
+        self.queue
+            .write_buffer(&self.uniform_buffer, 0, bytemuck::bytes_of(transform));
     }
 
     fn resize(&mut self, new_size: winit::dpi::PhysicalSize<u32>) {
@@ -205,23 +175,12 @@ impl GpuState {
         self.surface_config.width = new_size.width;
         self.surface_config.height = new_size.height;
         self.surface.configure(&self.device, &self.surface_config);
-        let transform = compute_transform(
-            self.bounds_min,
-            self.bounds_max,
-            new_size.width,
-            new_size.height,
-        );
-        self.queue
-            .write_buffer(&self.uniform_buffer, 0, bytemuck::bytes_of(&transform));
     }
 
     fn render(&mut self) -> bool {
-        let frame = match self.surface.get_current_texture() {
-            wgpu::CurrentSurfaceTexture::Success(t) => t,
-            wgpu::CurrentSurfaceTexture::Suboptimal(t) => {
-                self.surface.configure(&self.device, &self.surface_config);
-                t
-            }
+        let (frame, reconfigure) = match self.surface.get_current_texture() {
+            wgpu::CurrentSurfaceTexture::Success(t) => (t, false),
+            wgpu::CurrentSurfaceTexture::Suboptimal(t) => (t, true),
             wgpu::CurrentSurfaceTexture::Outdated | wgpu::CurrentSurfaceTexture::Lost => {
                 self.surface.configure(&self.device, &self.surface_config);
                 return true;
@@ -261,7 +220,10 @@ impl GpuState {
         }
         self.queue.submit([encoder.finish()]);
         frame.present();
-        false
+        if reconfigure {
+            self.surface.configure(&self.device, &self.surface_config);
+        }
+        reconfigure
     }
 }
 
@@ -271,6 +233,8 @@ pub struct App {
     vertices: Vec<Vertex>,
     bounds_min: [f32; 2],
     bounds_max: [f32; 2],
+    camera: Camera,
+    input: InputState,
 }
 
 impl App {
@@ -309,6 +273,18 @@ impl App {
             vertices,
             bounds_min: [min_x, min_y],
             bounds_max: [max_x, max_y],
+            camera: Camera::new(),
+            input: InputState::new(),
+        }
+    }
+
+    fn upload_camera_transform(&self) {
+        if let Some(state) = &self.state {
+            let (w, h) = state.size();
+            let transform = self
+                .camera
+                .compute_transform(self.bounds_min, self.bounds_max, w, h);
+            state.upload_transform(&transform);
         }
     }
 }
@@ -320,11 +296,17 @@ impl ApplicationHandler for App {
                 .create_window(Window::default_attributes().with_title("Grow Your Own Fractal"))
                 .unwrap(),
         );
+        let size = window.inner_size();
+        let initial_transform = self.camera.compute_transform(
+            self.bounds_min,
+            self.bounds_max,
+            size.width.max(1),
+            size.height.max(1),
+        );
         let state = pollster::block_on(GpuState::new(
             window.clone(),
             &self.vertices,
-            self.bounds_min,
-            self.bounds_max,
+            &initial_transform,
         ));
         window.request_redraw();
         self.window = Some(window);
@@ -334,14 +316,79 @@ impl ApplicationHandler for App {
     fn window_event(&mut self, event_loop: &ActiveEventLoop, _id: WindowId, event: WindowEvent) {
         match event {
             WindowEvent::CloseRequested => event_loop.exit(),
+
             WindowEvent::Resized(size) => {
                 if let Some(state) = &mut self.state {
                     state.resize(size);
                 }
+                self.upload_camera_transform();
                 if let Some(window) = &self.window {
                     window.request_redraw();
                 }
             }
+
+            WindowEvent::MouseInput {
+                state,
+                button: MouseButton::Left,
+                ..
+            } => {
+                self.input.on_left_button(state == ElementState::Pressed);
+            }
+
+            WindowEvent::CursorMoved { position, .. } => {
+                let x = position.x as f32;
+                let y = position.y as f32;
+                if let Some([dx, dy]) = self.input.on_cursor_moved(x, y) {
+                    if let Some(state) = &self.state {
+                        let (w, h) = state.size();
+                        self.camera
+                            .pan_by_pixels(dx, dy, self.bounds_min, self.bounds_max, w, h);
+                    }
+                    self.upload_camera_transform();
+                    if let Some(window) = &self.window {
+                        window.request_redraw();
+                    }
+                }
+            }
+
+            WindowEvent::MouseWheel { delta, .. } => {
+                let lines = match delta {
+                    MouseScrollDelta::LineDelta(_, y) => y,
+                    MouseScrollDelta::PixelDelta(pos) => pos.y as f32 / 20.0,
+                };
+                let factor = 1.1_f32.powf(lines);
+                if let Some(state) = &self.state {
+                    let (w, h) = state.size();
+                    let cursor = self.input.cursor_pos;
+                    self.camera.zoom_toward_cursor(
+                        factor,
+                        cursor,
+                        self.bounds_min,
+                        self.bounds_max,
+                        w,
+                        h,
+                    );
+                }
+                self.upload_camera_transform();
+                if let Some(window) = &self.window {
+                    window.request_redraw();
+                }
+            }
+
+            WindowEvent::KeyboardInput { event, .. }
+                if event.state == ElementState::Pressed && !event.repeat =>
+            {
+                if let Key::Character(ch) = &event.logical_key
+                    && ch.eq_ignore_ascii_case("f")
+                {
+                    self.camera.reset();
+                    self.upload_camera_transform();
+                    if let Some(window) = &self.window {
+                        window.request_redraw();
+                    }
+                }
+            }
+
             WindowEvent::RedrawRequested => {
                 if let (Some(state), Some(window)) = (&mut self.state, &self.window)
                     && state.render()
@@ -349,6 +396,7 @@ impl ApplicationHandler for App {
                     window.request_redraw();
                 }
             }
+
             _ => {}
         }
     }
@@ -369,67 +417,8 @@ mod tests {
         Config::parse(toml).unwrap()
     }
 
-    // --- compute_transform ---
-
-    #[test]
-    fn transform_square_geo_square_viewport() {
-        let t = compute_transform([-1.0, -1.0], [1.0, 1.0], 100, 100);
-        assert!(close(t.scale[0], 0.9), "scale x = {}", t.scale[0]);
-        assert!(close(t.scale[1], 0.9), "scale y = {}", t.scale[1]);
-        assert!(close(t.offset[0], 0.0));
-        assert!(close(t.offset[1], 0.0));
-    }
-
-    #[test]
-    fn transform_center_maps_to_ndc_origin() {
-        // Geometry centered at (3, 2).
-        let t = compute_transform([1.0, 0.0], [5.0, 4.0], 200, 200);
-        assert!(close(3.0 * t.scale[0] + t.offset[0], 0.0));
-        assert!(close(2.0 * t.scale[1] + t.offset[1], 0.0));
-    }
-
-    #[test]
-    fn transform_width_constrained_fills_horizontal() {
-        // 4-wide × 1-tall geometry is width-constrained: horizontal NDC extent = 0.9 × 2.
-        let t = compute_transform([0.0, 0.0], [4.0, 1.0], 100, 100);
-        assert!(close(4.0 * t.scale[0], 1.8));
-        assert!(1.0 * t.scale[1] < 0.9);
-    }
-
-    #[test]
-    fn transform_height_constrained_fills_vertical() {
-        // 1-wide × 4-tall geometry is height-constrained: vertical NDC extent = 0.9 × 2.
-        let t = compute_transform([0.0, 0.0], [1.0, 4.0], 100, 100);
-        assert!(close(4.0 * t.scale[1], 1.8));
-        assert!(1.0 * t.scale[0] < 0.9);
-    }
-
-    #[test]
-    fn transform_preserves_aspect_ratio_in_landscape_viewport() {
-        // 200×100 window, square geometry: scale_x ≠ scale_y, but pixel density per
-        // world unit must be equal in both axes so the fractal isn't stretched.
-        let t = compute_transform([-1.0, -1.0], [1.0, 1.0], 200, 100);
-        let px_per_unit_x = t.scale[0] * 100.0; // (width / 2) NDC-to-pixel factor
-        let px_per_unit_y = t.scale[1] * 50.0; //  (height / 2)
-        assert!(close(px_per_unit_x, px_per_unit_y));
-    }
-
-    #[test]
-    fn transform_degenerate_point_geometry_stays_finite() {
-        // Zero-size geometry hits the max(1.0) floor; scale must stay finite and positive.
-        let t = compute_transform([5.0, 3.0], [5.0, 3.0], 100, 100);
-        assert!(t.scale[0].is_finite() && t.scale[0] > 0.0);
-        assert!(t.scale[1].is_finite() && t.scale[1] > 0.0);
-        // The point itself should map to NDC origin.
-        assert!(close(5.0 * t.scale[0] + t.offset[0], 0.0));
-        assert!(close(3.0 * t.scale[1] + t.offset[1], 0.0));
-    }
-
-    // --- App::new ---
-
     #[test]
     fn app_empty_geometry_uses_fallback_bounds() {
-        // "A" has no rule and draws nothing — zero segments produced.
         let geom = generate(&cfg(
             "name=\"t\"\naxiom=\"A\"\niterations=0\nangle=90.0\nstep=1.0",
         ));
@@ -443,7 +432,6 @@ mod tests {
 
     #[test]
     fn app_vertices_match_segment_endpoints() {
-        // F+F with 90° angle: (0,0)→(1,0) then (1,0)→(1,1).
         let geom = generate(&cfg(
             "name=\"t\"\naxiom=\"F+F\"\niterations=0\nangle=90.0\nstep=1.0",
         ));
@@ -461,7 +449,6 @@ mod tests {
 
     #[test]
     fn app_bounds_are_tight_over_all_segments() {
-        // F+F-F with 90° angle: east → north → east, spanning x ∈ [0,2], y ∈ [0,1].
         let geom = generate(&cfg(
             "name=\"t\"\naxiom=\"F+F-F\"\niterations=0\nangle=90.0\nstep=1.0",
         ));


### PR DESCRIPTION
## Summary

- Adds mouse-drag pan, scroll-wheel zoom toward cursor, and `F`-key reset-to-fit to the native desktop viewer.
- Extracts `Camera` (pan/zoom state + NDC transform computation) into `camera.rs` and `InputState` (left-button drag tracking) into `input.rs`, removing that logic from `renderer.rs`.
- `GpuState` is simplified: it no longer owns geometry bounds or runs transform math — it receives a `Transform` and exposes `upload_transform()`.
- Tests for `Camera` (transform correctness, zoom-under-cursor invariant, pan direction) live in `camera.rs`; the moved tests are removed from `renderer.rs`.
- README updated with a controls reference table and updated architecture listing.