### PR TITLE
Add WebAssembly/WebGPU web build target

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -50,3 +50,15 @@ jobs:
           targets: wasm32-unknown-unknown
       - uses: Swatinem/rust-cache@v2
       - run: cargo check --target wasm32-unknown-unknown -p lsystem-app
+
+  trunk-build:
+    name: Trunk Build
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dtolnay/rust-toolchain@stable
+        with:
+          targets: wasm32-unknown-unknown
+      - uses: Swatinem/rust-cache@v2
+      - uses: jdx/mise-action@v2
+      - run: trunk build --release

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -351,6 +351,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "console_error_panic_hook"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a06aeb73f470f66dcdbf7223caeebb85984942f22f1adb2a088cf9668146bbbc"
+dependencies = [
+ "cfg-if",
+ "wasm-bindgen",
+]
+
+[[package]]
+name = "console_log"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "be8aed40e4edbf4d3b4431ab260b63fdc40f5780a4766824329ea0f1eefe3c0f"
+dependencies = [
+ "log",
+ "web-sys",
+]
+
+[[package]]
 name = "core-foundation"
 version = "0.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1203,12 +1223,18 @@ name = "lsystem-app"
 version = "0.1.0"
 dependencies = [
  "bytemuck",
+ "console_error_panic_hook",
+ "console_log",
  "egui",
  "egui-wgpu",
  "egui-winit",
  "env_logger",
+ "log",
  "lsystem-core",
  "pollster",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "web-sys",
  "wgpu",
  "winit",
 ]

