### PR TITLE
Document 3D forward-compat seams and whitespace stripping in CLAUDE.md

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -65,4 +65,6 @@ Five bundled TOML L-System definitions (`koch_snowflake.toml`, `dragon_curve.tom
 
 - **Lazy expansion**: `ExpandIter` avoids materializing the full string at each iteration, keeping memory bounded for high-iteration fractals.
 - **Dual target from day one**: `lsystem-core` has no platform-specific deps so it compiles for both native and `wasm32-unknown-unknown` without feature flags.
+- **3D forward-compat seams**: `Geometry::D3`, the `dimensions` TOML field (currently validated to `2` only), and the `Turtle` trait dispatch in `build()` are all present so that adding 3D is a purely additive extension — do not remove them as dead code.
+- **Whitespace in axiom/rules is stripped**: whitespace inside `axiom` and rule RHS strings is removed before validation and expansion, allowing multi-line formatting in TOML configs.
 - **Strict CI**: `clippy -D warnings` and `cargo fmt --check` must pass; the `wasm-check` job catches WASM regressions early.


### PR DESCRIPTION
## Summary

- Adds a **3D forward-compat seams** entry explaining that `Geometry::D3`, the `dimensions` TOML field, and the `Turtle` trait dispatch in `build()` are intentional stubs — not dead code — so contributors don't remove them.
- Adds a **Whitespace in axiom/rules is stripped** entry clarifying that whitespace is removed before validation and expansion, enabling multi-line TOML formatting.