### PR TITLE
Replace geometry_to_vertices tuple return with VertexData struct

### DIFF
--- a/crates/lsystem-app/src/fractal_renderer.rs
+++ b/crates/lsystem-app/src/fractal_renderer.rs
@@ -13,7 +13,13 @@ pub(crate) struct Vertex {
     position: [f32; 2],
 }
 
-pub(crate) fn geometry_to_vertices(geometry: &Geometry) -> (Vec<Vertex>, [f32; 2], [f32; 2]) {
+pub(crate) struct VertexData {
+    pub vertices: Vec<Vertex>,
+    pub bounds_min: [f32; 2],
+    pub bounds_max: [f32; 2],
+}
+
+pub(crate) fn geometry_to_vertices(geometry: &Geometry) -> VertexData {
     let Geometry::D2 { segments } = geometry;
 
     let mut min_x = f32::INFINITY;
@@ -42,7 +48,11 @@ pub(crate) fn geometry_to_vertices(geometry: &Geometry) -> (Vec<Vertex>, [f32; 2
         max_y = 1.0;
     }
 
-    (vertices, [min_x, min_y], [max_x, max_y])
+    VertexData {
+        vertices,
+        bounds_min: [min_x, min_y],
+        bounds_max: [max_x, max_y],
+    }
 }
 
 /// Maximum number of line segments that fit in a 256 MiB vertex buffer (wgpu's guaranteed limit).
@@ -420,10 +430,14 @@ mod tests {
         let geom = generate(&cfg(
             "name=\"t\"\naxiom=\"A\"\niterations=0\nangle=90.0\nstep=1.0",
         ));
-        let (verts, min, max) = geometry_to_vertices(&geom);
-        assert!(verts.is_empty());
-        assert!(close(min[0], -1.0) && close(min[1], -1.0));
-        assert!(close(max[0], 1.0) && close(max[1], 1.0));
+        let VertexData {
+            vertices,
+            bounds_min,
+            bounds_max,
+        } = geometry_to_vertices(&geom);
+        assert!(vertices.is_empty());
+        assert!(close(bounds_min[0], -1.0) && close(bounds_min[1], -1.0));
+        assert!(close(bounds_max[0], 1.0) && close(bounds_max[1], 1.0));
     }
 
     #[test]
@@ -432,12 +446,16 @@ mod tests {
         let geom = generate(&cfg(
             "name=\"t\"\naxiom=\"F\"\niterations=0\nangle=90.0\nstep=1.0",
         ));
-        let (verts, min, max) = geometry_to_vertices(&geom);
-        assert_eq!(verts.len(), 2);
-        assert!(close(verts[0].position[0], 0.0) && close(verts[0].position[1], 0.0));
-        assert!(close(verts[1].position[0], 1.0) && close(verts[1].position[1], 0.0));
-        assert!(close(min[0], 0.0) && close(min[1], 0.0));
-        assert!(close(max[0], 1.0) && close(max[1], 0.0));
+        let VertexData {
+            vertices,
+            bounds_min,
+            bounds_max,
+        } = geometry_to_vertices(&geom);
+        assert_eq!(vertices.len(), 2);
+        assert!(close(vertices[0].position[0], 0.0) && close(vertices[0].position[1], 0.0));
+        assert!(close(vertices[1].position[0], 1.0) && close(vertices[1].position[1], 0.0));
+        assert!(close(bounds_min[0], 0.0) && close(bounds_min[1], 0.0));
+        assert!(close(bounds_max[0], 1.0) && close(bounds_max[1], 0.0));
     }
 
     #[test]
@@ -446,9 +464,13 @@ mod tests {
         let geom = generate(&cfg(
             "name=\"t\"\naxiom=\"F+F-F\"\niterations=0\nangle=90.0\nstep=1.0",
         ));
-        let (verts, min, max) = geometry_to_vertices(&geom);
-        assert_eq!(verts.len(), 6);
-        assert!(close(min[0], 0.0) && close(min[1], 0.0));
-        assert!(close(max[0], 2.0) && close(max[1], 1.0));
+        let VertexData {
+            vertices,
+            bounds_min,
+            bounds_max,
+        } = geometry_to_vertices(&geom);
+        assert_eq!(vertices.len(), 6);
+        assert!(close(bounds_min[0], 0.0) && close(bounds_min[1], 0.0));
+        assert!(close(bounds_max[0], 2.0) && close(bounds_max[1], 1.0));
     }
 }

--- a/crates/lsystem-app/src/renderer.rs
+++ b/crates/lsystem-app/src/renderer.rs
@@ -8,7 +8,7 @@ use winit::window::{Window, WindowAttributes, WindowId};
 
 use crate::camera::Camera;
 use crate::fractal_renderer::{
-    ColorParams, FractalRenderer, FrameOutcome, Vertex, color_params_from_config,
+    ColorParams, FractalRenderer, FrameOutcome, Vertex, VertexData, color_params_from_config,
     geometry_to_vertices,
 };
 use crate::ui::{EguiRenderer, UiState};
@@ -64,7 +64,11 @@ impl App {
             return;
         };
         let geometry = lsystem_core::generate(&cfg);
-        let (vertices, bounds_min, bounds_max) = geometry_to_vertices(&geometry);
+        let VertexData {
+            vertices,
+            bounds_min,
+            bounds_max,
+        } = geometry_to_vertices(&geometry);
         self.bounds_min = bounds_min;
         self.bounds_max = bounds_max;
         self.camera.reset();


### PR DESCRIPTION
## Summary

- Introduces `VertexData { vertices, bounds_min, bounds_max }` to replace the opaque `(Vec<Vertex>, [f32; 2], [f32; 2])` tuple returned by `geometry_to_vertices`.
- All four call sites updated to use struct destructuring with named fields.
- No logic changes — purely a type-level improvement.

## Motivation

Groundwork for extracting the rendering code into a reusable crate. A public API should use named structs rather than bare tuples so callers don't need to remember positional meaning.