### PR TITLE
Add SVG export

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -22,6 +22,9 @@ cargo check --target wasm32-unknown-unknown -p lsystem-app
 
 # Run a single test
 cargo test -p lsystem-core config::tests::test_name
+
+# Run SVG export tests (svg feature must be enabled explicitly)
+cargo test -p lsystem-core --features svg svg_export
 ```
 
 `trunk` is managed by mise; run `mise install` to get the pinned version from `mise.toml`.
@@ -39,7 +42,8 @@ Three-crate workspace under `crates/`:
 | `grammar.rs` | `expand(axiom, rules, iterations)` → lazy `ExpandIter` char iterator; `expand_owned` → `OwnedExpandIter` (same logic, owns its data via `Vec<char>` so callers need no lifetime) |
 | `turtle/mod.rs` | Declares `turtle2d` submodule; documents the 3D extension path (add `Segments3D<I>`, dispatch in `generate()` on `cfg.dimensions`) |
 | `turtle/turtle2d.rs` | `Segments2D<I>` — pull iterator over `[Vec2; 2]` segments; owns position, heading, and bracket stack; yields one segment per `'F'` without collecting |
-| `lib.rs` | Public API: `generate(config) -> impl Iterator<Item = [Vec2; 2]>` |
+| `svg_export.rs` | `export_svg(config) -> String` — generates an SVG string; gated behind the `svg` Cargo feature |
+| `lib.rs` | Public API: `generate(config) -> impl Iterator<Item = [Vec2; 2]>`; exposes `svg_export` as a public module when the `svg` feature is enabled |
 
 Data flow: `Config` → `OwnedExpandIter` (owned lazy char rewriting) → `Segments2D` → streaming `[Vec2; 2]` segments.
 
@@ -67,7 +71,7 @@ Depends on `lsystem-core`, `lsystem-renderer`, `egui`/`egui-wgpu`/`egui-winit`, 
 
 ### `presets/`
 
-Five bundled TOML L-System definitions (`koch_snowflake.toml`, `dragon_curve.toml`, `sierpinski_triangle.toml`, `plant_a.toml`, `hilbert_curve.toml`). New fractals are added here; they are embedded at compile time via `include_dir!` in `ui.rs` and auto-discovered — no registration step needed.
+Bundled TOML L-System definitions. New fractals are added here; they are embedded at compile time via `include_dir!` in `ui.rs` and auto-discovered — no registration step needed.
 
 ## Key Design Decisions
 
@@ -80,4 +84,5 @@ Five bundled TOML L-System definitions (`koch_snowflake.toml`, `dragon_curve.tom
 - **One render pass per frame**: the egui-wgpu render pass uses `LoadOp::Clear` with the config's `background_color` (defaulting to black) and contains every draw — both egui shapes and the fractal callback. `GpuContext::begin_frame` only acquires the surface texture; there is no separate clear pass.
 - **`RedrawRequested` is handled directly, never fed to `egui-winit`**: `egui-winit::on_window_event` returns `repaint = true` for *every* `WindowEvent` variant, including `RedrawRequested` itself — feeding it back would queue another `RedrawRequested` every frame and burn CPU. `App::window_event` short-circuits on `RedrawRequested`. This mirrors eframe's pattern.
 - **Caller-driven geometry uploads**: `App` sets `needs_upload: bool` whenever it regenerates vertices; the flag is passed through `FractalCallback` to the egui adapter, which calls `LinePipeline::upload` (vertex buffer + `ColorParams`) only when `true`, and `write_transform` (camera uniform) every frame. `needs_upload` is cleared in `App::handle_redraw` after `egui.render` returns.
