### PR TITLE
Add egui side panel UI with preset picker and live overrides

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -19,6 +19,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "366ffbaa4442f4684d91e2cd7c5ea7c4ed8add41959a31447066e279e432b618"
 
 [[package]]
+name = "accesskit"
+version = "0.24.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5351dcebb14b579ccab05f288596b2ae097005be7ee50a7c3d4ca9d0d5a66f6a"
+dependencies = [
+ "uuid",
+]
+
+[[package]]
 name = "ahash"
 version = "0.8.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -308,6 +317,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "color"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a18ef4657441fb193b65f34dc39b3781f0dfec23d3bd94d0eeb4e88cde421edb"
+dependencies = [
+ "bytemuck",
+]
+
+[[package]]
 name = "colorchoice"
 version = "1.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -343,6 +361,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "core-foundation"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b2a6cd9ae233e7f62ba4e9353e81a88df7fc8a5987b8d445b4d90c879bd156f6"
+dependencies = [
+ "core-foundation-sys",
+ "libc",
+]
+
+[[package]]
 name = "core-foundation-sys"
 version = "0.8.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -355,7 +383,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c07782be35f9e1140080c6b96f0d44b739e2278479f64e02fdab4e32dfd8b081"
 dependencies = [
  "bitflags 1.3.2",
- "core-foundation",
+ "core-foundation 0.9.4",
  "core-graphics-types",
  "foreign-types",
  "libc",
@@ -368,7 +396,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "45390e6114f68f718cc7a830514a96f903cccd70d02a8f6d9f643ac4ba45afaf"
 dependencies = [
  "bitflags 1.3.2",
- "core-foundation",
+ "core-foundation 0.9.4",
  "libc",
 ]
 
@@ -407,6 +435,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "displaydoc"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "97369cbbc041bc366949bc74d34658d6cda5621039731c6310521892a3a20ae0"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "dlib"
 version = "0.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -437,6 +476,80 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d8b14ccef22fc6f5a8f4d7d768562a182c04ce9a3b3157b91390b52ddfdf1a76"
 
 [[package]]
+name = "ecolor"
+version = "0.34.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "137c0ce4ce4152ff7e223a7ce22ee1057cdff61fce0a45c32459c3ccec64868d"
+dependencies = [
+ "bytemuck",
+ "emath",
+]
+
+[[package]]
+name = "egui"
+version = "0.34.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f34aaf627da598dfadd64b0fee6101d22e9c451d1e5348157312720b7f459f0f"
+dependencies = [
+ "accesskit",
+ "ahash",
+ "bitflags 2.11.1",
+ "emath",
+ "epaint",
+ "log",
+ "nohash-hasher",
+ "profiling",
+ "smallvec",
+ "unicode-segmentation",
+]
+
+[[package]]
+name = "egui-wgpu"
+version = "0.34.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "71033ff78b041c9c363450f4498ff95468ef3ecbcc71a62f67036a6207d98fa4"
+dependencies = [
+ "ahash",
+ "bytemuck",
+ "document-features",
+ "epaint",
+ "log",
+ "profiling",
+ "thiserror 2.0.18",
+ "type-map",
+ "web-time",
+ "wgpu",
+]
+
+[[package]]
+name = "egui-winit"
+version = "0.34.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "11a2881b2bf1a305e413e644af63f836737a33d85077705ff808e88f902ff742"
+dependencies = [
+ "bytemuck",
+ "egui",
+ "log",
+ "objc2 0.6.4",
+ "objc2-foundation 0.3.2",
+ "objc2-ui-kit 0.3.2",
+ "profiling",
+ "raw-window-handle",
+ "web-time",
+ "webbrowser",
+ "winit",
+]
+
+[[package]]
+name = "emath"
+version = "0.34.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0a05cd8bdf3b598488c627ca97c7fe8909448ffa26278dd3c7e535cdb554d721"
+dependencies = [
+ "bytemuck",
+]
+
+[[package]]
 name = "env_filter"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -460,6 +573,34 @@ dependencies = [
 ]
 
 [[package]]
+name = "epaint"
+version = "0.34.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "04f3017dd67f147a697ee0c8484fb568fd9553e2a0c114be5020dbbc11962841"
+dependencies = [
+ "ahash",
+ "bytemuck",
+ "ecolor",
+ "emath",
+ "epaint_default_fonts",
+ "font-types",
+ "log",
+ "nohash-hasher",
+ "parking_lot",
+ "profiling",
+ "self_cell",
+ "skrifa",
+ "smallvec",
+ "vello_cpu",
+]
+
+[[package]]
+name = "epaint_default_fonts"
+version = "0.34.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e3b85a2bb775a3ab02d077a65cc31575c11b2584581913253cc11ce49f48bba"
+
+[[package]]
 name = "equivalent"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -473,6 +614,24 @@ checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
  "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "euclid"
+version = "0.22.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f1a05365e3b1c6d1650318537c7460c6923f1abdd272ad6842baa2b509957a06"
+dependencies = [
+ "num-traits",
+]
+
+[[package]]
+name = "fearless_simd"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8fb2907d1f08b2b316b9223ced5b0e89d87028ba8deae9764741dba8ff7f3903"
+dependencies = [
+ "bytemuck",
 ]
 
 [[package]]
@@ -492,6 +651,15 @@ name = "foldhash"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "77ce24cb58228fbb8aa041425bb1050850ac19177686ea6e0f41a70416f56fdb"
+
+[[package]]
+name = "font-types"
+version = "0.11.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5b38ad915f6dadd993ced50848a8291a543bd41ca62bc10740d5e64e2ab4cfd7"
+dependencies = [
+ "bytemuck",
+]
 
 [[package]]
 name = "foreign-types"
@@ -519,6 +687,15 @@ name = "foreign-types-shared"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "aa9a19cbb55df58761df49b23516a86d432839add4af60fc256da840f66ed35b"
+
+[[package]]
+name = "form_urlencoded"
+version = "1.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cb4cb245038516f5f85277875cdaa4f7d2c9a0fa0468de06ed190163b1581fcf"
+dependencies = [
+ "percent-encoding",
+]
 
 [[package]]
 name = "futures-core"
@@ -692,6 +869,109 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dfa686283ad6dd069f105e5ab091b04c62850d3e4cf5d67debad1933f55023df"
 
 [[package]]
+name = "icu_collections"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2984d1cd16c883d7935b9e07e44071dca8d917fd52ecc02c04d5fa0b5a3f191c"
+dependencies = [
+ "displaydoc",
+ "potential_utf",
+ "utf8_iter",
+ "yoke",
+ "zerofrom",
+ "zerovec",
+]
+
+[[package]]
+name = "icu_locale_core"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "92219b62b3e2b4d88ac5119f8904c10f8f61bf7e95b640d25ba3075e6cac2c29"
+dependencies = [
+ "displaydoc",
+ "litemap",
+ "tinystr",
+ "writeable",
+ "zerovec",
+]
+
+[[package]]
+name = "icu_normalizer"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c56e5ee99d6e3d33bd91c5d85458b6005a22140021cc324cea84dd0e72cff3b4"
+dependencies = [
+ "icu_collections",
+ "icu_normalizer_data",
+ "icu_properties",
+ "icu_provider",
+ "smallvec",
+ "zerovec",
+]
+
+[[package]]
+name = "icu_normalizer_data"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "da3be0ae77ea334f4da67c12f149704f19f81d1adf7c51cf482943e84a2bad38"
+
+[[package]]
+name = "icu_properties"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bee3b67d0ea5c2cca5003417989af8996f8604e34fb9ddf96208a033901e70de"
+dependencies = [
+ "icu_collections",
+ "icu_locale_core",
+ "icu_properties_data",
+ "icu_provider",
+ "zerotrie",
+ "zerovec",
+]
+
+[[package]]
+name = "icu_properties_data"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e2bbb201e0c04f7b4b3e14382af113e17ba4f63e2c9d2ee626b720cbce54a14"
+
+[[package]]
+name = "icu_provider"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "139c4cf31c8b5f33d7e199446eff9c1e02decfc2f0eec2c8d71f65befa45b421"
+dependencies = [
+ "displaydoc",
+ "icu_locale_core",
+ "writeable",
+ "yoke",
+ "zerofrom",
+ "zerotrie",
+ "zerovec",
+]
+
+[[package]]
+name = "idna"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3b0875f23caa03898994f6ddc501886a45c7d3d62d04d2d90788d47be1b1e4de"
+dependencies = [
+ "idna_adapter",
+ "smallvec",
+ "utf8_iter",
+]
+
+[[package]]
+name = "idna_adapter"
+version = "1.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cb68373c0d6620ef8105e855e7745e18b0d00d3bdb07fb532e434244cdb9a714"
+dependencies = [
+ "icu_normalizer",
+ "icu_properties",
+]
+
+[[package]]
 name = "indexmap"
 version = "2.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -829,6 +1109,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e2db585e1d738fc771bf08a151420d3ed193d9d895a36df7f6f8a9456b911ddc"
 
 [[package]]
+name = "kurbo"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7564e90fe3c0d5771e1f0bc95322b21baaeaa0d9213fa6a0b61c99f8b17b3bfb"
+dependencies = [
+ "arrayvec",
+ "euclid",
+ "smallvec",
+]
+
+[[package]]
 name = "libc"
 version = "0.2.186"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -863,6 +1154,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "linebender_resource_handle"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d4a5ff6bcca6c4867b1c4fd4ef63e4db7436ef363e0ad7531d1558856bae64f4"
+
+[[package]]
 name = "linux-raw-sys"
 version = "0.4.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -873,6 +1170,12 @@ name = "linux-raw-sys"
 version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32a66949e030da00e8c7d4434b251670a91556f4144941d37452769c25d58a53"
+
+[[package]]
+name = "litemap"
+version = "0.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "92daf443525c4cce67b150400bc2316076100ce0b3686209eb8cf3c31612e6f0"
 
 [[package]]
 name = "litrs"
@@ -900,6 +1203,9 @@ name = "lsystem-app"
 version = "0.1.0"
 dependencies = [
  "bytemuck",
+ "egui",
+ "egui-wgpu",
+ "egui-winit",
  "env_logger",
  "lsystem-core",
  "pollster",
@@ -952,7 +1258,7 @@ dependencies = [
  "log",
  "num-traits",
  "once_cell",
- "rustc-hash",
+ "rustc-hash 1.1.0",
  "spirv",
  "thiserror 2.0.18",
  "unicode-ident",
@@ -987,6 +1293,12 @@ checksum = "ee6cda3051665f1fb8d9e08fc35c96d5a244fb1be711a03b71118828afc9a873"
 dependencies = [
  "jni-sys 0.3.1",
 ]
+
+[[package]]
+name = "nohash-hasher"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2bf50223579dc7cdcfb3bfcacf7069ff68243f8c363f62ffa99cf000a6b9c451"
 
 [[package]]
 name = "num-traits"
@@ -1256,6 +1568,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "objc2-ui-kit"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d87d638e33c06f577498cbcc50491496a3ed4246998a7fbba7ccb98b1e7eab22"
+dependencies = [
+ "bitflags 2.11.1",
+ "objc2 0.6.4",
+ "objc2-core-foundation",
+ "objc2-foundation 0.3.2",
+]
+
+[[package]]
 name = "objc2-uniform-type-identifiers"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1343,6 +1667,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "peniko"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9a2b6aadb221872732e87d465213e9be5af2849b0e8cc5300a8ba98fffa2e00a"
+dependencies = [
+ "bytemuck",
+ "color",
+ "kurbo",
+ "linebender_resource_handle",
+ "smallvec",
+]
+
+[[package]]
 name = "percent-encoding"
 version = "2.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1419,6 +1756,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a106d1259c23fac8e543272398ae0e3c0b8d33c88ed73d0cc71b0f1d902618"
 dependencies = [
  "portable-atomic",
+]
+
+[[package]]
+name = "potential_utf"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0103b1cef7ec0cf76490e969665504990193874ea05c85ff9bab8b911d0a0564"
+dependencies = [
+ "zerovec",
 ]
 
 [[package]]
@@ -1500,6 +1846,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "read-fonts"
+version = "0.37.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7b634fabf032fab15307ffd272149b622260f55974d9fad689292a5d33df02e5"
+dependencies = [
+ "bytemuck",
+ "font-types",
+]
+
+[[package]]
 name = "redox_syscall"
 version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1566,6 +1922,12 @@ name = "rustc-hash"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "08d43f7aa6b08d49f382cde6a7982047c3426db949b1424bc4b7ec9ae12c6ce2"
+
+[[package]]
+name = "rustc-hash"
+version = "2.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "94300abf3f1ae2e2b8ffb7b58043de3d399c73fa6f4b73826402a5c457614dbe"
 
 [[package]]
 name = "rustc_version"
@@ -1643,6 +2005,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "self_cell"
+version = "1.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b12e76d157a900eb52e81bc6e9f3069344290341720e9178cde2407113ac8d89"
+
+[[package]]
 name = "semver"
 version = "1.0.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1710,6 +2078,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e3a9fe34e3e7a50316060351f37187a3f546bce95496156754b601a5fa71b76e"
 
 [[package]]
+name = "skrifa"
+version = "0.40.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7fbdfe3d2475fbd7ddd1f3e5cf8288a30eb3e5f95832829570cd88115a7434ac"
+dependencies = [
+ "bytemuck",
+ "read-fonts",
+]
+
+[[package]]
 name = "slab"
 version = "0.4.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1774,6 +2152,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "stable_deref_trait"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6ce2be8dc25455e1f91df71bfa12ad37d7af1092ae736f3a6cd0e37bc7810596"
+
+[[package]]
 name = "static_assertions"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1794,6 +2178,17 @@ dependencies = [
  "proc-macro2",
  "quote",
  "unicode-ident",
+]
+
+[[package]]
+name = "synstructure"
+version = "0.13.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "728a70f3dbaf5bab7f0c4b1ac8d7ae5ea60a4b5549c8a5914361c99147a709d2"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -1871,6 +2266,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "tinystr"
+version = "0.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c8323304221c2a851516f22236c5722a72eaa19749016521d6dff0824447d96d"
+dependencies = [
+ "displaydoc",
+ "zerovec",
+]
+
+[[package]]
 name = "toml"
 version = "1.1.2+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1944,6 +2349,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d2df906b07856748fa3f6e0ad0cbaa047052d4a7dd609e231c4f72cee8c36f31"
 
 [[package]]
+name = "type-map"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cb30dbbd9036155e74adad6812e9898d03ec374946234fbcebd5dfc7b9187b90"
+dependencies = [
+ "rustc-hash 2.1.2",
+]
+
+[[package]]
 name = "unicode-ident"
 version = "1.0.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1962,10 +2376,60 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7dd6e30e90baa6f72411720665d41d89b9a3d039dc45b8faea1ddd07f617f6af"
 
 [[package]]
+name = "url"
+version = "2.5.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ff67a8a4397373c3ef660812acab3268222035010ab8680ec4215f38ba3d0eed"
+dependencies = [
+ "form_urlencoded",
+ "idna",
+ "percent-encoding",
+ "serde",
+]
+
+[[package]]
+name = "utf8_iter"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6c140620e7ffbb22c2dee59cafe6084a59b5ffc27a8859a5f0d494b5d52b6be"
+
+[[package]]
 name = "utf8parse"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
+
+[[package]]
+name = "uuid"
+version = "1.23.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ddd74a9687298c6858e9b88ec8935ec45d22e8fd5e6394fa1bd4e99a87789c76"
+
+[[package]]
+name = "vello_common"
+version = "0.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1bd1a4c633ce09e7d713df1a6e036644a125e15e0c169cfb5180ddf5836ca04b"
+dependencies = [
+ "bytemuck",
+ "fearless_simd",
+ "hashbrown 0.16.1",
+ "log",
+ "peniko",
+ "skrifa",
+ "smallvec",
+]
+
+[[package]]
+name = "vello_cpu"
+version = "0.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0162bfe48aabf6a9fdcd401b628c7d9f260c2cbabb343c70a65feba6f7849edc"
+dependencies = [
+ "bytemuck",
+ "hashbrown 0.16.1",
+ "vello_common",
+]
 
 [[package]]
 name = "version_check"
@@ -2177,6 +2641,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "webbrowser"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0fc95580916af1e68ff6a7be07446fc5db73ebf71cf092de939bbf5f7e189f72"
+dependencies = [
+ "core-foundation 0.10.1",
+ "jni",
+ "log",
+ "ndk-context",
+ "objc2 0.6.4",
+ "objc2-foundation 0.3.2",
+ "url",
+ "web-sys",
+]
+
+[[package]]
 name = "wgpu"
 version = "29.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2228,11 +2708,12 @@ dependencies = [
  "portable-atomic",
  "profiling",
  "raw-window-handle",
- "rustc-hash",
+ "rustc-hash 1.1.0",
  "smallvec",
  "thiserror 2.0.18",
  "wgpu-core-deps-apple",
  "wgpu-core-deps-emscripten",
+ "wgpu-core-deps-wasm",
  "wgpu-core-deps-windows-linux-android",
  "wgpu-hal",
  "wgpu-naga-bridge",
@@ -2253,6 +2734,15 @@ name = "wgpu-core-deps-emscripten"
 version = "29.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ef043bf135cc68b6f667c55ff4e345ce2b5924d75bad36a47921b0287ca4b24a"
+dependencies = [
+ "wgpu-hal",
+]
+
+[[package]]
+name = "wgpu-core-deps-wasm"
+version = "29.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2f7b75e72f49035f000dd5262e4126242e92a090a4fd75931ecfe7e60784e6fa"
 dependencies = [
  "wgpu-hal",
 ]
@@ -2568,7 +3058,7 @@ dependencies = [
  "calloop",
  "cfg_aliases",
  "concurrent-queue",
- "core-foundation",
+ "core-foundation 0.9.4",
  "core-graphics",
  "cursor-icon",
  "dpi",
@@ -2579,7 +3069,7 @@ dependencies = [
  "objc2 0.5.2",
  "objc2-app-kit",
  "objc2-foundation 0.2.2",
- "objc2-ui-kit",
+ "objc2-ui-kit 0.2.2",
  "orbclient",
  "percent-encoding",
  "pin-project",
@@ -2619,6 +3109,12 @@ name = "wit-bindgen"
 version = "0.57.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1ebf944e87a7c253233ad6766e082e3cd714b5d03812acc24c318f549614536e"
+
+[[package]]
+name = "writeable"
+version = "0.6.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1ffae5123b2d3fc086436f8834ae3ab053a283cfac8fe0a0b8eaae044768a4c4"
 
 [[package]]
 name = "x11-dl"
@@ -2684,6 +3180,29 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3ae8337f8a065cfc972643663ea4279e04e7256de865aa66fe25cec5fb912d3f"
 
 [[package]]
+name = "yoke"
+version = "0.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "abe8c5fda708d9ca3df187cae8bfb9ceda00dd96231bed36e445a1a48e66f9ca"
+dependencies = [
+ "stable_deref_trait",
+ "yoke-derive",
+ "zerofrom",
+]
+
+[[package]]
+name = "yoke-derive"
+version = "0.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "de844c262c8848816172cef550288e7dc6c7b7814b4ee56b3e1553f275f1858e"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+ "synstructure",
+]
+
+[[package]]
 name = "zerocopy"
 version = "0.8.48"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2697,6 +3216,60 @@ name = "zerocopy-derive"
 version = "0.8.48"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "70e3cd084b1788766f53af483dd21f93881ff30d7320490ec3ef7526d203bad4"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "zerofrom"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "69faa1f2a1ea75661980b013019ed6687ed0e83d069bc1114e2cc74c6c04c4df"
+dependencies = [
+ "zerofrom-derive",
+]
+
+[[package]]
+name = "zerofrom-derive"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "11532158c46691caf0f2593ea8358fed6bbf68a0315e80aae9bd41fbade684a1"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+ "synstructure",
+]
+
+[[package]]
+name = "zerotrie"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0f9152d31db0792fa83f70fb2f83148effb5c1f5b8c7686c3459e361d9bc20bf"
+dependencies = [
+ "displaydoc",
+ "yoke",
+ "zerofrom",
+]
+
+[[package]]
+name = "zerovec"
+version = "0.11.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "90f911cbc359ab6af17377d242225f4d75119aec87ea711a880987b18cd7b239"
+dependencies = [
+ "yoke",
+ "zerofrom",
+ "zerovec-derive",
+]
+
+[[package]]
+name = "zerovec-derive"
+version = "0.11.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "625dc425cab0dca6dc3c3319506e6593dcb08a9f387ea3b284dbd52a92c40555"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/crates/lsystem-app/Cargo.toml
+++ b/crates/lsystem-app/Cargo.toml
@@ -10,6 +10,9 @@ crate-type = ["cdylib", "rlib"]
 [dependencies]
 lsystem-core = { path = "../lsystem-core" }
 bytemuck = { version = "1", features = ["derive"] }
+egui = "0.34"
+egui-wgpu = "0.34"
+egui-winit = { version = "0.34", default-features = false, features = ["wayland", "x11", "links"] }
 pollster = "0.4"
 wgpu = "29"
 winit = "0.30"

--- a/crates/lsystem-app/src/main.rs
+++ b/crates/lsystem-app/src/main.rs
@@ -1,21 +1,17 @@
 mod camera;
 mod input;
 mod renderer;
+mod ui;
 
-use lsystem_core::Config;
 use winit::event_loop::{ControlFlow, EventLoop};
 
 fn main() {
     #[cfg(not(target_arch = "wasm32"))]
     env_logger::init();
 
-    let config = Config::parse(include_str!("../../../presets/koch_snowflake.toml"))
-        .expect("bundled preset is valid");
-    let geometry = lsystem_core::generate(&config);
-
     let event_loop = EventLoop::new().unwrap();
     event_loop.set_control_flow(ControlFlow::Wait);
 
-    let mut app = renderer::App::new(geometry);
+    let mut app = renderer::App::new();
     event_loop.run_app(&mut app).unwrap();
 }

--- a/crates/lsystem-app/src/renderer.rs
+++ b/crates/lsystem-app/src/renderer.rs
@@ -1,6 +1,7 @@
 use std::sync::Arc;
 
 use bytemuck::{Pod, Zeroable};
+use egui_wgpu::ScreenDescriptor;
 use lsystem_core::Geometry;
 use wgpu::util::DeviceExt;
 use winit::application::ApplicationHandler;
@@ -11,11 +12,44 @@ use winit::window::{Window, WindowId};
 
 use crate::camera::{Camera, Transform};
 use crate::input::InputState;
+use crate::ui::UiState;
 
 #[repr(C)]
 #[derive(Copy, Clone, Pod, Zeroable)]
 struct Vertex {
     position: [f32; 2],
+}
+
+fn geometry_to_vertices(geometry: &Geometry) -> (Vec<Vertex>, [f32; 2], [f32; 2]) {
+    let Geometry::D2 { segments } = geometry;
+
+    let mut min_x = f32::INFINITY;
+    let mut min_y = f32::INFINITY;
+    let mut max_x = f32::NEG_INFINITY;
+    let mut max_y = f32::NEG_INFINITY;
+    let mut vertices = Vec::with_capacity(segments.len() * 2);
+
+    for [a, b] in segments {
+        min_x = min_x.min(a.x).min(b.x);
+        min_y = min_y.min(a.y).min(b.y);
+        max_x = max_x.max(a.x).max(b.x);
+        max_y = max_y.max(a.y).max(b.y);
+        vertices.push(Vertex {
+            position: [a.x, a.y],
+        });
+        vertices.push(Vertex {
+            position: [b.x, b.y],
+        });
+    }
+
+    if min_x.is_infinite() {
+        min_x = -1.0;
+        max_x = 1.0;
+        min_y = -1.0;
+        max_y = 1.0;
+    }
+
+    (vertices, [min_x, min_y], [max_x, max_y])
 }
 
 struct GpuState {
@@ -28,6 +62,7 @@ struct GpuState {
     vertex_count: u32,
     uniform_buffer: wgpu::Buffer,
     bind_group: wgpu::BindGroup,
+    egui_renderer: egui_wgpu::Renderer,
 }
 
 impl GpuState {
@@ -43,7 +78,7 @@ impl GpuState {
                 force_fallback_adapter: false,
             })
             .await
-            .expect("no GPU adapter found — is a WebGPU-compatible GPU available?");
+            .expect("no GPU adapter found");
         let (device, queue) = adapter
             .request_device(&wgpu::DeviceDescriptor::default())
             .await
@@ -146,6 +181,9 @@ impl GpuState {
             usage: wgpu::BufferUsages::VERTEX,
         });
 
+        let egui_renderer =
+            egui_wgpu::Renderer::new(&device, format, egui_wgpu::RendererOptions::default());
+
         Self {
             surface,
             device,
@@ -156,6 +194,7 @@ impl GpuState {
             vertex_count: vertices.len() as u32,
             uniform_buffer,
             bind_group,
+            egui_renderer,
         }
     }
 
@@ -168,6 +207,17 @@ impl GpuState {
             .write_buffer(&self.uniform_buffer, 0, bytemuck::bytes_of(transform));
     }
 
+    fn upload_vertices(&mut self, vertices: &[Vertex]) {
+        self.vertex_buffer = self
+            .device
+            .create_buffer_init(&wgpu::util::BufferInitDescriptor {
+                label: None,
+                contents: bytemuck::cast_slice(vertices),
+                usage: wgpu::BufferUsages::VERTEX,
+            });
+        self.vertex_count = vertices.len() as u32;
+    }
+
     fn resize(&mut self, new_size: winit::dpi::PhysicalSize<u32>) {
         if new_size.width == 0 || new_size.height == 0 {
             return;
@@ -177,7 +227,32 @@ impl GpuState {
         self.surface.configure(&self.device, &self.surface_config);
     }
 
-    fn render(&mut self) -> bool {
+    fn render(
+        &mut self,
+        egui_ctx: &egui::Context,
+        egui_winit: &mut egui_winit::State,
+        window: &Window,
+        ui: &mut UiState,
+        panel_px: u32,
+    ) -> bool {
+        let raw_input = egui_winit.take_egui_input(window);
+        egui_ctx.begin_pass(raw_input);
+        ui.draw(egui_ctx);
+        let full_output = egui_ctx.end_pass();
+        egui_winit.handle_platform_output(window, full_output.platform_output);
+
+        let (w, h) = self.size();
+        let effective_w = w.saturating_sub(panel_px).max(1);
+        let screen_desc = ScreenDescriptor {
+            size_in_pixels: [w, h],
+            pixels_per_point: full_output.pixels_per_point,
+        };
+        let tris = egui_ctx.tessellate(full_output.shapes, full_output.pixels_per_point);
+        for (id, delta) in &full_output.textures_delta.set {
+            self.egui_renderer
+                .update_texture(&self.device, &self.queue, *id, delta);
+        }
+
         let (frame, reconfigure) = match self.surface.get_current_texture() {
             wgpu::CurrentSurfaceTexture::Success(t) => (t, false),
             wgpu::CurrentSurfaceTexture::Suboptimal(t) => (t, true),
@@ -191,6 +266,7 @@ impl GpuState {
         };
         let view = frame.texture.create_view(&Default::default());
         let mut encoder = self.device.create_command_encoder(&Default::default());
+
         {
             let mut pass = encoder.begin_render_pass(&wgpu::RenderPassDescriptor {
                 label: None,
@@ -213,13 +289,52 @@ impl GpuState {
                 timestamp_writes: None,
                 multiview_mask: None,
             });
+            pass.set_viewport(panel_px as f32, 0.0, effective_w as f32, h as f32, 0.0, 1.0);
             pass.set_pipeline(&self.pipeline);
             pass.set_bind_group(0, &self.bind_group, &[]);
             pass.set_vertex_buffer(0, self.vertex_buffer.slice(..));
             pass.draw(0..self.vertex_count, 0..1);
         }
+
+        self.egui_renderer.update_buffers(
+            &self.device,
+            &self.queue,
+            &mut encoder,
+            &tris,
+            &screen_desc,
+        );
+        {
+            let mut egui_pass = encoder
+                .begin_render_pass(&wgpu::RenderPassDescriptor {
+                    label: None,
+                    color_attachments: &[Some(wgpu::RenderPassColorAttachment {
+                        view: &view,
+                        resolve_target: None,
+                        depth_slice: None,
+                        ops: wgpu::Operations {
+                            load: wgpu::LoadOp::Load,
+                            store: wgpu::StoreOp::Store,
+                        },
+                    })],
+                    depth_stencil_attachment: None,
+                    occlusion_query_set: None,
+                    timestamp_writes: None,
+                    multiview_mask: None,
+                })
+                // forget_lifetime is safe here: egui_pass is dropped before
+                // encoder.finish(), which is the invariant wgpu requires.
+                .forget_lifetime();
+            self.egui_renderer
+                .render(&mut egui_pass, &tris, &screen_desc);
+        }
+
+        for id in &full_output.textures_delta.free {
+            self.egui_renderer.free_texture(id);
+        }
+
         self.queue.submit([encoder.finish()]);
         frame.present();
+
         if reconfigure {
             self.surface.configure(&self.device, &self.surface_config);
         }
@@ -230,62 +345,78 @@ impl GpuState {
 pub struct App {
     window: Option<Arc<Window>>,
     state: Option<GpuState>,
-    vertices: Vec<Vertex>,
     bounds_min: [f32; 2],
     bounds_max: [f32; 2],
     camera: Camera,
     input: InputState,
+    egui_ctx: egui::Context,
+    egui_winit: Option<egui_winit::State>,
+    ui: UiState,
 }
 
 impl App {
-    pub fn new(geometry: Geometry) -> Self {
-        let Geometry::D2 { segments } = geometry;
-
-        let mut min_x = f32::INFINITY;
-        let mut min_y = f32::INFINITY;
-        let mut max_x = f32::NEG_INFINITY;
-        let mut max_y = f32::NEG_INFINITY;
-        let mut vertices = Vec::with_capacity(segments.len() * 2);
-
-        for [a, b] in &segments {
-            min_x = min_x.min(a.x).min(b.x);
-            min_y = min_y.min(a.y).min(b.y);
-            max_x = max_x.max(a.x).max(b.x);
-            max_y = max_y.max(a.y).max(b.y);
-            vertices.push(Vertex {
-                position: [a.x, a.y],
-            });
-            vertices.push(Vertex {
-                position: [b.x, b.y],
-            });
-        }
-
-        if min_x.is_infinite() {
-            min_x = -1.0;
-            max_x = 1.0;
-            min_y = -1.0;
-            max_y = 1.0;
-        }
-
+    pub fn new() -> Self {
+        let ui = UiState::new();
         Self {
             window: None,
             state: None,
-            vertices,
-            bounds_min: [min_x, min_y],
-            bounds_max: [max_x, max_y],
+            bounds_min: [-1.0, -1.0],
+            bounds_max: [1.0, 1.0],
             camera: Camera::new(),
             input: InputState::new(),
+            egui_ctx: egui::Context::default(),
+            egui_winit: None,
+            ui,
+        }
+    }
+
+    /// Physical pixel width of the egui side panel, used to restrict the camera viewport.
+    fn panel_px(&self) -> u32 {
+        let scale = self
+            .window
+            .as_ref()
+            .map(|w| w.scale_factor() as f32)
+            .unwrap_or(1.0);
+        self.ui.panel_width.mul_add(scale, 0.5) as u32
+    }
+
+    fn regenerate_if_dirty(&mut self) {
+        if !self.ui.dirty {
+            return;
+        }
+        self.ui.dirty = false;
+        let Some(cfg) = self.ui.effective_config() else {
+            return;
+        };
+        let geometry = lsystem_core::generate(&cfg);
+        let (vertices, bounds_min, bounds_max) = geometry_to_vertices(&geometry);
+        self.bounds_min = bounds_min;
+        self.bounds_max = bounds_max;
+        self.camera.reset();
+        if let Some(state) = &mut self.state {
+            state.upload_vertices(&vertices);
+        }
+        self.upload_camera_transform();
+        if let Some(window) = &self.window {
+            window.request_redraw();
         }
     }
 
     fn upload_camera_transform(&self) {
         if let Some(state) = &self.state {
             let (w, h) = state.size();
-            let transform = self
-                .camera
-                .compute_transform(self.bounds_min, self.bounds_max, w, h);
+            let effective_w = w.saturating_sub(self.panel_px()).max(1);
+            let transform =
+                self.camera
+                    .compute_transform(self.bounds_min, self.bounds_max, effective_w, h);
             state.upload_transform(&transform);
         }
+    }
+}
+
+impl Default for App {
+    fn default() -> Self {
+        Self::new()
     }
 }
 
@@ -296,7 +427,20 @@ impl ApplicationHandler for App {
                 .create_window(Window::default_attributes().with_title("Grow Your Own Fractal"))
                 .unwrap(),
         );
+
+        let egui_winit = egui_winit::State::new(
+            self.egui_ctx.clone(),
+            egui::ViewportId::ROOT,
+            &window,
+            Some(window.scale_factor() as f32),
+            None,
+            None,
+        );
+        self.egui_winit = Some(egui_winit);
+
         let size = window.inner_size();
+
+        let initial_vertices: Vec<Vertex> = Vec::new();
         let initial_transform = self.camera.compute_transform(
             self.bounds_min,
             self.bounds_max,
@@ -305,15 +449,47 @@ impl ApplicationHandler for App {
         );
         let state = pollster::block_on(GpuState::new(
             window.clone(),
-            &self.vertices,
+            &initial_vertices,
             &initial_transform,
         ));
-        window.request_redraw();
         self.window = Some(window);
         self.state = Some(state);
+
+        // Trigger initial geometry generation.
+        self.ui.dirty = true;
+        self.regenerate_if_dirty();
     }
 
     fn window_event(&mut self, event_loop: &ActiveEventLoop, _id: WindowId, event: WindowEvent) {
+        // Unconditionally clear drag on left-button release so it can never get stuck,
+        // even when egui consumes the release event.
+        if matches!(
+            &event,
+            WindowEvent::MouseInput {
+                state: ElementState::Released,
+                button: MouseButton::Left,
+                ..
+            }
+        ) {
+            self.input.on_left_button(false);
+        }
+
+        // Feed event to egui first.
+        let egui_consumed =
+            if let (Some(egui_winit), Some(window)) = (&mut self.egui_winit, &self.window) {
+                let response = egui_winit.on_window_event(window, &event);
+                // response.repaint keeps is_pointer_over_egui() fresh between clicks.
+                if response.repaint || response.consumed {
+                    window.request_redraw();
+                }
+                response.consumed
+            } else {
+                false
+            };
+        if egui_consumed {
+            return;
+        }
+
         match event {
             WindowEvent::CloseRequested => event_loop.exit(),
 
@@ -327,12 +503,14 @@ impl ApplicationHandler for App {
                 }
             }
 
+            // Only start a drag when the cursor is not over the egui panel.
+            // Releases are already handled unconditionally above.
             WindowEvent::MouseInput {
-                state,
+                state: ElementState::Pressed,
                 button: MouseButton::Left,
                 ..
-            } => {
-                self.input.on_left_button(state == ElementState::Pressed);
+            } if !self.egui_ctx.is_pointer_over_egui() => {
+                self.input.on_left_button(true);
             }
 
             WindowEvent::CursorMoved { position, .. } => {
@@ -341,8 +519,15 @@ impl ApplicationHandler for App {
                 if let Some([dx, dy]) = self.input.on_cursor_moved(x, y) {
                     if let Some(state) = &self.state {
                         let (w, h) = state.size();
-                        self.camera
-                            .pan_by_pixels(dx, dy, self.bounds_min, self.bounds_max, w, h);
+                        let effective_w = w.saturating_sub(self.panel_px()).max(1);
+                        self.camera.pan_by_pixels(
+                            dx,
+                            dy,
+                            self.bounds_min,
+                            self.bounds_max,
+                            effective_w,
+                            h,
+                        );
                     }
                     self.upload_camera_transform();
                     if let Some(window) = &self.window {
@@ -351,7 +536,7 @@ impl ApplicationHandler for App {
                 }
             }
 
-            WindowEvent::MouseWheel { delta, .. } => {
+            WindowEvent::MouseWheel { delta, .. } if !self.egui_ctx.is_pointer_over_egui() => {
                 let lines = match delta {
                     MouseScrollDelta::LineDelta(_, y) => y,
                     MouseScrollDelta::PixelDelta(pos) => pos.y as f32 / 20.0,
@@ -359,13 +544,19 @@ impl ApplicationHandler for App {
                 let factor = 1.1_f32.powf(lines);
                 if let Some(state) = &self.state {
                     let (w, h) = state.size();
-                    let cursor = self.input.cursor_pos;
+                    let panel_px = self.panel_px();
+                    let effective_w = w.saturating_sub(panel_px).max(1);
+                    // Cursor position relative to the canvas viewport.
+                    let cursor = [
+                        (self.input.cursor_pos[0] - panel_px as f32).max(0.0),
+                        self.input.cursor_pos[1],
+                    ];
                     self.camera.zoom_toward_cursor(
                         factor,
                         cursor,
                         self.bounds_min,
                         self.bounds_max,
-                        w,
+                        effective_w,
                         h,
                     );
                 }
@@ -390,8 +581,22 @@ impl ApplicationHandler for App {
             }
 
             WindowEvent::RedrawRequested => {
-                if let (Some(state), Some(window)) = (&mut self.state, &self.window)
-                    && state.render()
+                self.regenerate_if_dirty();
+                let panel_px = self.panel_px();
+                if let (Some(state), Some(egui_winit), Some(window)) =
+                    (&mut self.state, &mut self.egui_winit, &self.window)
+                {
+                    if state.render(&self.egui_ctx, egui_winit, window, &mut self.ui, panel_px) {
+                        window.request_redraw();
+                    }
+                    // Request another frame if egui wants to animate.
+                    if self.egui_ctx.has_requested_repaint() {
+                        window.request_redraw();
+                    }
+                }
+                // Dirty flag may have been set by slider interaction during draw.
+                if self.ui.dirty
+                    && let Some(window) = &self.window
                 {
                     window.request_redraw();
                 }
@@ -418,45 +623,40 @@ mod tests {
     }
 
     #[test]
-    fn app_empty_geometry_uses_fallback_bounds() {
+    fn empty_geometry_uses_fallback_bounds() {
+        // axiom has no F, so no segments are drawn
         let geom = generate(&cfg(
             "name=\"t\"\naxiom=\"A\"\niterations=0\nangle=90.0\nstep=1.0",
         ));
-        let app = App::new(geom);
-        assert!(app.vertices.is_empty());
-        assert!(close(app.bounds_min[0], -1.0));
-        assert!(close(app.bounds_min[1], -1.0));
-        assert!(close(app.bounds_max[0], 1.0));
-        assert!(close(app.bounds_max[1], 1.0));
+        let (verts, min, max) = geometry_to_vertices(&geom);
+        assert!(verts.is_empty());
+        assert!(close(min[0], -1.0) && close(min[1], -1.0));
+        assert!(close(max[0], 1.0) && close(max[1], 1.0));
     }
 
     #[test]
-    fn app_vertices_match_segment_endpoints() {
+    fn single_segment_produces_two_vertices_and_tight_bounds() {
+        // "F" at 0 iterations: one segment from (0,0) to (1,0)
         let geom = generate(&cfg(
-            "name=\"t\"\naxiom=\"F+F\"\niterations=0\nangle=90.0\nstep=1.0",
+            "name=\"t\"\naxiom=\"F\"\niterations=0\nangle=90.0\nstep=1.0",
         ));
-        let app = App::new(geom);
-        assert_eq!(app.vertices.len(), 4);
-        assert!(close(app.vertices[0].position[0], 0.0));
-        assert!(close(app.vertices[0].position[1], 0.0));
-        assert!(close(app.vertices[1].position[0], 1.0));
-        assert!(close(app.vertices[1].position[1], 0.0));
-        assert!(close(app.vertices[2].position[0], 1.0));
-        assert!(close(app.vertices[2].position[1], 0.0));
-        assert!(close(app.vertices[3].position[0], 1.0));
-        assert!(close(app.vertices[3].position[1], 1.0));
+        let (verts, min, max) = geometry_to_vertices(&geom);
+        assert_eq!(verts.len(), 2);
+        assert!(close(verts[0].position[0], 0.0) && close(verts[0].position[1], 0.0));
+        assert!(close(verts[1].position[0], 1.0) && close(verts[1].position[1], 0.0));
+        assert!(close(min[0], 0.0) && close(min[1], 0.0));
+        assert!(close(max[0], 1.0) && close(max[1], 0.0));
     }
 
     #[test]
-    fn app_bounds_are_tight_over_all_segments() {
+    fn bounds_are_tight_over_all_segments() {
+        // "F+F-F": three segments covering x=[0,2], y=[0,1]
         let geom = generate(&cfg(
             "name=\"t\"\naxiom=\"F+F-F\"\niterations=0\nangle=90.0\nstep=1.0",
         ));
-        let app = App::new(geom);
-        assert_eq!(app.vertices.len(), 6);
-        assert!(close(app.bounds_min[0], 0.0));
-        assert!(close(app.bounds_max[0], 2.0));
-        assert!(close(app.bounds_min[1], 0.0));
-        assert!(close(app.bounds_max[1], 1.0));
+        let (verts, min, max) = geometry_to_vertices(&geom);
+        assert_eq!(verts.len(), 6);
+        assert!(close(min[0], 0.0) && close(min[1], 0.0));
+        assert!(close(max[0], 2.0) && close(max[1], 1.0));
     }
 }

--- a/crates/lsystem-app/src/ui.rs
+++ b/crates/lsystem-app/src/ui.rs
@@ -1,0 +1,162 @@
+use lsystem_core::Config;
+
+pub const PRESETS: &[(&str, &str)] = &[
+    (
+        "Koch Snowflake",
+        include_str!("../../../presets/koch_snowflake.toml"),
+    ),
+    (
+        "Dragon Curve",
+        include_str!("../../../presets/dragon_curve.toml"),
+    ),
+    (
+        "Sierpinski Triangle",
+        include_str!("../../../presets/sierpinski_triangle.toml"),
+    ),
+    ("Plant A", include_str!("../../../presets/plant_a.toml")),
+    (
+        "Hilbert Curve",
+        include_str!("../../../presets/hilbert_curve.toml"),
+    ),
+];
+
+pub struct UiState {
+    pub preset_idx: usize,
+    pub toml_text: String,
+    pub base_config: Option<Config>,
+    pub iterations: u32,
+    pub angle: f32,
+    pub step: f32,
+    pub error: Option<String>,
+    /// Set to true when geometry needs regenerating.
+    pub dirty: bool,
+    /// Width of the side panel in egui logical pixels, updated each frame.
+    pub panel_width: f32,
+}
+
+impl UiState {
+    pub fn new() -> Self {
+        let toml_text = PRESETS[0].1.to_string();
+        let mut s = Self {
+            preset_idx: 0,
+            toml_text: toml_text.clone(),
+            base_config: None,
+            iterations: 4,
+            angle: 60.0,
+            step: 1.0,
+            error: None,
+            dirty: true,
+            panel_width: 280.0,
+        };
+        s.apply();
+        s
+    }
+
+    pub fn apply(&mut self) {
+        match Config::parse(&self.toml_text) {
+            Ok(cfg) => {
+                self.iterations = cfg.iterations;
+                self.angle = cfg.angle;
+                self.step = cfg.step;
+                self.base_config = Some(cfg);
+                self.error = None;
+                self.dirty = true;
+            }
+            Err(e) => {
+                self.error = Some(e.to_string());
+            }
+        }
+    }
+
+    pub fn effective_config(&self) -> Option<Config> {
+        self.base_config.clone().map(|mut c| {
+            c.iterations = self.iterations;
+            c.angle = self.angle;
+            c.step = self.step;
+            c
+        })
+    }
+
+    #[allow(deprecated)]
+    pub fn draw(&mut self, ctx: &egui::Context) {
+        let panel_response = egui::Panel::left("controls")
+            .resizable(false)
+            .default_size(280.0)
+            .show(ctx, |ui| {
+                ui.heading("Grow Your Own Fractal");
+                ui.separator();
+
+                ui.label("Preset");
+                let prev = self.preset_idx;
+                egui::ComboBox::from_id_salt("preset_combo")
+                    .selected_text(PRESETS[self.preset_idx].0)
+                    .show_ui(ui, |ui| {
+                        for (i, (name, _)) in PRESETS.iter().enumerate() {
+                            ui.selectable_value(&mut self.preset_idx, i, *name);
+                        }
+                    });
+                if self.preset_idx != prev {
+                    self.toml_text = PRESETS[self.preset_idx].1.to_string();
+                    self.apply();
+                }
+
+                ui.separator();
+
+                ui.label("Config (TOML)");
+                ui.add(
+                    egui::TextEdit::multiline(&mut self.toml_text)
+                        .font(egui::TextStyle::Monospace)
+                        .desired_rows(12)
+                        .desired_width(f32::INFINITY),
+                );
+
+                if ui.button("Apply").clicked() {
+                    self.apply();
+                }
+
+                match &self.error {
+                    Some(err) => {
+                        ui.colored_label(egui::Color32::RED, err);
+                    }
+                    None => {
+                        ui.colored_label(egui::Color32::GREEN, "OK");
+                    }
+                }
+
+                if self.base_config.is_some() {
+                    ui.separator();
+                    ui.label("Overrides");
+
+                    let prev_iter = self.iterations;
+                    ui.add(egui::Slider::new(&mut self.iterations, 1..=10).text("Iterations"));
+                    if self.iterations != prev_iter {
+                        self.dirty = true;
+                    }
+
+                    let prev_angle = self.angle;
+                    ui.add(
+                        egui::Slider::new(&mut self.angle, 1.0..=180.0)
+                            .text("Angle °")
+                            .step_by(0.5),
+                    );
+                    if self.angle != prev_angle {
+                        self.dirty = true;
+                    }
+
+                    let prev_step = self.step;
+                    ui.add(
+                        egui::Slider::new(&mut self.step, 0.1..=10.0)
+                            .text("Step")
+                            .step_by(0.1),
+                    );
+                    if self.step != prev_step {
+                        self.dirty = true;
+                    }
+                }
+
+                ui.separator();
+                ui.small("Drag to pan · Scroll to zoom · F to fit");
+            });
+        self.panel_width = panel_response.response.rect.width();
+    }
+}


### PR DESCRIPTION
## Summary

- **New `ui.rs`** — `UiState` holds the full panel state (preset index, TOML text, parsed `Config`, override sliders, dirty flag, panel width). `draw()` renders a resizable-disabled left panel containing a preset `ComboBox`, a monospace `TextEdit` for raw TOML, an `Apply` button (with red/green status label), and Iterations / Angle / Step sliders whose changes immediately set `dirty = true`.
- **`renderer.rs`** — integrates `egui-winit::State` and `egui_wgpu::Renderer` into the existing wgpu pipeline. The fractal render pass is restricted to the canvas area right of the panel via `wgpu::RenderPass::set_viewport`. Mouse input is gated on `egui_ctx.is_pointer_over_egui()` to prevent click-through; releases are cleared unconditionally before egui processes them so drag state cannot get stuck. `geometry_to_vertices` extracted as a free function with three unit tests (empty geometry, single segment, multi-segment tight bounds). `.forget_lifetime()` on the egui render pass is safe because the pass is dropped before `encoder.finish()`.
- **`main.rs`** — simplified to `App::new()` only; preset loading moved into `UiState::new()`.
- **`Cargo.toml`** — added `egui 0.34`, `egui-wgpu 0.34`, `egui-winit 0.34` (with `default-features = false` to exclude `arboard` for WASM compatibility).