### PR TITLE
Add configurable background and line colors with gradient/hue-cycle modes

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -34,7 +34,7 @@ Two-crate workspace under `crates/`:
 
 | Module | Role |
 |--------|------|
-| `config.rs` | Parses TOML `Config` struct; validates axiom, rules, step/angle finiteness, bracket balance |
+| `config.rs` | Parses TOML `Config` struct (including `ColorConfig`/`LineColorConfig` for background and line colors); validates axiom, rules, step/angle finiteness, bracket balance |
 | `alphabet.rs` | Reserved symbols (`F f + - \| [ ]`), character set validation |
 | `grammar.rs` | `expand(axiom, rules, iterations)` → lazy `ExpandIter` char iterator; stack-based rewriting avoids materializing the full string |
 | `geometry.rs` | `Geometry::D2` wrapping `Vec<[Vec2; 2]>` line segments |
@@ -50,11 +50,11 @@ Data flow: `Config` → `ExpandIter` (lazy string rewriting) → `Turtle2D` → 
 |------|------|
 | `main.rs` | Thin native entry that calls `lib.rs::run_native()` |
 | `lib.rs` | Module declarations; `run_native()` builds an `EventLoop<UserEvent>` and calls `run_app`; `#[wasm_bindgen(start)] start()` does the same on web via `EventLoopExtWebSys::spawn_app` |
-| `fractal_renderer.rs` | Toolkit-independent wgpu module. `FractalRenderer` — owns the wgpu surface; `begin_frame` acquires the next surface texture and `end_frame` submits + presents. `FractalPipelineResources` (pipeline, bind group, vertex/uniform buffers) — `update()` re-uploads vertices when `geometry_version` changes and writes the camera transform; `draw()` issues the line-list draw. `FractalCallback` — plain per-frame data struct (vertices, transform, geometry_version). On wasm `FractalRenderer` is built asynchronously and delivered via `UserEvent::GpuReady` |
+| `fractal_renderer.rs` | Toolkit-independent wgpu module. `FractalRenderer` — owns the wgpu surface; `begin_frame` acquires the next surface texture and `end_frame` submits + presents. `FractalPipelineResources` (pipeline, bind group, vertex buffer, transform uniform, color-params uniform) — `update()` re-uploads vertices and color params when `geometry_version` changes and writes the camera transform every frame; `draw()` issues the line-list draw. `FractalCallback` — plain per-frame data struct (vertices, transform, geometry_version, color_params). On wasm `FractalRenderer` is built asynchronously and delivered via `UserEvent::GpuReady` |
 | `renderer.rs` | `App` (`ApplicationHandler<UserEvent>`) — owns `Camera`, geometry buffer, side-panel state. Routes `WindowEvent::RedrawRequested` straight to its own renderer; routes everything else through `egui-winit` |
 | `ui.rs` | `UiState` (preset/config state, egui layout including the central fractal canvas via `ui.allocate_painter()`, pan/zoom from the painter `Response`) + `EguiRenderer` (egui context, egui-wgpu integration, single render pass that does both the surface clear and the fractal+egui draw) + `impl egui_wgpu::CallbackTrait for FractalCallback` (thin egui adapter that delegates to `FractalPipelineResources::update/draw`) |
 | `camera.rs` | `Camera` (pan/zoom state), `Transform` uniform, `compute_transform` |
-| `shader.wgsl` | Vertex shader applies a `Transform` uniform (scale + offset); fragment shader outputs a fixed colour; topology is `LineList` |
+| `shader.wgsl` | Vertex shader applies a `Transform` uniform (scale + offset) and computes per-segment color from a `ColorParams` uniform using `vertex_index / 2`; supports solid, gradient, and HSV hue-cycle modes; fragment shader passes the interpolated color through; topology is `LineList` |
 
 ### `presets/`
 
