### PR TITLE
Use include_dir to auto-discover preset TOML files

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -992,6 +992,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "include_dir"
+version = "0.7.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "923d117408f1e49d914f1a379a309cffe4f18c05cf4e3d12e613a15fc81bd0dd"
+dependencies = [
+ "include_dir_macros",
+]
+
+[[package]]
+name = "include_dir_macros"
+version = "0.7.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7cab85a7ed0bd5f0e76d93846e0147172bed2e2d3f859bcc33a8d9699cad1a75"
+dependencies = [
+ "proc-macro2",
+ "quote",
+]
+
+[[package]]
 name = "indexmap"
 version = "2.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1229,6 +1248,7 @@ dependencies = [
  "egui-wgpu",
  "egui-winit",
  "env_logger",
+ "include_dir",
  "log",
  "lsystem-core",
  "pollster",

--- a/crates/lsystem-app/Cargo.toml
+++ b/crates/lsystem-app/Cargo.toml
@@ -13,6 +13,7 @@ bytemuck = { version = "1", features = ["derive"] }
 egui = "0.34"
 egui-wgpu = "0.34"
 egui-winit = { version = "0.34", default-features = false, features = ["wayland", "x11", "links"] }
+include_dir = "0.7"
 log = "0.4"
 wgpu = "29"
 winit = "0.30"

--- a/crates/lsystem-app/src/ui.rs
+++ b/crates/lsystem-app/src/ui.rs
@@ -1,26 +1,36 @@
+use include_dir::{Dir, include_dir};
 use lsystem_core::Config;
 
-pub const PRESETS: &[(&str, &str)] = &[
-    (
-        "Koch Snowflake",
-        include_str!("../../../presets/koch_snowflake.toml"),
-    ),
-    (
-        "Dragon Curve",
-        include_str!("../../../presets/dragon_curve.toml"),
-    ),
-    (
-        "Sierpinski Triangle",
-        include_str!("../../../presets/sierpinski_triangle.toml"),
-    ),
-    ("Plant A", include_str!("../../../presets/plant_a.toml")),
-    (
-        "Hilbert Curve",
-        include_str!("../../../presets/hilbert_curve.toml"),
-    ),
-];
+static PRESETS_DIR: Dir<'_> = include_dir!("$CARGO_MANIFEST_DIR/../../presets");
+
+fn load_presets() -> Vec<(String, &'static str)> {
+    let mut files: Vec<_> = PRESETS_DIR
+        .files()
+        .filter(|f| f.path().extension().and_then(|e| e.to_str()) == Some("toml"))
+        .collect();
+    files.sort_by_key(|f| f.path());
+    files
+        .into_iter()
+        .filter_map(|f| {
+            let stem = f.path().file_stem()?.to_str()?;
+            let name = stem
+                .split('_')
+                .map(|w| {
+                    let mut chars = w.chars();
+                    match chars.next() {
+                        None => String::new(),
+                        Some(first) => first.to_uppercase().collect::<String>() + chars.as_str(),
+                    }
+                })
+                .collect::<Vec<_>>()
+                .join(" ");
+            Some((name, f.contents_utf8()?))
+        })
+        .collect()
+}
 
 pub struct UiState {
+    presets: Vec<(String, &'static str)>,
     pub preset_idx: usize,
     pub toml_text: String,
     pub base_config: Option<Config>,
@@ -36,10 +46,16 @@ pub struct UiState {
 
 impl UiState {
     pub fn new() -> Self {
-        let toml_text = PRESETS[0].1.to_string();
+        let presets = load_presets();
+        let toml_text = presets
+            .first()
+            .expect("no preset TOML files found")
+            .1
+            .to_string();
         let mut s = Self {
+            presets,
             preset_idx: 0,
-            toml_text: toml_text.clone(),
+            toml_text,
             base_config: None,
             iterations: 4,
             angle: 60.0,
@@ -89,14 +105,14 @@ impl UiState {
                 ui.label("Preset");
                 let prev = self.preset_idx;
                 egui::ComboBox::from_id_salt("preset_combo")
-                    .selected_text(PRESETS[self.preset_idx].0)
+                    .selected_text(self.presets[self.preset_idx].0.as_str())
                     .show_ui(ui, |ui| {
-                        for (i, (name, _)) in PRESETS.iter().enumerate() {
-                            ui.selectable_value(&mut self.preset_idx, i, *name);
+                        for (i, (name, _)) in self.presets.iter().enumerate() {
+                            ui.selectable_value(&mut self.preset_idx, i, name.as_str());
                         }
                     });
                 if self.preset_idx != prev {
-                    self.toml_text = PRESETS[self.preset_idx].1.to_string();
+                    self.toml_text = self.presets[self.preset_idx].1.to_string();
                     self.apply();
                 }
 


### PR DESCRIPTION
## Summary

- Replaces the hardcoded `PRESETS` constant (five explicit `include_str!` calls) with a `static Dir` embedded via [`include_dir`](https://crates.io/crates/include_dir)
- Presets are discovered automatically by scanning `presets/*.toml` at compile time, sorted alphabetically by filename, with display names derived from filenames (`koch_snowflake` → `Koch Snowflake`)
- Adding a new preset now only requires dropping a `.toml` file into `presets/` — no code changes needed

## Implementation notes

- Content strings are stored as `&'static str` (no extra heap allocation); the only `String` conversion happens when copying a preset into the editable `toml_text` buffer
- Non-empty presets are treated as a startup invariant — `expect` panics with a clear message if `presets/` contains no `.toml` files
- Works on both native and WASM targets since `include_dir` embeds files at compile time