### PR TITLE
Add GitHub Pages deploy workflow

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,39 @@
+name: Deploy to GitHub Pages
+
+on:
+  workflow_run:
+    workflows: [CI]
+    types: [completed]
+    branches: [main]
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+concurrency:
+  group: pages
+  cancel-in-progress: true
+
+jobs:
+  deploy:
+    name: Deploy
+    runs-on: ubuntu-latest
+    if: ${{ github.event.workflow_run.conclusion == 'success' }}
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dtolnay/rust-toolchain@stable
+        with:
+          targets: wasm32-unknown-unknown
+      - uses: Swatinem/rust-cache@v2
+      - uses: jdx/mise-action@v2
+      - run: trunk build --release --public-url /${{ github.event.repository.name }}/
+      - uses: actions/configure-pages@v5
+      - uses: actions/upload-pages-artifact@v3
+        with:
+          path: dist
+      - id: deployment
+        uses: actions/deploy-pages@v4


### PR DESCRIPTION
## Changes

- Adds `.github/workflows/deploy.yml` to automatically deploy the WebAssembly release build to GitHub Pages.

## How it works

- Triggered via `workflow_run` after the CI workflow completes on `main`, so deployment only proceeds when all CI jobs pass.
- Builds with `trunk build --release --public-url /${{ github.event.repository.name }}/` so asset paths are correct under the Pages sub-path — no hardcoded repo name.
- Uploads the `dist/` directory as a Pages artifact and deploys via `actions/deploy-pages`.
- Concurrency group `pages` with `cancel-in-progress: true` cancels an in-flight deployment when a newer push arrives.

## Required manual step

In the repo **Settings → Pages**, set Source to **"GitHub Actions"** before merging. Without this, the deploy job will succeed but nothing will be served.