### PR TITLE
Restrict CI workflow to minimal permissions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,6 +6,9 @@ on:
   pull_request:
     branches: [main]
 
+permissions:
+  contents: read
+
 env:
   CARGO_TERM_COLOR: always
 


### PR DESCRIPTION
## What changed

Added `permissions: contents: read` at the workflow level in `ci.yml`. All five jobs only check out code and run read-only build/lint/test commands, so `contents: read` is the only permission required. Every other permission defaults to `none`, satisfying the principle of least privilege for the `GITHUB_TOKEN`.