+- **SVG export is a `lsystem-core` Cargo feature**: The `svg` feature adds `svg_export::export_svg(config) -> String`. It collects segments into a `Vec` (the only allocation — acceptable for export), computes a padded bounding box, and builds SVG XML. The Y-axis flip (turtle is Y-up, SVG is Y-down) is handled by a `<g transform="matrix(1 0 0 -1 0 0)">` group so turtle coordinates are written as-is; the viewBox compensates. `stroke-width`, `stroke-linecap`, and `fill` are set on the `<g>` and inherited by children. Solid mode emits a single `<path>`; gradient and hue-cycle modes emit per-segment `<line>` elements to match the shader's segment-index-based coloring exactly. On native, `rfd::FileDialog` handles the save dialog; on WASM, a programmatic Blob download is triggered via `web-sys`.
 - **Strict CI**: `clippy -D warnings` and `cargo fmt --check` must pass; the `wasm-check` job catches WASM regressions early.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -451,6 +451,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e0e367e4e7da84520dedcac1901e4da967309406d1e51017ae1abfb97adbd38"
 dependencies = [
  "bitflags 2.11.1",
+ "block2 0.6.2",
+ "libc",
  "objc2 0.6.4",
 ]
 
@@ -1248,10 +1250,12 @@ dependencies = [
  "egui-winit",
  "env_logger",
  "include_dir",
+ "js-sys",
  "log",
  "lsystem-core",
  "lsystem-renderer",
  "pollster",
+ "rfd",
  "wasm-bindgen",
  "wasm-bindgen-futures",
  "web-sys",
@@ -1431,6 +1435,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "objc2-app-kit"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d49e936b501e5c5bf01fda3a9452ff86dc3ea98ad5f283e1455153142d97518c"
+dependencies = [
+ "bitflags 2.11.1",
+ "block2 0.6.2",
+ "objc2 0.6.4",
+ "objc2-foundation 0.3.2",
+]
+
+[[package]]
 name = "objc2-cloud-kit"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1539,7 +1555,7 @@ checksum = "a1a1ae721c5e35be65f01a03b6d2ac13a54cb4fa70d8a5da293d7b0020261398"
 dependencies = [
  "block2 0.5.1",
  "objc2 0.5.2",
- "objc2-app-kit",
+ "objc2-app-kit 0.2.2",
  "objc2-foundation 0.2.2",
 ]
 
@@ -1973,6 +1989,33 @@ name = "renderdoc-sys"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "19b30a45b0cd0bcca8037f3d0dc3421eaf95327a17cad11964fb8179b4fc4832"
+
+[[package]]
+name = "rfd"
+version = "0.17.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "20dafead71c16a34e1ff357ddefc8afc11e7d51d6d2b9fbd07eaa48e3e540220"
+dependencies = [
+ "block2 0.6.2",
+ "dispatch2",
+ "js-sys",
+ "libc",
+ "log",
+ "objc2 0.6.4",
+ "objc2-app-kit 0.3.2",
+ "objc2-core-foundation",
+ "objc2-foundation 0.3.2",
+ "percent-encoding",
+ "pollster",
+ "raw-window-handle",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "wayland-backend",
+ "wayland-client",
+ "wayland-protocols",
+ "web-sys",
+ "windows-sys 0.61.2",
+]
 
 [[package]]
 name = "rustc-hash"
@@ -3125,7 +3168,7 @@ dependencies = [
  "memmap2",
  "ndk",
  "objc2 0.5.2",
- "objc2-app-kit",
+ "objc2-app-kit 0.2.2",
  "objc2-foundation 0.2.2",
  "objc2-ui-kit 0.2.2",
  "orbclient",

--- a/README.md
+++ b/README.md
@@ -98,6 +98,10 @@ you can break long rules across lines for readability.
 | Scroll wheel | Zoom in / out toward the cursor |
 | `F` | Reset view to fit the fractal |
 
+### Exporting
+
+The **Export SVG** button in the left panel saves the current fractal (including the active iteration, angle, and step overrides) as a resolution-independent SVG file. On the desktop a native save dialog opens; in the browser the file is downloaded automatically.
+
 ### Bundled presets
 
 | File | Name | Description |
@@ -170,6 +174,7 @@ crates/
       grammar.rs            axiom + rule expansion (N iterations); OwnedExpandIter for lifetime-free streaming
       turtle/
         turtle2d.rs         Segments2D<I>: pull iterator yielding [Vec2; 2] segments lazily
+      svg_export.rs         SVG export — export_svg(config) -> String (enabled by the `svg` Cargo feature)
   lsystem-renderer/         toolkit-independent wgpu renderer (no egui)
     src/
       line_renderer.rs      Transform/Vertex/ColorParams types, LinePipeline, GpuContext

--- a/crates/lsystem-app/Cargo.toml
+++ b/crates/lsystem-app/Cargo.toml
@@ -8,7 +8,7 @@ license.workspace = true
 crate-type = ["cdylib", "rlib"]
 
 [dependencies]
-lsystem-core = { path = "../lsystem-core" }
+lsystem-core = { path = "../lsystem-core", features = ["svg"] }
 lsystem-renderer = { path = "../lsystem-renderer" }
 egui = "0.34"
 egui-wgpu = "0.34"
@@ -21,17 +21,23 @@ winit = "0.30"
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]
 env_logger = "0.11"
 pollster = "0.4"
+rfd = "0.17"
 
 [target.'cfg(target_arch = "wasm32")'.dependencies]
 console_error_panic_hook = "0.1"
 console_log = "1"
+js-sys = "0.3"
 wasm-bindgen = "0.2"
 wasm-bindgen-futures = "0.4"
 web-sys = { version = "0.3", features = [
+    "Blob",
+    "BlobPropertyBag",
     "CssStyleDeclaration",
     "Document",
     "Element",
+    "HtmlAnchorElement",
     "HtmlCanvasElement",
     "HtmlElement",
+    "Url",
     "Window",
 ] }

--- a/crates/lsystem-app/src/ui.rs
+++ b/crates/lsystem-app/src/ui.rs
@@ -239,6 +239,15 @@ impl UiState {
                     if self.step != prev_step {
                         self.dirty = true;
                     }
+
+                    ui.separator();
+                    if ui.button("Export SVG").clicked()
+                        && let Some(cfg) = self.effective_config()
+                    {
+                        let svg = lsystem_core::svg_export::export_svg(&cfg);
+                        let filename = sanitize_svg_filename(&cfg.name);
+                        save_svg(svg, filename);
+                    }
                 }
 
                 ui.separator();
@@ -440,4 +449,69 @@ impl EguiRenderer {
 
         repaint_delay
     }
+}
+
+fn sanitize_svg_filename(name: &str) -> String {
+    let base: String = name
+        .chars()
+        .map(|c| {
+            if c.is_ascii_alphanumeric() {
+                c.to_ascii_lowercase()
+            } else {
+                '_'
+            }
+        })
+        .collect();
+    format!("{base}.svg")
+}
+
+#[cfg(not(target_arch = "wasm32"))]
+fn save_svg(svg: String, suggested_name: String) {
+    if let Some(path) = rfd::FileDialog::new()
+        .set_file_name(&suggested_name)
+        .add_filter("SVG Image", &["svg"])
+        .save_file()
+        && let Err(e) = std::fs::write(&path, svg.as_bytes())
+    {
+        log::error!("Failed to write SVG: {e}");
+    }
+}
+
+#[cfg(target_arch = "wasm32")]
+fn save_svg(svg: String, suggested_name: String) {
+    use wasm_bindgen::JsCast;
+
+    let Some(window) = web_sys::window() else {
+        return;
+    };
+    let Some(document) = window.document() else {
+        return;
+    };
+
+    let array = js_sys::Array::new();
+    array.push(&wasm_bindgen::JsValue::from_str(&svg));
+    let props = web_sys::BlobPropertyBag::new();
+    props.set_type("image/svg+xml");
+    let Ok(blob) = web_sys::Blob::new_with_str_sequence_and_options(&array, &props) else {
+        return;
+    };
+    let Ok(url) = web_sys::Url::create_object_url_with_blob(&blob) else {
+        return;
+    };
+
+    let Ok(el) = document.create_element("a") else {
+        return;
+    };
+    let Ok(anchor) = el.dyn_into::<web_sys::HtmlAnchorElement>() else {
+        return;
+    };
+    anchor.set_href(&url);
+    anchor.set_download(&suggested_name);
+    // Append to body so click() works in Firefox, then remove immediately after.
+    if let Some(body) = document.body() {
+        let _ = body.append_child(&anchor);
+        anchor.click();
+        let _ = body.remove_child(&anchor);
+    }
+    let _ = web_sys::Url::revoke_object_url(&url);
 }

