### PR TITLE
Cap iterations slider to safe maximum per fractal

### DIFF
--- a/crates/lsystem-app/src/fractal_renderer.rs
+++ b/crates/lsystem-app/src/fractal_renderer.rs
@@ -47,6 +47,10 @@ pub(crate) fn geometry_to_vertices(geometry: &Geometry) -> (Vec<Vertex>, [f32; 2
     (vertices, [min_x, min_y], [max_x, max_y])
 }
 
+/// Maximum number of line segments that fit in a 256 MiB vertex buffer (wgpu's guaranteed limit).
+/// Each segment occupies 2 vertices × `size_of::<Vertex>()` bytes.
+pub(crate) const MAX_SEGMENTS: u64 = 268_435_456 / (2 * std::mem::size_of::<Vertex>() as u64);
+
 /// GPU resources for fractal rendering, stored in egui's `CallbackResources` TypeMap.
 pub(crate) struct FractalPipelineResources {
     pipeline: wgpu::RenderPipeline,

--- a/crates/lsystem-app/src/ui.rs
+++ b/crates/lsystem-app/src/ui.rs
@@ -44,6 +44,7 @@ pub struct UiState {
     pub toml_text: String,
     pub base_config: Option<Config>,
     pub iterations: u32,
+    pub max_iterations: u32,
     pub angle: f32,
     pub step: f32,
     pub error: Option<String>,
@@ -65,6 +66,7 @@ impl UiState {
             toml_text,
             base_config: None,
             iterations: 4,
+            max_iterations: 10,
             angle: 60.0,
             step: 1.0,
             error: None,
@@ -77,7 +79,13 @@ impl UiState {
     pub fn apply(&mut self) {
         match Config::parse(&self.toml_text) {
             Ok(cfg) => {
-                self.iterations = cfg.iterations;
+                self.max_iterations = lsystem_core::max_safe_iterations(
+                    &cfg.axiom,
+                    &cfg.rules,
+                    crate::fractal_renderer::MAX_SEGMENTS,
+                )
+                .max(1);
+                self.iterations = cfg.iterations.min(self.max_iterations);
                 self.angle = cfg.angle;
                 self.step = cfg.step;
                 self.base_config = Some(cfg);
@@ -160,7 +168,10 @@ impl UiState {
                     ui.label("Overrides");
 
                     let prev_iter = self.iterations;
-                    ui.add(egui::Slider::new(&mut self.iterations, 1..=10).text("Iterations"));
+                    ui.add(
+                        egui::Slider::new(&mut self.iterations, 1..=self.max_iterations)
+                            .text("Iterations"),
+                    );
                     if self.iterations != prev_iter {
                         self.dirty = true;
                     }

--- a/crates/lsystem-core/src/grammar.rs
+++ b/crates/lsystem-core/src/grammar.rs
@@ -41,6 +41,46 @@ pub fn expand<'a>(
     }
 }
 
+/// Returns the maximum iteration count for which the total number of drawn segments
+/// (produced by `F` symbols) does not exceed `max_segments`.
+///
+/// Uses symbolic growth tracking: iterates the per-character segment yield one step at
+/// a time without materialising any strings. Saturating arithmetic prevents overflow for
+/// fast-growing systems. Hard-capped at 30 so the loop always terminates.
+pub fn max_safe_iterations(axiom: &str, rules: &HashMap<char, String>, max_segments: u64) -> u32 {
+    const HARD_MAX: u32 = 30;
+
+    let axiom_counts: HashMap<char, u64> = axiom.chars().fold(HashMap::new(), |mut m, c| {
+        *m.entry(c).or_insert(0) += 1;
+        m
+    });
+
+    let total = |yields: &HashMap<char, u64>| -> u64 {
+        axiom_counts
+            .iter()
+            .map(|(c, n)| n.saturating_mul(*yields.get(c).unwrap_or(&0)))
+            .fold(0u64, |a, x| a.saturating_add(x))
+    };
+
+    let mut yields: HashMap<char, u64> = [('F', 1u64)].into();
+
+    for n in 0..=HARD_MAX {
+        if total(&yields) > max_segments {
+            return n.saturating_sub(1);
+        }
+        let mut next = yields.clone();
+        for (c, rhs) in rules {
+            let v = rhs
+                .chars()
+                .map(|ch| *yields.get(&ch).unwrap_or(&0))
+                .fold(0u64, |a, x| a.saturating_add(x));
+            next.insert(*c, v);
+        }
+        yields = next;
+    }
+    HARD_MAX
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -72,6 +112,33 @@ mod tests {
                 .count();
             assert_eq!(f_count, 3 * 4usize.pow(iter), "iter {iter}");
         }
+    }
+
+    fn sierpinski_rules() -> HashMap<char, String> {
+        [('F', "F-F+F+F-F".to_string())].into()
+    }
+
+    #[test]
+    fn max_safe_koch_exact_boundary() {
+        // Koch: 3 × 4^n segments. At n=4 → 768; at n=5 → 3072.
+        let rules = koch_rules();
+        assert_eq!(max_safe_iterations("F++F++F", &rules, 768), 4);
+        assert_eq!(max_safe_iterations("F++F++F", &rules, 767), 3);
+    }
+
+    #[test]
+    fn max_safe_sierpinski_gpu_limit() {
+        // Sierpinski: 3 × 5^n segments.
+        // n=9 → 5_859_375, n=10 → 29_296_875. Limit = 16_777_216.
+        let rules = sierpinski_rules();
+        assert_eq!(max_safe_iterations("F-F-F", &rules, 16_777_216), 9);
+    }
+
+    #[test]
+    fn max_safe_no_drawing_symbols_returns_hard_max() {
+        // Axiom "A" with no F → always 0 segments, should return HARD_MAX (30).
+        let rules: HashMap<char, String> = [('A', "AA".to_string())].into();
+        assert_eq!(max_safe_iterations("A", &rules, 16_777_216), 30);
     }
 
     #[test]

--- a/crates/lsystem-core/src/lib.rs
+++ b/crates/lsystem-core/src/lib.rs
@@ -6,6 +6,7 @@ pub mod turtle;
 
 pub use config::{Config, ConfigError};
 pub use geometry::Geometry;
+pub use grammar::max_safe_iterations;
 pub use turtle::Turtle;
 
 /// Convenience function: expand the grammar and run the turtle in one call.


### PR DESCRIPTION
## What

Fixes a panic when selecting 10 iterations on the Sierpinski Triangle preset. The vertex buffer for that configuration is ~447 MiB, which exceeds wgpu's 256 MiB `max_buffer_size` limit, causing an immediate `Validation Error` panic in `FractalCallback::prepare`.

## How

Rather than silently truncating geometry in the renderer, the fix computes the analytically safe iteration ceiling upfront and enforces it in the UI slider.

### `lsystem-core`: new `max_safe_iterations` function

Tracks per-character segment yield symbolically — no string materialisation, no iteration over the actual grammar output. For each character `c`, `yield(c, n)` = number of drawing segments it produces after `n` expansions:

- Base: `yield('F', 0) = 1`; all other characters 0
- Step: `yield(c, n) = Σ yield(c', n−1) for c' in rule[c]`; identity for symbols without rules

The function iterates until total segments exceed `max_segments`, returning `n − 1`. Saturating arithmetic prevents overflow for fast-growing systems; hard-capped at 30 iterations so the loop always terminates.

### `lsystem-app`: slider bounded to computed maximum

- `MAX_SEGMENTS` constant in `fractal_renderer.rs`: 16,777,216 segments (exact fit in wgpu's 268,435,456-byte limit with 8-byte vertices)
- `UiState::apply()` calls `max_safe_iterations` on every successful config parse and stores the result in `max_iterations`; the TOML's `iterations` value is also clamped to this ceiling on load
- Iterations slider range changed from the hardcoded `1..=10` to `1..=self.max_iterations`

For Sierpinski Triangle the slider now tops out at 9 (3 × 5⁹ = 5.8 M segments ≤ 16.7 M; 3 × 5¹⁰ = 29.3 M > 16.7 M).