@@ -67,7 +67,7 @@ Five bundled TOML L-System definitions (`koch_snowflake.toml`, `dragon_curve.tom
 - **3D forward-compat seams**: `Geometry::D3`, the `dimensions` TOML field (currently validated to `2` only), and the `Turtle` trait dispatch in `build()` are all present so that adding 3D is a purely additive extension — do not remove them as dead code.
 - **Whitespace in axiom/rules is stripped**: whitespace inside `axiom` and rule RHS strings is removed before validation and expansion, allowing multi-line formatting in TOML configs.
 - **Fractal lives in egui's layout**: the fractal canvas is allocated via `ui.allocate_painter()` inside an `egui::CentralPanel { frame: Frame::NONE }`, and drawn through an `egui_wgpu::CallbackTrait`. Pan/zoom come from the painter `Response` (no raw winit mouse handling); egui automatically sets the wgpu viewport to the allocated rect before invoking `paint()`, so the callback only sets pipeline/bind group/vertex buffer.
-- **One render pass per frame**: the egui-wgpu render pass uses `LoadOp::Clear(BLACK)` and contains every draw — both egui shapes and the fractal callback. `FractalRenderer::begin_frame` only acquires the surface texture; there is no separate clear pass.
+- **One render pass per frame**: the egui-wgpu render pass uses `LoadOp::Clear` with the config's `background_color` (defaulting to black) and contains every draw — both egui shapes and the fractal callback. `FractalRenderer::begin_frame` only acquires the surface texture; there is no separate clear pass.
 - **`RedrawRequested` is handled directly, never fed to `egui-winit`**: `egui-winit::on_window_event` returns `repaint = true` for *every* `WindowEvent` variant, including `RedrawRequested` itself — feeding it back would queue another `RedrawRequested` every frame and burn CPU. `App::window_event` short-circuits on `RedrawRequested`. This mirrors eframe's pattern.
-- **Geometry uploads are versioned**: `App` increments `geometry_version: u64` whenever it regenerates vertices; `FractalPipelineResources::update` compares against its stored version and re-creates the vertex buffer only when they differ. The transform uniform is rewritten every frame.
+- **Geometry uploads are versioned**: `App` increments `geometry_version: u64` whenever it regenerates vertices; `FractalPipelineResources::update` compares against its stored version and re-creates the vertex buffer and re-uploads `ColorParams` only when they differ. The transform uniform is rewritten every frame (camera can change every frame).
 - **Strict CI**: `clippy -D warnings` and `cargo fmt --check` must pass; the `wasm-check` job catches WASM regressions early.

--- a/README.md
+++ b/README.md
@@ -61,9 +61,31 @@ step = 1.0              # length of each F / f move
 initial_heading = 0.0   # starting direction in degrees (0 = east,
                         # counter-clockwise positive)
 
+background_color = [0.0, 0.0, 0.0]   # RGB 0–1; optional, default black
+
+[line_color]
+# mode = "solid"          # (default) single color; set with `color`
+# mode = "gradient"       # linear RGB from `start` to `end` across all segments
+# mode = "hue_cycle"      # full HSV hue rotation across all segments
+mode = "solid"
+color = [0.0, 0.9, 0.5]  # used by solid mode
+
+# gradient example:
+# mode  = "gradient"
+# start = [1.0, 0.4, 0.0]
+# end   = [0.6, 0.0, 1.0]
+
+# hue_cycle example:
+# mode       = "hue_cycle"
+# start_hue  = 0.0    # degrees, default 0
+# saturation = 1.0    # default 1.0
+# value      = 0.9    # default 0.9
+
 [rules]
 F = "F-F++F-F"          # each F is replaced by this string each iteration
 ```
+
+Color fields are optional — omitting `background_color` or `[line_color]` keeps the defaults (black background, solid teal lines).
 
 Whitespace inside `axiom` and rule strings is stripped before processing, so
 you can break long rules across lines for readability.

--- a/crates/lsystem-app/src/fractal_renderer.rs
+++ b/crates/lsystem-app/src/fractal_renderer.rs
@@ -1,7 +1,7 @@
 use std::sync::Arc;
 
 use bytemuck::{Pod, Zeroable};
-use lsystem_core::Geometry;
+use lsystem_core::{Geometry, LineColorConfig};
 use wgpu::util::DeviceExt;
 use winit::window::Window;
 
@@ -49,10 +49,76 @@ pub(crate) fn geometry_to_vertices(geometry: &Geometry) -> (Vec<Vertex>, [f32; 2
 /// Each segment occupies 2 vertices × `size_of::<Vertex>()` bytes.
 pub(crate) const MAX_SEGMENTS: u64 = 268_435_456 / (2 * std::mem::size_of::<Vertex>() as u64);
 
+/// Per-frame color parameters written to the GPU as a uniform.
+/// Layout mirrors `ColorParams` in `shader.wgsl`; padding keeps vec4 alignment.
+#[repr(C)]
+#[derive(Copy, Clone, Pod, Zeroable)]
+pub(crate) struct ColorParams {
+    /// 0 = solid, 1 = gradient, 2 = hue_cycle
+    mode: u32,
+    total_segments: u32,
+    _pad: [u32; 2],
+    color_start: [f32; 4],
+    color_end: [f32; 4],
+    hue_start: f32,
+    saturation: f32,
+    value: f32,
+    _pad2: f32,
+}
+
+impl Default for ColorParams {
+    fn default() -> Self {
+        color_params_from_config(&LineColorConfig::default(), 0)
+    }
+}
+
+pub(crate) fn color_params_from_config(line: &LineColorConfig, total_segments: u32) -> ColorParams {
+    match *line {
+        LineColorConfig::Solid(c) => ColorParams {
+            mode: 0,
+            total_segments,
+            _pad: [0; 2],
+            color_start: [c[0], c[1], c[2], 1.0],
+            color_end: [0.0; 4],
+            hue_start: 0.0,
+            saturation: 0.0,
+            value: 0.0,
+            _pad2: 0.0,
+        },
+        LineColorConfig::Gradient { start, end } => ColorParams {
+            mode: 1,
+            total_segments,
+            _pad: [0; 2],
+            color_start: [start[0], start[1], start[2], 1.0],
+            color_end: [end[0], end[1], end[2], 1.0],
+            hue_start: 0.0,
+            saturation: 0.0,
+            value: 0.0,
+            _pad2: 0.0,
+        },
+        LineColorConfig::HueCycle {
+            start_hue,
+            saturation,
+            value,
+        } => ColorParams {
+            mode: 2,
+            total_segments,
+            _pad: [0; 2],
+            color_start: [0.0; 4],
+            color_end: [0.0; 4],
+            hue_start: start_hue,
+            saturation,
+            value,
+            _pad2: 0.0,
+        },
+    }
+}
+
 /// GPU resources for fractal rendering.
 pub(crate) struct FractalPipelineResources {
     pipeline: wgpu::RenderPipeline,
     uniform_buffer: wgpu::Buffer,
+    color_params_buffer: wgpu::Buffer,
     bind_group: wgpu::BindGroup,
     vertex_buffer: wgpu::Buffer,
     vertex_count: u32,
@@ -76,27 +142,44 @@ impl FractalPipelineResources {
             usage: wgpu::BufferUsages::UNIFORM | wgpu::BufferUsages::COPY_DST,
         });
 
+        let color_params_buffer = device.create_buffer_init(&wgpu::util::BufferInitDescriptor {
+            label: None,
+            contents: bytemuck::bytes_of(&ColorParams::default()),
+            usage: wgpu::BufferUsages::UNIFORM | wgpu::BufferUsages::COPY_DST,
+        });
+
+        let uniform_entry = wgpu::BindGroupLayoutEntry {
+            binding: 0,
+            visibility: wgpu::ShaderStages::VERTEX,
+            ty: wgpu::BindingType::Buffer {
+                ty: wgpu::BufferBindingType::Uniform,
+                has_dynamic_offset: false,
+                min_binding_size: None,
+            },
+            count: None,
+        };
+        let color_entry = wgpu::BindGroupLayoutEntry {
+            binding: 1,
+            ..uniform_entry
+        };
         let bgl = device.create_bind_group_layout(&wgpu::BindGroupLayoutDescriptor {
             label: None,
-            entries: &[wgpu::BindGroupLayoutEntry {
-                binding: 0,
-                visibility: wgpu::ShaderStages::VERTEX,
-                ty: wgpu::BindingType::Buffer {
-                    ty: wgpu::BufferBindingType::Uniform,
-                    has_dynamic_offset: false,
-                    min_binding_size: None,
-                },
-                count: None,
-            }],
+            entries: &[uniform_entry, color_entry],
         });
 
         let bind_group = device.create_bind_group(&wgpu::BindGroupDescriptor {
             label: None,
             layout: &bgl,
-            entries: &[wgpu::BindGroupEntry {
-                binding: 0,
-                resource: uniform_buffer.as_entire_binding(),
-            }],
+            entries: &[
+                wgpu::BindGroupEntry {
+                    binding: 0,
+                    resource: uniform_buffer.as_entire_binding(),
+                },
+                wgpu::BindGroupEntry {
+                    binding: 1,
+                    resource: color_params_buffer.as_entire_binding(),
+                },
+            ],
         });
 
         let pipeline_layout = device.create_pipeline_layout(&wgpu::PipelineLayoutDescriptor {
@@ -150,6 +233,7 @@ impl FractalPipelineResources {
         Self {
             pipeline,
             uniform_buffer,
+            color_params_buffer,
             bind_group,
             vertex_buffer,
             vertex_count: 0,
@@ -166,6 +250,7 @@ impl FractalPipelineResources {
         vertices: &[Vertex],
         transform: Transform,
         geometry_version: u64,
+        color_params: ColorParams,
     ) {
         if geometry_version != self.geometry_version {
             if !vertices.is_empty() {
@@ -177,6 +262,12 @@ impl FractalPipelineResources {
             }
             self.vertex_count = vertices.len() as u32;
             self.geometry_version = geometry_version;
+            // color_params changes exactly when geometry does (both updated in regenerate_if_dirty)
+            queue.write_buffer(
+                &self.color_params_buffer,
+                0,
+                bytemuck::bytes_of(&color_params),
+            );
         }
         queue.write_buffer(&self.uniform_buffer, 0, bytemuck::bytes_of(&transform));
     }
@@ -196,6 +287,7 @@ pub(crate) struct FractalCallback {
     pub vertices: Arc<Vec<Vertex>>,
     pub transform: Transform,
     pub geometry_version: u64,
+    pub color_params: ColorParams,
 }
 
 pub(crate) enum FrameOutcome {

--- a/crates/lsystem-app/src/renderer.rs
+++ b/crates/lsystem-app/src/renderer.rs
@@ -7,7 +7,10 @@ use winit::keyboard::Key;
 use winit::window::{Window, WindowAttributes, WindowId};
 
 use crate::camera::Camera;
-use crate::fractal_renderer::{FractalRenderer, FrameOutcome, Vertex, geometry_to_vertices};
+use crate::fractal_renderer::{
+    ColorParams, FractalRenderer, FrameOutcome, Vertex, color_params_from_config,
+    geometry_to_vertices,
+};
 use crate::ui::{EguiRenderer, UiState};
 
 /// Events raised outside the winit event loop and routed back through
@@ -28,6 +31,7 @@ pub struct App {
     egui: Option<EguiRenderer>,
     ui: UiState,
     vertices: Arc<Vec<Vertex>>,
+    color_params: ColorParams,
     geometry_version: u64,
     #[cfg_attr(not(target_arch = "wasm32"), allow(dead_code))]
     proxy: EventLoopProxy<UserEvent>,
@@ -45,6 +49,7 @@ impl App {
             egui: None,
             ui,
             vertices: Arc::new(vec![]),
+            color_params: ColorParams::default(),
             geometry_version: 0,
             proxy,
         }
@@ -63,6 +68,8 @@ impl App {
         self.bounds_min = bounds_min;
         self.bounds_max = bounds_max;
         self.camera.reset();
+        let total_segments = (vertices.len() / 2) as u32;
+        self.color_params = color_params_from_config(&cfg.colors.line, total_segments);
         self.vertices = Arc::new(vertices);
         self.geometry_version += 1;
     }
@@ -227,6 +234,7 @@ impl App {
                         &mut self.ui,
                         Arc::clone(&self.vertices),
                         self.geometry_version,
+                        self.color_params,
                         &mut self.camera,
                         self.bounds_min,
                         self.bounds_max,

--- a/crates/lsystem-app/src/shader.wgsl
+++ b/crates/lsystem-app/src/shader.wgsl
@@ -3,16 +3,83 @@ struct Transform {
     offset: vec2<f32>,
 }
 
+struct ColorParams {
+    mode: u32,
+    total_segments: u32,
+    _pad0: u32,
+    _pad1: u32,
+    color_start: vec4<f32>,
+    color_end: vec4<f32>,
+    hue_start: f32,
+    saturation: f32,
+    value: f32,
+    _pad2: f32,
+}
+
 @group(0) @binding(0)
 var<uniform> transform: Transform;
 
+@group(0) @binding(1)
+var<uniform> color_params: ColorParams;
+
+fn hsv_to_rgb(h: f32, s: f32, v: f32) -> vec3<f32> {
+    let h6 = (h % 360.0) / 60.0;
+    let i = u32(h6) % 6u;
+    let f = h6 - floor(h6);
+    let p = v * (1.0 - s);
+    let q = v * (1.0 - f * s);
+    let t = v * (1.0 - (1.0 - f) * s);
+    switch i {
+        case 0u: { return vec3<f32>(v, t, p); }
+        case 1u: { return vec3<f32>(q, v, p); }
+        case 2u: { return vec3<f32>(p, v, t); }
+        case 3u: { return vec3<f32>(p, q, v); }
+        case 4u: { return vec3<f32>(t, p, v); }
+        default: { return vec3<f32>(v, p, q); }
+    }
+}
+
+struct VertexOutput {
+    @builtin(position) clip_position: vec4<f32>,
+    @location(0) color: vec4<f32>,
+}
+
 @vertex
-fn vs_main(@location(0) position: vec2<f32>) -> @builtin(position) vec4<f32> {
-    let ndc = position * transform.scale + transform.offset;
-    return vec4<f32>(ndc, 0.0, 1.0);
+fn vs_main(
+    @builtin(vertex_index) vi: u32,
+    @location(0) position: vec2<f32>,
+) -> VertexOutput {
+    let denom = max(color_params.total_segments, 2u) - 1u;
+    let t = f32(vi / 2u) / f32(denom);
+
+    var color: vec4<f32>;
+    switch color_params.mode {
+        case 1u: {
+            color = mix(color_params.color_start, color_params.color_end, t);
+        }
+        case 2u: {
+            let hue = color_params.hue_start + t * 360.0;
+            color = vec4<f32>(
+                hsv_to_rgb(hue, color_params.saturation, color_params.value),
+                1.0,
+            );
+        }
+        default: {
+            color = color_params.color_start;
+        }
+    }
+
+    var out: VertexOutput;
+    out.clip_position = vec4<f32>(
+        position * transform.scale + transform.offset,
+        0.0,
+        1.0,
+    );
+    out.color = color;
+    return out;
 }
 
 @fragment
-fn fs_main() -> @location(0) vec4<f32> {
-    return vec4<f32>(0.0, 0.9, 0.5, 1.0);
+fn fs_main(in: VertexOutput) -> @location(0) vec4<f32> {
+    return in.color;
 }

--- a/crates/lsystem-app/src/ui.rs
+++ b/crates/lsystem-app/src/ui.rs
@@ -8,7 +8,7 @@ use winit::event::WindowEvent;
 use winit::window::Window;
 
 use crate::camera::Camera;
-use crate::fractal_renderer::{FractalCallback, FractalPipelineResources, Vertex};
+use crate::fractal_renderer::{ColorParams, FractalCallback, FractalPipelineResources, Vertex};
 
 impl egui_wgpu::CallbackTrait for FractalCallback {
     fn prepare(
@@ -28,6 +28,7 @@ impl egui_wgpu::CallbackTrait for FractalCallback {
                 &self.vertices,
                 self.transform,
                 self.geometry_version,
+                self.color_params,
             );
         vec![]
     }
@@ -143,14 +144,30 @@ impl UiState {
         })
     }
 
+    pub fn background_color(&self) -> wgpu::Color {
+        let [r, g, b] = self
+            .base_config
+            .as_ref()
+            .map(|c| c.colors.background)
+            .unwrap_or_default();
+        wgpu::Color {
+            r: r as f64,
+            g: g as f64,
+            b: b as f64,
+            a: 1.0,
+        }
+    }
+
     /// Draw the egui UI. Mutates `camera` based on pan/zoom interactions inside the
     /// central panel.
     #[allow(deprecated)]
+    #[allow(clippy::too_many_arguments)]
     pub fn draw(
         &mut self,
         ctx: &egui::Context,
         vertices: Arc<Vec<Vertex>>,
         geometry_version: u64,
+        color_params: ColorParams,
         camera: &mut Camera,
         bounds_min: [f32; 2],
         bounds_max: [f32; 2],
@@ -284,6 +301,7 @@ impl UiState {
                         vertices,
                         transform,
                         geometry_version,
+                        color_params,
                     },
                 ));
             });
@@ -349,6 +367,7 @@ impl EguiRenderer {
         ui: &mut UiState,
         vertices: Arc<Vec<Vertex>>,
         geometry_version: u64,
+        color_params: ColorParams,
         camera: &mut Camera,
         bounds_min: [f32; 2],
         bounds_max: [f32; 2],
@@ -371,6 +390,7 @@ impl EguiRenderer {
             &self.ctx,
             vertices,
             geometry_version,
+            color_params,
             camera,
             bounds_min,
             bounds_max,
@@ -408,7 +428,7 @@ impl EguiRenderer {
                         ops: wgpu::Operations {
                             // Clearing here also serves as the fractal viewport background,
                             // which is why CentralPanel uses Frame::NONE (no own fill).
-                            load: wgpu::LoadOp::Clear(wgpu::Color::BLACK),
+                            load: wgpu::LoadOp::Clear(ui.background_color()),
                             store: wgpu::StoreOp::Store,
                         },
                     })],

--- a/crates/lsystem-core/src/config.rs
+++ b/crates/lsystem-core/src/config.rs
@@ -39,6 +39,43 @@ pub enum ConfigError {
     InvalidInitialHeading(f32),
 }
 
+/// Color mode for the fractal lines.
+#[derive(Debug, Clone)]
+pub enum LineColorConfig {
+    Solid([f32; 3]),
+    Gradient {
+        start: [f32; 3],
+        end: [f32; 3],
+    },
+    HueCycle {
+        start_hue: f32,
+        saturation: f32,
+        value: f32,
+    },
+}
+
+impl Default for LineColorConfig {
+    fn default() -> Self {
+        Self::Solid([0.0, 0.9, 0.5])
+    }
+}
+
+/// Visual color settings for background and fractal lines.
+#[derive(Debug, Clone)]
+pub struct ColorConfig {
+    pub background: [f32; 3],
+    pub line: LineColorConfig,
+}
+
+impl Default for ColorConfig {
+    fn default() -> Self {
+        Self {
+            background: [0.0, 0.0, 0.0],
+            line: LineColorConfig::default(),
+        }
+    }
+}
+
 /// Parsed and validated L-System configuration.
 #[derive(Debug, Clone)]
 pub struct Config {
@@ -53,6 +90,7 @@ pub struct Config {
     pub initial_heading: f32,
     /// Production rules: single ASCII letter → replacement string.
     pub rules: HashMap<char, String>,
+    pub colors: ColorConfig,
 }
 
 impl Config {
@@ -96,6 +134,26 @@ impl Config {
             rules.insert(key, rhs);
         }
 
+        let colors = ColorConfig {
+            background: raw.background_color.unwrap_or_default(),
+            line: match raw.line_color {
+                None => LineColorConfig::default(),
+                Some(RawLineColor::Solid { color }) => LineColorConfig::Solid(color),
+                Some(RawLineColor::Gradient { start, end }) => {
+                    LineColorConfig::Gradient { start, end }
+                }
+                Some(RawLineColor::HueCycle {
+                    start_hue,
+                    saturation,
+                    value,
+                }) => LineColorConfig::HueCycle {
+                    start_hue,
+                    saturation,
+                    value,
+                },
+            },
+        };
+
         Ok(Config {
             name: raw.name,
             axiom,
@@ -104,6 +162,7 @@ impl Config {
             step: raw.step,
             initial_heading: raw.initial_heading,
             rules,
+            colors,
         })
     }
 }
@@ -121,10 +180,47 @@ struct RawConfig {
     initial_heading: f32,
     #[serde(default)]
     rules: HashMap<String, String>,
+    #[serde(default)]
+    background_color: Option<[f32; 3]>,
+    #[serde(default)]
+    line_color: Option<RawLineColor>,
+}
+
+#[derive(Deserialize)]
+#[serde(tag = "mode", rename_all = "snake_case")]
+enum RawLineColor {
+    Solid {
+        #[serde(default = "default_line_color")]
+        color: [f32; 3],
+    },
+    Gradient {
+        start: [f32; 3],
+        end: [f32; 3],
+    },
+    HueCycle {
+        #[serde(default)]
+        start_hue: f32,
+        #[serde(default = "default_saturation")]
+        saturation: f32,
+        #[serde(default = "default_value")]
+        value: f32,
+    },
 }
 
 fn default_dimensions() -> u8 {
     2
+}
+
+fn default_line_color() -> [f32; 3] {
+    [0.0, 0.9, 0.5]
+}
+
+fn default_saturation() -> f32 {
+    1.0
+}
+
+fn default_value() -> f32 {
+    0.9
 }
 
 #[cfg(test)]

--- a/crates/lsystem-core/src/lib.rs
+++ b/crates/lsystem-core/src/lib.rs
@@ -4,7 +4,7 @@ pub mod geometry;
 pub mod grammar;
 pub mod turtle;
 
-pub use config::{Config, ConfigError};
+pub use config::{ColorConfig, Config, ConfigError, LineColorConfig};
 pub use geometry::Geometry;
 pub use grammar::max_safe_iterations;
 pub use turtle::Turtle;

--- a/presets/dragon_curve.toml
+++ b/presets/dragon_curve.toml
@@ -6,6 +6,12 @@ angle = 90.0
 step = 1.0
 initial_heading = 0.0
 
+[line_color]
+mode = "hue_cycle"
+start_hue = 0.0
+saturation = 1.0
+value = 0.9
+
 [rules]
 X = "X+YF+"
 Y = "-FX-Y"

--- a/presets/hilbert_curve.toml
+++ b/presets/hilbert_curve.toml
@@ -6,6 +6,12 @@ angle = 90.0
 step = 1.0
 initial_heading = 0.0
 
+[line_color]
+mode = "hue_cycle"
+start_hue = 0.0
+saturation = 1.0
+value = 0.9
+
 [rules]
 A = "-BF+AFA+FB-"
 B = "+AF-BFB-FA+"

--- a/presets/koch_snowflake.toml
+++ b/presets/koch_snowflake.toml
@@ -6,5 +6,11 @@ angle = 60.0
 step = 1.0
 initial_heading = 0.0
 
+[line_color]
+mode = "hue_cycle"
+start_hue = 180.0
+saturation = 1.0
+value = 0.9
+
 [rules]
 F = "F-F++F-F"

--- a/presets/plant_a.toml
+++ b/presets/plant_a.toml
@@ -6,6 +6,11 @@ angle = 25.0
 step = 1.0
 initial_heading = 90.0
 
+[line_color]
+mode = "gradient"
+start = [0.05, 0.35, 0.05]
+end = [0.6, 0.9, 0.1]
+
 [rules]
 X = "F+[[X]-X]-F[-FX]+X"
 F = "FF"


### PR DESCRIPTION
## Summary

- Adds optional `background_color` and `[line_color]` fields to the TOML preset format, parsed into a new `ColorConfig`/`LineColorConfig` type in `lsystem-core`
- Three line-color modes: `solid` (default, backward-compatible), `gradient` (linear RGB interpolation), `hue_cycle` (HSV hue rotation)
- Color is computed per segment in the vertex shader via `vertex_index / 2u` against a new `ColorParams` uniform (~64 bytes); the vertex buffer layout and `MAX_SEGMENTS` limit are unchanged
- The `ColorParams` uniform is re-uploaded only when `geometry_version` changes, not every frame
- Background color drives `LoadOp::Clear` in the egui render pass, replacing the hardcoded black
- Four presets ship with color schemes: Dragon Curve and Koch Snowflake (hue-cycle), Plant A (green→yellow gradient), Hilbert Curve (full hue-cycle)

## Architecture notes

- `lsystem-core::Config` gains a `colors: ColorConfig` field; all existing TOMLs without color fields parse cleanly with defaults
- `FractalPipelineResources` gains a second uniform buffer (binding 1) for `ColorParams`; bind group layout updated accordingly
- `FractalCallback` carries `color_params: ColorParams` (Copy, ~64 bytes) alongside the existing fields
- `color_params_from_config()` in `fractal_renderer.rs` bridges `LineColorConfig` to the GPU struct
- HSV→RGB conversion lives entirely in the WGSL shader