--- a/crates/lsystem-core/Cargo.toml
+++ b/crates/lsystem-core/Cargo.toml
@@ -4,6 +4,9 @@ version = "0.1.0"
 edition = "2024"
 license.workspace = true
 
+[features]
+svg = []
+
 [dependencies]
 glam = { version = "0.32", features = ["bytemuck"] }
 serde = { version = "1", features = ["derive"] }

--- a/crates/lsystem-core/src/lib.rs
+++ b/crates/lsystem-core/src/lib.rs
@@ -1,3 +1,6 @@
+#[cfg(feature = "svg")]
+pub mod svg_export;
+
 pub(crate) mod alphabet;
 pub mod config;
 pub mod grammar;

--- a/crates/lsystem-core/src/svg_export.rs
+++ b/crates/lsystem-core/src/svg_export.rs
@@ -1,0 +1,224 @@
+use glam::Vec2;
+
+use crate::{Config, LineColorConfig, generate};
+
+/// Generate an SVG string for the given config.
+///
+/// The SVG uses the natural turtle coordinate system, scaled to fit the fractal.
+/// Colors match the GPU render exactly.
+pub fn export_svg(config: &Config) -> String {
+    let segments: Vec<[Vec2; 2]> = generate(config).collect();
+
+    if segments.is_empty() {
+        let bg = to_hex(config.colors.background);
+        return format!(
+            r#"<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1 1"><rect width="1" height="1" fill="{bg}"/></svg>"#
+        );
+    }
+
+    let (mut min_x, mut min_y, mut max_x, mut max_y) = (
+        f32::INFINITY,
+        f32::INFINITY,
+        f32::NEG_INFINITY,
+        f32::NEG_INFINITY,
+    );
+    for [a, b] in &segments {
+        for p in [a, b] {
+            min_x = min_x.min(p.x);
+            min_y = min_y.min(p.y);
+            max_x = max_x.max(p.x);
+            max_y = max_y.max(p.y);
+        }
+    }
+
+    // Pad degenerate (zero-width or zero-height) bounding boxes.
+    let pad = config.step * 0.5;
+    if max_x == min_x {
+        min_x -= pad;
+        max_x += pad;
+    }
+    if max_y == min_y {
+        min_y -= pad;
+        max_y += pad;
+    }
+
+    let w = max_x - min_x;
+    let h = max_y - min_y;
+    let stroke_width = (w + h) * 0.0005;
+
+    // Add a small margin so strokes near the edges are not clipped.
+    let margin = (w + h) * 0.02;
+    min_x -= margin;
+    max_x += margin;
+    min_y -= margin;
+    max_y += margin;
+    let w = max_x - min_x;
+    let h = max_y - min_y;
+
+    let bg = to_hex(config.colors.background);
+    // SVG Y-axis is flipped relative to the turtle (math Y-up vs screen Y-down).
+    // We use a group transform "matrix(1 0 0 -1 0 0)" so turtle coordinates can be
+    // written as-is. The viewBox compensates: top of image = -max_y in SVG space.
+    let neg_max_y = -max_y;
+
+    let body = build_body(&segments, &config.colors.line);
+
+    format!(
+        "<svg xmlns=\"http://www.w3.org/2000/svg\" viewBox=\"{min_x:.3} {neg_max_y:.3} {w:.3} {h:.3}\">\n\
+        <rect x=\"{min_x:.3}\" y=\"{neg_max_y:.3}\" width=\"{w:.3}\" height=\"{h:.3}\" fill=\"{bg}\"/>\n\
+        <g transform=\"matrix(1 0 0 -1 0 0)\" stroke-width=\"{stroke_width:.4}\" stroke-linecap=\"round\" fill=\"none\">\n\
+        {body}\
+        </g>\n\
+        </svg>"
+    )
+}
+
+fn build_body(segments: &[[Vec2; 2]], line: &LineColorConfig) -> String {
+    match line {
+        LineColorConfig::Solid(c) => {
+            let color = to_hex(*c);
+            let mut d = String::new();
+            for [a, b] in segments {
+                d.push_str(&format!("M{:.3},{:.3}L{:.3},{:.3}", a.x, a.y, b.x, b.y));
+            }
+            format!("<path d=\"{d}\" stroke=\"{color}\"/>\n")
+        }
+        LineColorConfig::Gradient { start, end } => {
+            let n = segments.len();
+            let denom = (n.max(2) - 1) as f32;
+            let mut out = String::new();
+            for (i, [a, b]) in segments.iter().enumerate() {
+                let t = i as f32 / denom;
+                let rgb = [
+                    start[0] + (end[0] - start[0]) * t,
+                    start[1] + (end[1] - start[1]) * t,
+                    start[2] + (end[2] - start[2]) * t,
+                ];
+                let color = to_hex(rgb);
+                out.push_str(&format!(
+                    "<line x1=\"{:.3}\" y1=\"{:.3}\" x2=\"{:.3}\" y2=\"{:.3}\" stroke=\"{color}\"/>\n",
+                    a.x, a.y, b.x, b.y
+                ));
+            }
+            out
+        }
+        LineColorConfig::HueCycle {
+            start_hue,
+            saturation,
+            value,
+        } => {
+            let n = segments.len();
+            let denom = (n.max(2) - 1) as f32;
+            let mut out = String::new();
+            for (i, [a, b]) in segments.iter().enumerate() {
+                let t = i as f32 / denom;
+                let hue = start_hue + t * 360.0;
+                let rgb = hsv_to_rgb(hue, *saturation, *value);
+                let color = to_hex(rgb);
+                out.push_str(&format!(
+                    "<line x1=\"{:.3}\" y1=\"{:.3}\" x2=\"{:.3}\" y2=\"{:.3}\" stroke=\"{color}\"/>\n",
+                    a.x, a.y, b.x, b.y
+                ));
+            }
+            out
+        }
+    }
+}
+
+/// Port of the WGSL `hsv_to_rgb` in `shader.wgsl`. Inputs must match the shader's
+/// conventions: `h` is in any range (modulo 360 is applied internally), `s` and `v`
+/// are in [0, 1].
+fn hsv_to_rgb(h: f32, s: f32, v: f32) -> [f32; 3] {
+    let h6 = (h % 360.0) / 60.0;
+    let i = (h6 as u32) % 6;
+    let f = h6 - h6.floor();
+    let p = v * (1.0 - s);
+    let q = v * (1.0 - f * s);
+    let tc = v * (1.0 - (1.0 - f) * s);
+    match i {
+        0 => [v, tc, p],
+        1 => [q, v, p],
+        2 => [p, v, tc],
+        3 => [p, q, v],
+        4 => [tc, p, v],
+        _ => [v, p, q],
+    }
+}
+
+fn to_hex(rgb: [f32; 3]) -> String {
+    let [r, g, b] = rgb.map(|c| (c.clamp(0.0, 1.0) * 255.0).round() as u8);
+    format!("#{r:02X}{g:02X}{b:02X}")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn make_config(extra_toml: &str) -> Config {
+        let toml = format!(
+            "name = \"Test\"\naxiom = \"F+F\"\niterations = 1\nangle = 90.0\nstep = 1.0\n{extra_toml}"
+        );
+        Config::parse(&toml).unwrap()
+    }
+
+    fn make_empty_config() -> Config {
+        Config::parse("name = \"Empty\"\naxiom = \"+\"\niterations = 1\nangle = 90.0\nstep = 1.0")
+            .unwrap()
+    }
+
+    #[test]
+    fn solid_contains_svg_and_color() {
+        let cfg = make_config("[line_color]\nmode = \"solid\"\ncolor = [1.0, 0.0, 0.0]");
+        let svg = export_svg(&cfg);
+        assert!(svg.contains("<svg"), "missing <svg tag");
+        assert!(
+            svg.contains("matrix(1 0 0 -1 0 0)"),
+            "missing Y-flip transform"
+        );
+        assert!(svg.contains("#FF0000"), "missing solid color");
+        assert!(svg.contains("<path"), "expected <path for solid mode");
+    }
+
+    #[test]
+    fn gradient_first_and_last_segment_colors() {
+        let cfg = make_config(
+            "[line_color]\nmode = \"gradient\"\nstart = [1.0, 0.0, 0.0]\nend = [0.0, 0.0, 1.0]",
+        );
+        let svg = export_svg(&cfg);
+        assert!(svg.contains("<svg"), "missing <svg tag");
+        assert!(
+            svg.contains("matrix(1 0 0 -1 0 0)"),
+            "missing Y-flip transform"
+        );
+        // 2 segments: t=0 → #FF0000, t=1 → #0000FF
+        assert!(svg.contains("#FF0000"), "missing gradient start color");
+        assert!(svg.contains("#0000FF"), "missing gradient end color");
+    }
+
+    #[test]
+    fn hue_cycle_start_color() {
+        // start_hue=0, s=1, v=1 → hue=0 → pure red for first segment
+        let cfg = make_config(
+            "[line_color]\nmode = \"hue_cycle\"\nstart_hue = 0.0\nsaturation = 1.0\nvalue = 1.0",
+        );
+        let svg = export_svg(&cfg);
+        assert!(svg.contains("<svg"), "missing <svg tag");
+        assert!(
+            svg.contains("matrix(1 0 0 -1 0 0)"),
+            "missing Y-flip transform"
+        );
+        assert!(
+            svg.contains("#FF0000"),
+            "missing hue-cycle start color (red at hue=0)"
+        );
+    }
+
+    #[test]
+    fn empty_geometry_returns_minimal_svg() {
+        let cfg = make_empty_config();
+        let svg = export_svg(&cfg);
+        assert!(svg.contains("<svg"), "missing <svg tag");
+        assert!(!svg.contains("<path"), "unexpected <path in empty SVG");
+        assert!(!svg.contains("<line"), "unexpected <line in empty SVG");
+    }
+}


