### PR TITLE
Add CLAUDE.md and Claude Code project rules

### DIFF
--- a/.claude/rules/git-and-github.md
+++ b/.claude/rules/git-and-github.md
@@ -1,0 +1,46 @@
+# Git and GitHub workflow guidelines
+
+## Git command conventions
+
+Avoid using `git -C <path>` to run git commands from a different directory. Instead, rely on the shell's working directory or `cd` into the target directory first. The `-C` flag prevents permission rules in `settings.local.json` from matching (e.g. `Bash(git status)` won't match `git -C /some/path status`).
+
+## Branch naming convention
+
+All branches must follow a descriptive, prefix-based naming convention. Use lowercase letters and hyphens for word separation.
+
+Standard Prefixes:
+
+Features: feature/<short-description>
+
+Bug Fixes: fix/<short-description>
+
+Flexibility Note: You are encouraged to select alternative prefixes (e.g., docs/, refactor/, perf/, chore/, or test/) if the standard "feature" or "fix" categories do not accurately represent the scope of the work.
+
+## Attribution in commits
+
+AI contributions should include an `Assisted-by` trailer in the following format:
+```
+Assisted-by: AGENT_NAME:MODEL_VERSION
+```
+Where:
+`AGENT_NAME` is the name of the AI tool or framework
+`MODEL_VERSION` is the specific model version used
+
+Example:
+```
+Assisted-by: Claude:claude-3-opus
+```
+
+## Pull requests
+
+When opening a Pull Request, the description must serve as a concise technical summary for human reviewers.
+
+Content Focus: Detail what was changed and why. Focus on architectural shifts, logic updates, or dependency changes.
+
+No CI/CD Info: Do not mention build statuses, test passes, or linting results.
+
+No Redundant Attribution: Since the commits already contain the `Assisted-by` trailer, do not mention your AI identity in the PR description.
+
+No TODOs: Unless the PR is explicitly marked as a [Draft], the description should not contain "to-do" items or "work in progress" notes.
+
+Structure: Use bullet points for readability and clear headings.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,68 @@
+# CLAUDE.md
+
+This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+
+## Project Overview
+
+**Grow Your Own Fractal** — an interactive L-System (Lindenmayer system) visualizer in Rust. Supports both native desktop and browser (WebAssembly/WebGPU) from a shared codebase. The fractal wgpu pipeline (`fractal_renderer.rs`) is fully decoupled from the egui GUI (`ui.rs`); `renderer.rs` is a thin winit orchestration layer that wires them together.
+
+## Common Commands
+
+```bash
+# Build & run
+cargo run -p lsystem-app          # native desktop
+trunk serve                        # web dev server at localhost:8080
+trunk build --release              # web release build → dist/
+
+# Verification (all run in CI)
+cargo test --workspace
+cargo fmt --check --all
+cargo clippy --workspace -- -D warnings
+cargo check --target wasm32-unknown-unknown -p lsystem-app
+
+# Run a single test
+cargo test -p lsystem-core config::tests::test_name
+```
+
+`trunk` is managed by mise; run `mise install` to get the pinned version from `mise.toml`.
+
+## Architecture
+
+Two-crate workspace under `crates/`:
+
+### `lsystem-core` — pure library, zero rendering deps
+
+| Module | Role |
+|--------|------|
+| `config.rs` | Parses TOML `Config` struct; validates axiom, rules, step/angle finiteness, bracket balance |
+| `alphabet.rs` | Reserved symbols (`F f + - \| [ ]`), character set validation |
+| `grammar.rs` | `expand(axiom, rules, iterations)` → lazy `ExpandIter` char iterator; stack-based rewriting avoids materializing the full string |
+| `geometry.rs` | `Geometry::D2` wrapping `Vec<[Vec2; 2]>` line segments |
+| `turtle/mod.rs` | `Turtle` trait + `build()` factory; currently always returns `Turtle2D` (reserved for future 3D dispatch) |
+| `turtle/turtle2d.rs` | `Turtle2D` — consumes char iterator, tracks position/heading via a stack, emits line segments |
+| `lib.rs` | Public API: `generate(config) -> Geometry` |
+
+Data flow: `Config` → `ExpandIter` (lazy string rewriting) → `Turtle2D` → `Geometry`.
+
+### `lsystem-app` — entry points and rendering
+
+| File | Role |
+|------|------|
+| `main.rs` | Thin native entry that calls `lib.rs::run_native()` |
+| `lib.rs` | Module declarations; `run_native()` builds an `EventLoop<UserEvent>` and calls `run_app`; `#[wasm_bindgen(start)] start()` does the same on web via `EventLoopExtWebSys::spawn_app` |
+| `fractal_renderer.rs` | `FractalRenderer` — wgpu surface/pipeline/buffers, `begin_frame`/`end_frame`; no egui dependency. On wasm `FractalRenderer` is built asynchronously and delivered via `UserEvent::GpuReady` |
+| `renderer.rs` | `App` (`ApplicationHandler<UserEvent>`) — winit event handling, coordinates `FractalRenderer` and `EguiRenderer` each frame |
+| `ui.rs` | `UiState` (preset/config state, egui draw logic) + `EguiRenderer` (egui context, winit integration, wgpu render pass) |
+| `camera.rs` | `Camera` (pan/zoom state), `Transform` uniform, `compute_transform` |
+| `input.rs` | `InputState` — mouse drag and cursor tracking |
+| `shader.wgsl` | Vertex shader applies a `Transform` uniform (scale + offset); fragment shader outputs a fixed colour; topology is `LineList` |
+
+### `presets/`
+
+Five bundled TOML L-System definitions (`koch_snowflake.toml`, `dragon_curve.toml`, `sierpinski_triangle.toml`, `plant_a.toml`, `hilbert_curve.toml`). New fractals are added here; they are embedded at compile time via `include_dir!` in `ui.rs` and auto-discovered — no registration step needed.
+
+## Key Design Decisions
+
+- **Lazy expansion**: `ExpandIter` avoids materializing the full string at each iteration, keeping memory bounded for high-iteration fractals.
+- **Dual target from day one**: `lsystem-core` has no platform-specific deps so it compiles for both native and `wasm32-unknown-unknown` without feature flags.
+- **Strict CI**: `clippy -D warnings` and `cargo fmt --check` must pass; the `wasm-check` job catches WASM regressions early.


### PR DESCRIPTION
## Summary

- Adds `CLAUDE.md` with commands, two-crate architecture overview, per-module role table, data flow, and key design decisions — gives Claude Code agents enough context to be productive without reading the full source tree.
- Adds `.claude/rules/git-and-github.md` with branch naming conventions, AI attribution (`Assisted-by` trailer) requirements, and PR description guidelines.
- Extends the rules file to instruct agents against using `git -C <path>`, which prevents `settings.local.json` allowed-command rules from matching.

## Changes

- **`CLAUDE.md`** — covers common commands (`cargo`, `trunk`), `lsystem-core` module table (including `turtle/mod.rs` `Turtle` trait and the public `expand()` entry point), `lsystem-app` file table, preset auto-discovery via `include_dir!`, and the three key design decisions (lazy expansion, dual-target crate split, strict CI).
- **`.claude/rules/git-and-github.md`** — branch prefixes, `Assisted-by` commit trailer format, PR content rules (no CI info, no redundant AI attribution, no TODOs outside drafts), and the `git -C` avoidance convention.