### PR TITLE
Move Transform to fractal_renderer.rs

### DIFF
--- a/crates/lsystem-app/src/camera.rs
+++ b/crates/lsystem-app/src/camera.rs
@@ -1,11 +1,4 @@
-use bytemuck::{Pod, Zeroable};
-
-#[repr(C)]
-#[derive(Copy, Clone, Pod, Zeroable)]
-pub struct Transform {
-    pub scale: [f32; 2],
-    pub offset: [f32; 2],
-}
+use crate::fractal_renderer::Transform;
 
 pub struct Camera {
     pan: [f32; 2],

--- a/crates/lsystem-app/src/fractal_renderer.rs
+++ b/crates/lsystem-app/src/fractal_renderer.rs
@@ -5,7 +5,12 @@ use lsystem_core::{Geometry, LineColorConfig};
 use wgpu::util::DeviceExt;
 use winit::window::Window;
 
-use crate::camera::Transform;
+#[repr(C)]
+#[derive(Copy, Clone, Pod, Zeroable)]
+pub(crate) struct Transform {
+    pub(crate) scale: [f32; 2],
+    pub(crate) offset: [f32; 2],
+}
 
 #[repr(C)]
 #[derive(Copy, Clone, Pod, Zeroable)]


### PR DESCRIPTION
## Summary

- `Transform` (the GPU scale+offset uniform) was defined in `camera.rs` and imported into `fractal_renderer.rs`, inverting the natural ownership: the renderer owns its uniform type; the camera is a consumer that computes values for it.
- Moved `Transform` into `fractal_renderer.rs`; `camera.rs` now imports it from there.
- No behavior change — purely a dependency-direction fix.

## Motivation

Correct ownership is a prerequisite for extracting `fractal_renderer` into a standalone reusable crate: the crate must own all its GPU contract types without depending on an application-level module like `camera`.