--- a/README.md
+++ b/README.md
@@ -95,11 +95,11 @@ you can break long rules across lines for readability.
 | Tool | Purpose |
 |------|---------|
 | [Rust](https://rustup.rs/) stable | compiler (version pinned in `rust-toolchain.toml`) |
-| [trunk](https://trunkrs.dev/) | web build + dev server |
+| [mise](https://mise.jdx.dev/) | installs pinned tools — trunk (version pinned in `mise.toml`) |
 | Chrome ≥ 113 / Edge | WebGPU support in the browser |
 
 ```sh
-cargo install trunk
+mise install   # installs trunk at the version pinned in mise.toml
 ```
 
 ### Building
@@ -133,7 +133,8 @@ cargo test --workspace
 ```
 Cargo.toml                  workspace manifest
 rust-toolchain.toml         pins stable Rust + wasm32 target + components
-.github/workflows/ci.yml    fmt · clippy · test · wasm-check
+mise.toml                   pins trunk version (read by CI and local dev)
+.github/workflows/ci.yml    fmt · clippy · test · wasm-check · trunk-build
 
 crates/
   lsystem-core/             pure Rust, no rendering deps
@@ -151,14 +152,19 @@ crates/
       camera.rs             Camera (pan/zoom state) and Transform uniform
       input.rs              mouse drag and cursor tracking
       shader.wgsl           WGSL vertex + fragment shaders (LineList topology)
-      lib.rs                wasm-bindgen entry point (web, rendering TBD)
+      lib.rs                shared module declarations + native run_native()
+                            and #[wasm_bindgen(start)] entry point for web
+      ui.rs                 egui side panel (preset picker, TOML edit, sliders)
+
+index.html                  trunk entry: canvas + WebGPU detection
+Trunk.toml                  trunk build config
 
 presets/                    bundled TOML L-System definitions
 ```
 
 ### CI
 
-Every push and pull request to `main` runs four jobs:
+Every push and pull request to `main` runs five jobs:
 
 | Job | Command |
 |-----|---------|
@@ -166,6 +172,7 @@ Every push and pull request to `main` runs four jobs:
 | clippy | `cargo clippy --workspace -- -D warnings` |
 | test | `cargo test --workspace` |
 | wasm-check | `cargo check --target wasm32-unknown-unknown -p lsystem-app` |
+| trunk-build | `trunk build --release` |
 
 ### License
 

--- a/Trunk.toml
+++ b/Trunk.toml
@@ -1,0 +1,8 @@
+[build]
+target = "index.html"
+dist = "dist"
+
+[serve]
+addresses = ["127.0.0.1"]
+port = 8080
+open = false

--- a/crates/lsystem-app/Cargo.toml
+++ b/crates/lsystem-app/Cargo.toml
@@ -13,9 +13,24 @@ bytemuck = { version = "1", features = ["derive"] }
 egui = "0.34"
 egui-wgpu = "0.34"
 egui-winit = { version = "0.34", default-features = false, features = ["wayland", "x11", "links"] }
-pollster = "0.4"
+log = "0.4"
 wgpu = "29"
 winit = "0.30"
 
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]
 env_logger = "0.11"
+pollster = "0.4"
+
+[target.'cfg(target_arch = "wasm32")'.dependencies]
+console_error_panic_hook = "0.1"
+console_log = "1"
+wasm-bindgen = "0.2"
+wasm-bindgen-futures = "0.4"
+web-sys = { version = "0.3", features = [
+    "CssStyleDeclaration",
+    "Document",
+    "Element",
+    "HtmlCanvasElement",
+    "HtmlElement",
+    "Window",
+] }

--- a/crates/lsystem-app/src/lib.rs
+++ b/crates/lsystem-app/src/lib.rs
@@ -1,1 +1,62 @@
-// Web entry point (M5). Stub for now.
+mod camera;
+mod input;
+mod renderer;
+mod ui;
+
+use winit::event_loop::{ControlFlow, EventLoop};
+
+use crate::renderer::{App, UserEvent};
+
+#[cfg(not(target_arch = "wasm32"))]
+pub fn run_native() {
+    env_logger::init();
+    let event_loop = build_event_loop();
+    let mut app = App::new(event_loop.create_proxy());
+    event_loop.run_app(&mut app).unwrap();
+}
+
+#[cfg(target_arch = "wasm32")]
+#[wasm_bindgen::prelude::wasm_bindgen(start)]
+pub fn start() {
+    std::panic::set_hook(Box::new(console_error_panic_hook::hook));
+    let _ = console_log::init_with_level(log::Level::Info);
+    spawn_event_loop();
+}
+
+#[cfg(target_arch = "wasm32")]
+fn spawn_event_loop() {
+    use winit::platform::web::EventLoopExtWebSys;
+
+    let event_loop = build_event_loop();
+    let app = App::new(event_loop.create_proxy());
+    event_loop.spawn_app(app);
+}
+
+fn build_event_loop() -> EventLoop<UserEvent> {
+    let event_loop = EventLoop::<UserEvent>::with_user_event().build().unwrap();
+    event_loop.set_control_flow(ControlFlow::Wait);
+    event_loop
+}
+
+#[cfg(target_arch = "wasm32")]
+mod web {
+    use wasm_bindgen::JsCast;
+
+    pub fn show_unsupported_overlay() {
+        let Some(document) = web_sys::window().and_then(|w| w.document()) else {
+            return;
+        };
+        if let Some(canvas) = document
+            .get_element_by_id("lsystem-canvas")
+            .and_then(|el| el.dyn_into::<web_sys::HtmlElement>().ok())
+        {
+            let _ = canvas.style().set_property("display", "none");
+        }
+        if let Some(overlay) = document
+            .get_element_by_id("unsupported")
+            .and_then(|el| el.dyn_into::<web_sys::HtmlElement>().ok())
+        {
+            let _ = overlay.style().set_property("display", "flex");
+        }
+    }
+}

--- a/crates/lsystem-app/src/main.rs
+++ b/crates/lsystem-app/src/main.rs
@@ -1,17 +1,4 @@
-mod camera;
-mod input;
-mod renderer;
-mod ui;
-
-use winit::event_loop::{ControlFlow, EventLoop};
-
 fn main() {
     #[cfg(not(target_arch = "wasm32"))]
-    env_logger::init();
-
-    let event_loop = EventLoop::new().unwrap();
-    event_loop.set_control_flow(ControlFlow::Wait);
-
-    let mut app = renderer::App::new();
-    event_loop.run_app(&mut app).unwrap();
+    lsystem_app::run_native();
 }

--- a/crates/lsystem-app/src/renderer.rs
+++ b/crates/lsystem-app/src/renderer.rs
@@ -6,13 +6,22 @@ use lsystem_core::Geometry;
 use wgpu::util::DeviceExt;
 use winit::application::ApplicationHandler;
 use winit::event::{ElementState, MouseButton, MouseScrollDelta, WindowEvent};
-use winit::event_loop::ActiveEventLoop;
+use winit::event_loop::{ActiveEventLoop, EventLoopProxy};
 use winit::keyboard::Key;
-use winit::window::{Window, WindowId};
+use winit::window::{Window, WindowAttributes, WindowId};
 
 use crate::camera::{Camera, Transform};
 use crate::input::InputState;
 use crate::ui::UiState;
+
+/// Events raised outside the winit event loop and routed back through
+/// `ApplicationHandler::user_event`. On wasm the GPU device is acquired
+/// asynchronously and delivered this way; on native the device is built
+/// synchronously and this variant is unused.
+pub enum UserEvent {
+    #[cfg_attr(not(target_arch = "wasm32"), allow(dead_code))]
+    GpuReady(Box<GpuState>),
+}
 
 #[repr(C)]
 #[derive(Copy, Clone, Pod, Zeroable)]
@@ -52,7 +61,7 @@ fn geometry_to_vertices(geometry: &Geometry) -> (Vec<Vertex>, [f32; 2], [f32; 2]
     (vertices, [min_x, min_y], [max_x, max_y])
 }
 
-struct GpuState {
+pub struct GpuState {
     surface: wgpu::Surface<'static>,
     device: wgpu::Device,
     queue: wgpu::Queue,
@@ -66,19 +75,25 @@ struct GpuState {
 }
 
 impl GpuState {
-    async fn new(window: Arc<Window>, vertices: &[Vertex], initial_transform: &Transform) -> Self {
+    async fn new(
+        window: Arc<Window>,
+        vertices: &[Vertex],
+        initial_transform: &Transform,
+    ) -> Result<Self, ()> {
         let size = window.inner_size();
 
         let instance = wgpu::Instance::default();
         let surface = instance.create_surface(window).unwrap();
-        let adapter = instance
+        let Ok(adapter) = instance
             .request_adapter(&wgpu::RequestAdapterOptions {
                 power_preference: wgpu::PowerPreference::default(),
                 compatible_surface: Some(&surface),
                 force_fallback_adapter: false,
             })
             .await
-            .expect("no GPU adapter found");
+        else {
+            return Err(());
+        };
         let (device, queue) = adapter
             .request_device(&wgpu::DeviceDescriptor::default())
             .await
@@ -184,7 +199,7 @@ impl GpuState {
         let egui_renderer =
             egui_wgpu::Renderer::new(&device, format, egui_wgpu::RendererOptions::default());
 
-        Self {
+        Ok(Self {
             surface,
             device,
             queue,
@@ -195,7 +210,7 @@ impl GpuState {
             uniform_buffer,
             bind_group,
             egui_renderer,
-        }
+        })
     }
 
     fn size(&self) -> (u32, u32) {
@@ -234,12 +249,18 @@ impl GpuState {
         window: &Window,
         ui: &mut UiState,
         panel_px: u32,
-    ) -> bool {
+    ) -> (bool, std::time::Duration) {
         let raw_input = egui_winit.take_egui_input(window);
         egui_ctx.begin_pass(raw_input);
         ui.draw(egui_ctx);
         let full_output = egui_ctx.end_pass();
         egui_winit.handle_platform_output(window, full_output.platform_output);
+
+        let repaint_delay = full_output
+            .viewport_output
+            .get(&egui::ViewportId::ROOT)
+            .map(|vo| vo.repaint_delay)
+            .unwrap_or(std::time::Duration::MAX);
 
         let (w, h) = self.size();
         let effective_w = w.saturating_sub(panel_px).max(1);
@@ -258,11 +279,11 @@ impl GpuState {
             wgpu::CurrentSurfaceTexture::Suboptimal(t) => (t, true),
             wgpu::CurrentSurfaceTexture::Outdated | wgpu::CurrentSurfaceTexture::Lost => {
                 self.surface.configure(&self.device, &self.surface_config);
-                return true;
+                return (true, repaint_delay);
             }
             wgpu::CurrentSurfaceTexture::Timeout
             | wgpu::CurrentSurfaceTexture::Occluded
-            | wgpu::CurrentSurfaceTexture::Validation => return false,
+            | wgpu::CurrentSurfaceTexture::Validation => return (false, repaint_delay),
         };
         let view = frame.texture.create_view(&Default::default());
         let mut encoder = self.device.create_command_encoder(&Default::default());
@@ -338,7 +359,7 @@ impl GpuState {
         if reconfigure {
             self.surface.configure(&self.device, &self.surface_config);
         }
-        reconfigure
+        (reconfigure, repaint_delay)
     }
 }
 
@@ -352,10 +373,12 @@ pub struct App {
     egui_ctx: egui::Context,
     egui_winit: Option<egui_winit::State>,
     ui: UiState,
+    #[cfg_attr(not(target_arch = "wasm32"), allow(dead_code))]
+    proxy: EventLoopProxy<UserEvent>,
 }
 
 impl App {
-    pub fn new() -> Self {
+    pub fn new(proxy: EventLoopProxy<UserEvent>) -> Self {
         let ui = UiState::new();
         Self {
             window: None,
@@ -367,7 +390,14 @@ impl App {
             egui_ctx: egui::Context::default(),
             egui_winit: None,
             ui,
+            proxy,
         }
+    }
+
+    /// Run after `state` is populated to upload the initial geometry.
+    fn finish_init(&mut self) {
+        self.ui.dirty = true;
+        self.regenerate_if_dirty();
     }
 
     /// Physical pixel width of the egui side panel, used to restrict the camera viewport.
@@ -414,19 +444,32 @@ impl App {
     }
 }
 
-impl Default for App {
-    fn default() -> Self {
-        Self::new()
+fn window_attributes() -> WindowAttributes {
+    let attrs = Window::default_attributes().with_title("Grow Your Own Fractal");
+    #[cfg(target_arch = "wasm32")]
+    {
+        use wasm_bindgen::JsCast;
+        use winit::platform::web::WindowAttributesExtWebSys;
+        let canvas = web_sys::window()
+            .and_then(|w| w.document())
+            .and_then(|d| d.get_element_by_id("lsystem-canvas"))
+            .and_then(|el| el.dyn_into::<web_sys::HtmlCanvasElement>().ok());
+        attrs.with_canvas(canvas)
+    }
+    #[cfg(not(target_arch = "wasm32"))]
+    {
+        attrs
     }
 }
 
-impl ApplicationHandler for App {
+impl ApplicationHandler<UserEvent> for App {
     fn resumed(&mut self, event_loop: &ActiveEventLoop) {
-        let window = Arc::new(
-            event_loop
-                .create_window(Window::default_attributes().with_title("Grow Your Own Fractal"))
-                .unwrap(),
-        );
+        if self.window.is_some() {
+            // Reentrant resume (e.g. mobile app foreground): keep existing state.
+            return;
+        }
+
+        let window = Arc::new(event_loop.create_window(window_attributes()).unwrap());
 
         let egui_winit = egui_winit::State::new(
             self.egui_ctx.clone(),
@@ -447,17 +490,55 @@ impl ApplicationHandler for App {
             size.width.max(1),
             size.height.max(1),
         );
-        let state = pollster::block_on(GpuState::new(
-            window.clone(),
-            &initial_vertices,
-            &initial_transform,
-        ));
-        self.window = Some(window);
-        self.state = Some(state);
 
-        // Trigger initial geometry generation.
-        self.ui.dirty = true;
-        self.regenerate_if_dirty();
+        self.window = Some(window.clone());
+
+        #[cfg(not(target_arch = "wasm32"))]
+        {
+            let state =
+                pollster::block_on(GpuState::new(window, &initial_vertices, &initial_transform))
+                    .expect("no GPU adapter found");
+            self.state = Some(state);
+            self.finish_init();
+        }
+        #[cfg(target_arch = "wasm32")]
+        {
+            // wgpu's adapter/device requests are JS Promises and must be awaited
+            // on the JS event loop. Hand the result back via a UserEvent so the
+            // App regains exclusive ownership before installing the GpuState.
+            let proxy = self.proxy.clone();
+            wasm_bindgen_futures::spawn_local(async move {
+                match GpuState::new(window, &initial_vertices, &initial_transform).await {
+                    Ok(state) => {
+                        let _ = proxy.send_event(UserEvent::GpuReady(Box::new(state)));
+                    }
+                    Err(()) => {
+                        crate::web::show_unsupported_overlay();
+                    }
+                }
+            });
+        }
+    }
+
+    fn user_event(&mut self, _event_loop: &ActiveEventLoop, event: UserEvent) {
+        match event {
+            UserEvent::GpuReady(state) => {
+                self.state = Some(*state);
+                // A Resized event may have arrived between resumed() and now
+                // (the canvas's CSS layout typically completes during async
+                // device init) and been dropped because `state` was None.
+                // Re-sync the surface to the window's current size before
+                // rendering so the first frame isn't stuck at the stale init
+                // size.
+                if let (Some(state), Some(window)) = (&mut self.state, &self.window) {
+                    state.resize(window.inner_size());
+                }
+                self.finish_init();
+                if let Some(window) = &self.window {
+                    window.request_redraw();
+                }
+            }
+        }
     }
 
     fn window_event(&mut self, event_loop: &ActiveEventLoop, _id: WindowId, event: WindowEvent) {
@@ -586,11 +667,13 @@ impl ApplicationHandler for App {
                 if let (Some(state), Some(egui_winit), Some(window)) =
                     (&mut self.state, &mut self.egui_winit, &self.window)
                 {
-                    if state.render(&self.egui_ctx, egui_winit, window, &mut self.ui, panel_px) {
-                        window.request_redraw();
-                    }
-                    // Request another frame if egui wants to animate.
-                    if self.egui_ctx.has_requested_repaint() {
+                    let (reconfigure, repaint_delay) =
+                        state.render(&self.egui_ctx, egui_winit, window, &mut self.ui, panel_px);
+                    // Redraw immediately on surface reconfiguration or when egui
+                    // needs the very next frame (repaint_delay == ZERO). Deferred
+                    // egui animations (repaint_delay > ZERO) are fine to skip —
+                    // they will resume on the next user-input event.
+                    if reconfigure || repaint_delay.is_zero() {
                         window.request_redraw();
                     }
                 }

--- a/index.html
+++ b/index.html
@@ -1,0 +1,58 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover" />
+    <title>Grow Your Own Fractal</title>
+    <style>
+      html,
+      body {
+        margin: 0;
+        padding: 0;
+        width: 100%;
+        height: 100%;
+        overflow: hidden;
+        background: #0d0d1a;
+        color: #ddd;
+        font-family: system-ui, -apple-system, sans-serif;
+      }
+      #lsystem-canvas {
+        display: block;
+        width: 100vw;
+        height: 100vh;
+        outline: none;
+        touch-action: none;
+      }
+      #unsupported {
+        display: none;
+        position: absolute;
+        inset: 0;
+        align-items: center;
+        justify-content: center;
+        text-align: center;
+        padding: 2rem;
+      }
+      #unsupported a {
+        color: #6cf;
+      }
+    </style>
+    <link data-trunk rel="rust" href="crates/lsystem-app/Cargo.toml" data-target-name="lsystem_app" data-wasm-opt="z" />
+  </head>
+  <body>
+    <canvas id="lsystem-canvas" tabindex="0"></canvas>
+    <div id="unsupported">
+      <div>
+        <h1>WebGPU is not available in this browser.</h1>
+        <p>
+          Try the latest <a href="https://www.google.com/chrome/">Chrome</a>,
+          Edge, or Firefox Nightly with WebGPU enabled.
+        </p>
+        <p>
+          On Linux you may also need to enable
+          <code>chrome://flags/#enable-unsafe-webgpu</code> and confirm
+          <code>chrome://gpu</code> reports WebGPU as hardware-accelerated.
+        </p>
+      </div>
+    </div>
+  </body>
+</html>

--- a/mise.toml
+++ b/mise.toml
@@ -1,0 +1,2 @@
+[tools]
+"github:trunk-rs/trunk" = "0.21.14"


### PR DESCRIPTION
## What changed

- **`lib.rs` is now the real entry point** for both targets. Module declarations and `run_native()` moved there from `main.rs`; `main.rs` is a one-liner stub. On wasm, `#[wasm_bindgen(start)] fn start()` sets up panic hooks, logging, and spawns the event loop via `EventLoopExtWebSys::spawn_app`.

- **Async GPU initialisation on wasm.** `GpuState::new` now returns `Result<GpuState, ()>` so a missing adapter can be surfaced. On wasm the adapter/device Promises must be driven on the JS event loop, so the future is handed to `wasm_bindgen_futures::spawn_local`; the completed state is delivered back to `App` via a new `UserEvent::GpuReady(Box<GpuState>)`, handled in `ApplicationHandler::user_event`.

- **`#unsupported` overlay.** If no WebGPU adapter is found, `web::show_unsupported_overlay()` hides the canvas and shows a help message.

- **Canvas attachment.** A `window_attributes()` helper resolves the `#lsystem-canvas` HTML element and passes it to `WindowAttributesExtWebSys::with_canvas` on wasm; native path is unchanged.

- **Egui repaint scheduling fix.** Replaced the `has_requested_repaint()` check with `repaint_delay` from the viewport output. This avoids busy-looping on idle animations while still redrawing immediately when `repaint_delay == ZERO`.

- **New web dependencies** (wasm-target only): `wasm-bindgen`, `wasm-bindgen-futures`, `web-sys`, `console_error_panic_hook`, `console_log`. `pollster` moved to native-only.

- **`index.html`** — Trunk entry point: `<canvas id="lsystem-canvas">` + the `#unsupported` overlay div + a `<link data-trunk rel="rust">` directive pointing at the app crate.

- **`Trunk.toml`** — configures build output to `dist/` and dev server on `127.0.0.1:8080`.

- **`mise.toml`** — pins `trunk 0.21.14` so all contributors and CI get the exact same binary.

- **CI `trunk-build` job** — installs mise + trunk via `jdx/mise-action`, then runs `trunk build --release`.

- **README** updated: mise-based install instructions, expanded project tree, CI table now lists all five jobs.