### PR DESCRIPTION
## Summary

- Adds an **Export SVG** button to the left panel in `lsystem-app`. It uses the active iteration/angle/step overrides, so what you see is what you export.
- On native a `rfd::FileDialog` save dialog opens; in the browser a Blob download is triggered via `web-sys`.
- SVG generation lives in `lsystem-core` behind a new `svg` Cargo feature (`svg_export::export_svg`).

## Implementation details

**`lsystem-core` — `svg` feature (`crates/lsystem-core/src/svg_export.rs`)**

- Collects the lazy segment iterator into a `Vec` (the only allocation; acceptable for an export path).
- Computes a padded bounding box; adds a 2% margin on all sides so strokes near the edges are not clipped.
- Turtle Y-up / SVG Y-down flip is handled by `<g transform="matrix(1 0 0 -1 0 0)">` so turtle coordinates are written as-is and the `viewBox` compensates.
- `stroke-width`, `stroke-linecap`, and `fill` are set once on the `<g>` and inherited, keeping per-element output minimal.
- **Solid** mode: single compact `<path d="M…L…M…">`.
- **Gradient / HueCycle** modes: per-segment `<line>` elements to match the shader's segment-index-based coloring exactly (a spatial SVG gradient would be a different effect). HSV-to-RGB is ported from `shader.wgsl` for bit-identical colors.

**`lsystem-app`**

- `rfd = "0.17"` added as a native-only dependency; `js-sys` and additional `web-sys` features (`Blob`, `BlobPropertyBag`, `Url`, `HtmlAnchorElement`) added for WASM.
- The download anchor is appended to `<body>` before `.click()` and removed immediately after — required for Firefox to honour the `download` attribute.
- Filename is derived from `config.name` with non-alphanumeric characters replaced by `_`.

## Testing

```sh
cargo test -p lsystem-core --features svg svg_export
cargo clippy --workspace -- -D warnings
cargo fmt --check --all
cargo check --target wasm32-unknown-unknown -p lsystem-app
```