### PR TITLE
Remove winit dependency from lsystem-renderer

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -49,7 +49,7 @@ Data flow: `Config` → `OwnedExpandIter` (owned lazy char rewriting) → `Segme
 
 ### `lsystem-renderer` — toolkit-independent wgpu renderer
 
-Depends on `lsystem-core` and `wgpu`/`winit`; no egui coupling.
+Depends on `lsystem-core` and `wgpu`.
 
 | File | Role |
 |------|------|

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1281,7 +1281,6 @@ dependencies = [
  "glam",
  "lsystem-core",
  "wgpu",
- "winit",
 ]
 
 [[package]]

--- a/crates/lsystem-app/src/renderer.rs
+++ b/crates/lsystem-app/src/renderer.rs
@@ -111,7 +111,9 @@ impl ApplicationHandler<UserEvent> for App {
 
         #[cfg(not(target_arch = "wasm32"))]
         {
-            let gpu = pollster::block_on(GpuContext::new(window)).expect("no GPU adapter found");
+            let size = window.inner_size();
+            let gpu = pollster::block_on(GpuContext::new(window, size.width, size.height))
+                .expect("no GPU adapter found");
             if let Some(egui) = &mut self.egui {
                 egui.attach_gpu(gpu.device.clone(), gpu.queue.clone(), gpu.surface_format());
             }
@@ -127,7 +129,8 @@ impl ApplicationHandler<UserEvent> for App {
             // App regains exclusive ownership before installing the GpuContext.
             let proxy = self.proxy.clone();
             wasm_bindgen_futures::spawn_local(async move {
-                match GpuContext::new(window).await {
+                let size = window.inner_size();
+                match GpuContext::new(window, size.width, size.height).await {
                     Ok(gpu) => {
                         let _ = proxy.send_event(UserEvent::GpuReady(Box::new(gpu)));
                     }
@@ -151,7 +154,8 @@ impl ApplicationHandler<UserEvent> for App {
                 // been dropped. Re-sync the surface to the window's current size so the
                 // first frame isn't stuck at the stale init size.
                 if let (Some(gpu), Some(window)) = (&mut self.gpu, &self.window) {
-                    gpu.resize(window.inner_size());
+                    let s = window.inner_size();
+                    gpu.resize(s.width, s.height);
                 }
                 if let Some(window) = &self.window {
                     window.request_redraw();
@@ -191,7 +195,7 @@ impl ApplicationHandler<UserEvent> for App {
 
             WindowEvent::Resized(size) => {
                 if let Some(gpu) = &mut self.gpu {
-                    gpu.resize(size);
+                    gpu.resize(size.width, size.height);
                 }
             }
 

--- a/crates/lsystem-renderer/Cargo.toml
+++ b/crates/lsystem-renderer/Cargo.toml
@@ -9,4 +9,3 @@ lsystem-core = { path = "../lsystem-core" }
 bytemuck = { version = "1", features = ["derive"] }
 glam = "0.32"
 wgpu = "29"
-winit = "0.30"

--- a/crates/lsystem-renderer/src/line_renderer.rs
+++ b/crates/lsystem-renderer/src/line_renderer.rs
@@ -2,7 +2,6 @@ use std::sync::Arc;
 
 use bytemuck::{Pod, Zeroable};
 use wgpu::util::DeviceExt;
-use winit::window::Window;
 
 #[repr(C)]
 #[derive(Copy, Clone, Pod, Zeroable)]
@@ -216,11 +215,13 @@ pub struct GpuContext {
 }
 
 impl GpuContext {
-    pub async fn new(window: Arc<Window>) -> Result<Self, ()> {
-        let size = window.inner_size();
-
+    pub async fn new(
+        target: impl Into<wgpu::SurfaceTarget<'static>>,
+        width: u32,
+        height: u32,
+    ) -> Result<Self, ()> {
         let instance = wgpu::Instance::default();
-        let surface = instance.create_surface(window).map_err(|_| ())?;
+        let surface = instance.create_surface(target).map_err(|_| ())?;
         let adapter = instance
             .request_adapter(&wgpu::RequestAdapterOptions {
                 power_preference: wgpu::PowerPreference::default(),
@@ -248,8 +249,8 @@ impl GpuContext {
         let surface_config = wgpu::SurfaceConfiguration {
             usage: wgpu::TextureUsages::RENDER_ATTACHMENT,
             format,
-            width: size.width.max(1),
-            height: size.height.max(1),
+            width: width.max(1),
+            height: height.max(1),
             present_mode: caps.present_modes[0],
             alpha_mode: caps.alpha_modes[0],
             view_formats: vec![],
@@ -273,12 +274,12 @@ impl GpuContext {
         (self.surface_config.width, self.surface_config.height)
     }
 
-    pub fn resize(&mut self, new_size: winit::dpi::PhysicalSize<u32>) {
-        if new_size.width == 0 || new_size.height == 0 {
+    pub fn resize(&mut self, width: u32, height: u32) {
+        if width == 0 || height == 0 {
             return;
         }
-        self.surface_config.width = new_size.width;
-        self.surface_config.height = new_size.height;
+        self.surface_config.width = width;
+        self.surface_config.height = height;
         self.surface.configure(&self.device, &self.surface_config);
     }
 


### PR DESCRIPTION
## Summary

- `GpuContext::new` now accepts `impl Into<wgpu::SurfaceTarget<'static>>` plus explicit `width`/`height` instead of `Arc<winit::Window>`
- `GpuContext::resize` takes `(u32, u32)` instead of `winit::dpi::PhysicalSize<u32>`
- `winit = "0.30"` removed from `lsystem-renderer/Cargo.toml`
- Call sites in `lsystem-app` extract `.width`/`.height` from `PhysicalSize` before passing them

`lsystem-renderer` is described as a toolkit-independent wgpu renderer, but previously its public API leaked winit types, preventing use with other windowing solutions. The new API depends only on wgpu's own `SurfaceTarget` abstraction.