### PR TITLE
Add PNG export

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -28,6 +28,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "adler2"
+version = "2.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
+
+[[package]]
 name = "ahash"
 version = "0.8.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -421,6 +427,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "crc32fast"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9481c1c90cbf2ac953f07c8d4a58aa3945c425b7185c9154d67a65e4230da511"
+dependencies = [
+ "cfg-if",
+]
+
+[[package]]
 name = "crossbeam-utils"
 version = "0.8.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -648,6 +663,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "fdeflate"
+version = "0.3.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e6853b52649d4ac5c0bd02320cddc5ba956bdb407c4b75a2c6b75bf51500f8c"
+dependencies = [
+ "simd-adler32",
+]
+
+[[package]]
 name = "fearless_simd"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -661,6 +685,16 @@ name = "find-msvc-tools"
 version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5baebc0774151f905a1a2cc41989300b1e6fbb29aff0ceffa1064fdd3088d582"
+
+[[package]]
+name = "flate2"
+version = "1.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "843fba2746e448b37e26a819579957415c8cef339bf08564fe8b7ddbd959573c"
+dependencies = [
+ "crc32fast",
+ "miniz_oxide",
+]
 
 [[package]]
 name = "foldhash"
@@ -717,6 +751,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cb4cb245038516f5f85277875cdaa4f7d2c9a0fa0468de06ed190163b1581fcf"
 dependencies = [
  "percent-encoding",
+]
+
+[[package]]
+name = "futures-channel"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "07bbe89c50d7a535e539b8c17bc0b49bdb77747034daa8087407d655f3f7cc1d"
+dependencies = [
+ "futures-core",
 ]
 
 [[package]]
@@ -1278,8 +1321,10 @@ name = "lsystem-renderer"
 version = "0.1.0"
 dependencies = [
  "bytemuck",
+ "futures-channel",
  "glam",
  "lsystem-core",
+ "png",
  "wgpu",
 ]
 
@@ -1296,6 +1341,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "714098028fe011992e1c3962653c96b2d578c4b4bce9036e15ff220319b1e0e3"
 dependencies = [
  "libc",
+]
+
+[[package]]
+name = "miniz_oxide"
+version = "0.8.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1fa76a2c86f704bdb222d66965fb3d63269ce38518b83cb0575fca855ebb6316"
+dependencies = [
+ "adler2",
+ "simd-adler32",
 ]
 
 [[package]]
@@ -1796,6 +1851,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b4596b6d070b27117e987119b4dac604f3c58cfb0b191112e24771b2faeac1a6"
 
 [[package]]
+name = "png"
+version = "0.18.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "60769b8b31b2a9f263dae2776c37b1b28ae246943cf719eb6946a1db05128a61"
+dependencies = [
+ "bitflags 2.11.1",
+ "crc32fast",
+ "fdeflate",
+ "flate2",
+ "miniz_oxide",
+]
+
+[[package]]
 name = "polling"
 version = "3.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2159,6 +2227,12 @@ name = "shlex"
 version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
+
+[[package]]
+name = "simd-adler32"
+version = "0.3.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "703d5c7ef118737c72f1af64ad2f6f8c5e1921f818cdcb97b8fe6fc69bf66214"
 
 [[package]]
 name = "simd_cesu8"

--- a/crates/lsystem-app/Cargo.toml
+++ b/crates/lsystem-app/Cargo.toml
@@ -9,7 +9,7 @@ crate-type = ["cdylib", "rlib"]
 
 [dependencies]
 lsystem-core = { path = "../lsystem-core", features = ["svg"] }
-lsystem-renderer = { path = "../lsystem-renderer" }
+lsystem-renderer = { path = "../lsystem-renderer", features = ["png"] }
 egui = "0.34"
 egui-wgpu = "0.34"
 egui-winit = { version = "0.34", default-features = false, features = ["wayland", "x11", "links"] }

--- a/crates/lsystem-app/src/camera.rs
+++ b/crates/lsystem-app/src/camera.rs
@@ -1,4 +1,5 @@
 use lsystem_renderer::line_renderer::Transform;
+use lsystem_renderer::lsystem_bridge::{fitted_pixels_per_unit, viewport_transform};
 
 pub struct Camera {
     pan: [f32; 2],
@@ -25,10 +26,7 @@ impl Camera {
         width: u32,
         height: u32,
     ) -> f32 {
-        let geom_w = (bounds_max[0] - bounds_min[0]).max(1.0);
-        let geom_h = (bounds_max[1] - bounds_min[1]).max(1.0);
-        let base = (width as f32 / geom_w).min(height as f32 / geom_h) * 0.9;
-        base * self.zoom
+        fitted_pixels_per_unit(bounds_min, bounds_max, width, height) * self.zoom
     }
 
     pub fn compute_transform(
@@ -38,15 +36,7 @@ impl Camera {
         width: u32,
         height: u32,
     ) -> Transform {
-        let cx = (bounds_min[0] + bounds_max[0]) * 0.5;
-        let cy = (bounds_min[1] + bounds_max[1]) * 0.5;
-        let ppu = self.px_per_unit(bounds_min, bounds_max, width, height);
-        let sx = ppu * 2.0 / width as f32;
-        let sy = ppu * 2.0 / height as f32;
-        Transform {
-            scale: [sx, sy],
-            offset: [(-cx + self.pan[0]) * sx, (-cy + self.pan[1]) * sy],
-        }
+        viewport_transform(bounds_min, bounds_max, width, height, self.pan, self.zoom)
     }
 
     pub fn pan_by_pixels(

--- a/crates/lsystem-app/src/export.rs
+++ b/crates/lsystem-app/src/export.rs
@@ -1,0 +1,154 @@
+use std::sync::Arc;
+
+use lsystem_core::Config;
+
+pub(crate) enum ExportRequest {
+    Svg(Config),
+    Png { config: Config, width: u32 },
+}
+
+pub(crate) fn handle_export(
+    request: ExportRequest,
+    device: Arc<wgpu::Device>,
+    queue: Arc<wgpu::Queue>,
+) {
+    match request {
+        ExportRequest::Svg(cfg) => {
+            let filename = sanitize_filename(&cfg.name, "svg");
+            let svg = lsystem_core::svg_export::export_svg(&cfg);
+            save_svg(svg, filename);
+        }
+        ExportRequest::Png { config, width } => {
+            let filename = sanitize_filename(&config.name, "png");
+            save_png(device, queue, config, width, filename);
+        }
+    }
+}
+
+fn sanitize_filename(name: &str, extension: &str) -> String {
+    let base: String = name
+        .chars()
+        .map(|c| {
+            if c.is_ascii_alphanumeric() {
+                c.to_ascii_lowercase()
+            } else {
+                '_'
+            }
+        })
+        .collect();
+    format!("{base}.{extension}")
+}
+
+#[cfg(not(target_arch = "wasm32"))]
+fn save_svg(svg: String, suggested_name: String) {
+    if let Some(path) = rfd::FileDialog::new()
+        .set_file_name(&suggested_name)
+        .add_filter("SVG Image", &["svg"])
+        .save_file()
+        && let Err(e) = std::fs::write(&path, svg.as_bytes())
+    {
+        log::error!("Failed to write SVG: {e}");
+    }
+}
+
+#[cfg(not(target_arch = "wasm32"))]
+fn save_png(
+    device: Arc<wgpu::Device>,
+    queue: Arc<wgpu::Queue>,
+    cfg: Config,
+    width: u32,
+    suggested_name: String,
+) {
+    if let Some(path) = rfd::FileDialog::new()
+        .set_file_name(&suggested_name)
+        .add_filter("PNG Image", &["png"])
+        .save_file()
+    {
+        match pollster::block_on(lsystem_renderer::png_export::render_png(
+            &device, &queue, &cfg, width,
+        )) {
+            Ok(png) => {
+                if let Err(e) = std::fs::write(&path, png.bytes) {
+                    log::error!("Failed to write PNG: {e}");
+                }
+            }
+            Err(e) => {
+                log::error!("Failed to export PNG: {e}");
+            }
+        }
+    }
+}
+
+#[cfg(target_arch = "wasm32")]
+fn save_svg(svg: String, suggested_name: String) {
+    let array = js_sys::Array::new();
+    array.push(&wasm_bindgen::JsValue::from_str(&svg));
+    let props = web_sys::BlobPropertyBag::new();
+    props.set_type("image/svg+xml");
+    let Ok(blob) = web_sys::Blob::new_with_str_sequence_and_options(&array, &props) else {
+        return;
+    };
+    download_blob(blob, suggested_name);
+}
+
+#[cfg(target_arch = "wasm32")]
+fn save_png(
+    device: Arc<wgpu::Device>,
+    queue: Arc<wgpu::Queue>,
+    cfg: Config,
+    width: u32,
+    suggested_name: String,
+) {
+    wasm_bindgen_futures::spawn_local(async move {
+        match lsystem_renderer::png_export::render_png(&device, &queue, &cfg, width).await {
+            Ok(png) => {
+                let array = js_sys::Array::new();
+                let bytes = js_sys::Uint8Array::from(png.bytes.as_slice());
+                array.push(&bytes);
+                let props = web_sys::BlobPropertyBag::new();
+                props.set_type("image/png");
+                let Ok(blob) =
+                    web_sys::Blob::new_with_u8_array_sequence_and_options(&array, &props)
+                else {
+                    return;
+                };
+                download_blob(blob, suggested_name);
+            }
+            Err(e) => {
+                log::error!("Failed to export PNG: {e}");
+            }
+        }
+    });
+}
+
+#[cfg(target_arch = "wasm32")]
+fn download_blob(blob: web_sys::Blob, suggested_name: String) {
+    use wasm_bindgen::JsCast;
+
+    let Some(window) = web_sys::window() else {
+        return;
+    };
+    let Some(document) = window.document() else {
+        return;
+    };
+
+    let Ok(url) = web_sys::Url::create_object_url_with_blob(&blob) else {
+        return;
+    };
+
+    let Ok(el) = document.create_element("a") else {
+        return;
+    };
+    let Ok(anchor) = el.dyn_into::<web_sys::HtmlAnchorElement>() else {
+        return;
+    };
+    anchor.set_href(&url);
+    anchor.set_download(&suggested_name);
+    // Append to body so click() works in Firefox, then remove immediately after.
+    if let Some(body) = document.body() {
+        let _ = body.append_child(&anchor);
+        anchor.click();
+        let _ = body.remove_child(&anchor);
+    }
+    let _ = web_sys::Url::revoke_object_url(&url);
+}

--- a/crates/lsystem-app/src/lib.rs
+++ b/crates/lsystem-app/src/lib.rs
@@ -1,4 +1,5 @@
 mod camera;
+mod export;
 mod renderer;
 mod ui;
 

--- a/crates/lsystem-app/src/renderer.rs
+++ b/crates/lsystem-app/src/renderer.rs
@@ -7,6 +7,7 @@ use winit::keyboard::Key;
 use winit::window::{Window, WindowAttributes, WindowId};
 
 use crate::camera::Camera;
+use crate::export::handle_export;
 use crate::ui::{EguiRenderer, UiState};
 use lsystem_renderer::line_renderer::{ColorParams, FrameOutcome, GpuContext, Vertex};
 use lsystem_renderer::lsystem_bridge::{
@@ -226,7 +227,7 @@ impl App {
                 }
                 FrameOutcome::Ready(frame, view, mut encoder, reconfigure_after) => {
                     let surface_size = gpu.size();
-                    let repaint_delay = egui.render(
+                    let render_output = egui.render(
                         window,
                         &mut self.ui,
                         Arc::clone(&self.vertices),
@@ -241,9 +242,16 @@ impl App {
                     );
                     self.needs_upload = false;
                     gpu.end_frame(*frame, encoder, reconfigure_after);
+                    if let Some(export_request) = render_output.export_request {
+                        handle_export(
+                            export_request,
+                            Arc::clone(&gpu.device),
+                            Arc::clone(&gpu.queue),
+                        );
+                    }
                     // `repaint_delay == 0` covers active drags, scrolls, and
                     // animations; egui itself drives them.
-                    if reconfigure_after || repaint_delay.is_zero() {
+                    if reconfigure_after || render_output.repaint_delay.is_zero() {
                         window.request_redraw();
                     }
                 }

--- a/crates/lsystem-app/src/ui.rs
+++ b/crates/lsystem-app/src/ui.rs
@@ -8,6 +8,7 @@ use winit::event::WindowEvent;
 use winit::window::Window;
 
 use crate::camera::Camera;
+use crate::export::ExportRequest;
 use lsystem_renderer::line_renderer::{ColorParams, LinePipeline, Transform, Vertex};
 
 struct FractalCallback {
@@ -75,6 +76,7 @@ pub struct UiState {
     pub max_iterations: u32,
     pub angle: f32,
     pub step: f32,
+    pub png_width: u32,
     pub error: Option<String>,
     /// Set to true when geometry needs regenerating.
     pub dirty: bool,
@@ -97,6 +99,7 @@ impl UiState {
             max_iterations: 10,
             angle: 60.0,
             step: 1.0,
+            png_width: 2048,
             error: None,
             dirty: true,
         };
@@ -162,7 +165,9 @@ impl UiState {
         camera: &mut Camera,
         bounds_min: [f32; 2],
         bounds_max: [f32; 2],
-    ) {
+    ) -> Option<ExportRequest> {
+        let mut export_request = None;
+
         egui::Panel::left("controls")
             .resizable(false)
             .default_size(280.0)
@@ -241,13 +246,31 @@ impl UiState {
                     }
 
                     ui.separator();
-                    if ui.button("Export SVG").clicked()
-                        && let Some(cfg) = self.effective_config()
-                    {
-                        let svg = lsystem_core::svg_export::export_svg(&cfg);
-                        let filename = sanitize_svg_filename(&cfg.name);
-                        save_svg(svg, filename);
-                    }
+                    ui.horizontal(|ui| {
+                        ui.label("PNG width");
+                        ui.add(
+                            egui::DragValue::new(&mut self.png_width)
+                                .range(256..=4096)
+                                .speed(16),
+                        );
+                    });
+                    self.png_width = self.png_width.clamp(256, 4096);
+                    ui.horizontal(|ui| {
+                        if ui.button("Export SVG").clicked()
+                            && let Some(cfg) = self.effective_config()
+                        {
+                            export_request = Some(ExportRequest::Svg(cfg));
+                        }
+
+                        if ui.button("Export PNG").clicked()
+                            && let Some(cfg) = self.effective_config()
+                        {
+                            export_request = Some(ExportRequest::Png {
+                                config: cfg,
+                                width: self.png_width,
+                            });
+                        }
+                    });
                 }
 
                 ui.separator();
@@ -305,7 +328,14 @@ impl UiState {
                     },
                 ));
             });
+
+        export_request
     }
+}
+
+pub(crate) struct EguiRenderOutput {
+    pub(crate) repaint_delay: std::time::Duration,
+    pub(crate) export_request: Option<ExportRequest>,
 }
 
 pub struct EguiRenderer {
@@ -374,19 +404,24 @@ impl EguiRenderer {
         view: &wgpu::TextureView,
         encoder: &mut wgpu::CommandEncoder,
         surface_size: (u32, u32),
-    ) -> std::time::Duration {
+    ) -> EguiRenderOutput {
         let (renderer, device, queue) = match (
             self.renderer.as_mut(),
             self.device.as_ref(),
             self.queue.as_ref(),
         ) {
             (Some(r), Some(d), Some(q)) => (r, d, q),
-            _ => return std::time::Duration::MAX,
+            _ => {
+                return EguiRenderOutput {
+                    repaint_delay: std::time::Duration::MAX,
+                    export_request: None,
+                };
+            }
         };
 
         let raw_input = self.winit_state.take_egui_input(window);
         self.ctx.begin_pass(raw_input);
-        ui.draw(
+        let export_request = ui.draw(
             &self.ctx,
             vertices,
             needs_upload,
@@ -447,71 +482,9 @@ impl EguiRenderer {
             renderer.free_texture(id);
         }
 
-        repaint_delay
+        EguiRenderOutput {
+            repaint_delay,
+            export_request,
+        }
     }
-}
-
-fn sanitize_svg_filename(name: &str) -> String {
-    let base: String = name
-        .chars()
-        .map(|c| {
-            if c.is_ascii_alphanumeric() {
-                c.to_ascii_lowercase()
-            } else {
-                '_'
-            }
-        })
-        .collect();
-    format!("{base}.svg")
-}
-
-#[cfg(not(target_arch = "wasm32"))]
-fn save_svg(svg: String, suggested_name: String) {
-    if let Some(path) = rfd::FileDialog::new()
-        .set_file_name(&suggested_name)
-        .add_filter("SVG Image", &["svg"])
-        .save_file()
-        && let Err(e) = std::fs::write(&path, svg.as_bytes())
-    {
-        log::error!("Failed to write SVG: {e}");
-    }
-}
-
-#[cfg(target_arch = "wasm32")]
-fn save_svg(svg: String, suggested_name: String) {
-    use wasm_bindgen::JsCast;
-
-    let Some(window) = web_sys::window() else {
-        return;
-    };
-    let Some(document) = window.document() else {
-        return;
-    };
-
-    let array = js_sys::Array::new();
-    array.push(&wasm_bindgen::JsValue::from_str(&svg));
-    let props = web_sys::BlobPropertyBag::new();
-    props.set_type("image/svg+xml");
-    let Ok(blob) = web_sys::Blob::new_with_str_sequence_and_options(&array, &props) else {
-        return;
-    };
-    let Ok(url) = web_sys::Url::create_object_url_with_blob(&blob) else {
-        return;
-    };
-
-    let Ok(el) = document.create_element("a") else {
-        return;
-    };
-    let Ok(anchor) = el.dyn_into::<web_sys::HtmlAnchorElement>() else {
-        return;
-    };
-    anchor.set_href(&url);
-    anchor.set_download(&suggested_name);
-    // Append to body so click() works in Firefox, then remove immediately after.
-    if let Some(body) = document.body() {
-        let _ = body.append_child(&anchor);
-        anchor.click();
-        let _ = body.remove_child(&anchor);
-    }
-    let _ = web_sys::Url::revoke_object_url(&url);
 }

--- a/crates/lsystem-renderer/Cargo.toml
+++ b/crates/lsystem-renderer/Cargo.toml
@@ -4,8 +4,14 @@ version = "0.1.0"
 edition = "2024"
 license.workspace = true
 
+[features]
+default = []
+png = ["dep:futures-channel", "dep:png"]
+
 [dependencies]
 lsystem-core = { path = "../lsystem-core" }
 bytemuck = { version = "1", features = ["derive"] }
+futures-channel = { version = "0.3", optional = true }
 glam = "0.32"
+png = { version = "0.18", optional = true }
 wgpu = "29"

--- a/crates/lsystem-renderer/src/lib.rs
+++ b/crates/lsystem-renderer/src/lib.rs
@@ -1,2 +1,4 @@
 pub mod line_renderer;
 pub mod lsystem_bridge;
+#[cfg(feature = "png")]
+pub mod png_export;

--- a/crates/lsystem-renderer/src/lsystem_bridge.rs
+++ b/crates/lsystem-renderer/src/lsystem_bridge.rs
@@ -1,7 +1,7 @@
 use glam::Vec2;
 use lsystem_core::LineColorConfig;
 
-use crate::line_renderer::{ColorParams, Vertex};
+use crate::line_renderer::{ColorParams, Transform, Vertex};
 
 pub struct VertexData {
     pub vertices: Vec<Vertex>,
@@ -73,6 +73,36 @@ pub fn color_params_from_config(line: &LineColorConfig, total_segments: u32) -> 
     }
 }
 
+pub fn fitted_pixels_per_unit(
+    bounds_min: [f32; 2],
+    bounds_max: [f32; 2],
+    width: u32,
+    height: u32,
+) -> f32 {
+    let geom_w = (bounds_max[0] - bounds_min[0]).max(1.0);
+    let geom_h = (bounds_max[1] - bounds_min[1]).max(1.0);
+    (width as f32 / geom_w).min(height as f32 / geom_h) * 0.9
+}
+
+pub fn viewport_transform(
+    bounds_min: [f32; 2],
+    bounds_max: [f32; 2],
+    width: u32,
+    height: u32,
+    pan: [f32; 2],
+    zoom: f32,
+) -> Transform {
+    let cx = (bounds_min[0] + bounds_max[0]) * 0.5;
+    let cy = (bounds_min[1] + bounds_max[1]) * 0.5;
+    let ppu = fitted_pixels_per_unit(bounds_min, bounds_max, width, height) * zoom;
+    let sx = ppu * 2.0 / width as f32;
+    let sy = ppu * 2.0 / height as f32;
+    Transform {
+        scale: [sx, sy],
+        offset: [(-cx + pan[0]) * sx, (-cy + pan[1]) * sy],
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use lsystem_core::{Config, generate};
@@ -131,5 +161,23 @@ mod tests {
         assert_eq!(vertices.len(), 6);
         assert!(close(bounds_min[0], 0.0) && close(bounds_min[1], 0.0));
         assert!(close(bounds_max[0], 2.0) && close(bounds_max[1], 1.0));
+    }
+
+    #[test]
+    fn viewport_transform_fits_and_centers_bounds() {
+        let t = viewport_transform([1.0, 0.0], [5.0, 4.0], 200, 200, [0.0, 0.0], 1.0);
+        assert!(close(3.0 * t.scale[0] + t.offset[0], 0.0));
+        assert!(close(2.0 * t.scale[1] + t.offset[1], 0.0));
+        assert!(close(4.0 * t.scale[0], 1.8));
+        assert!(close(4.0 * t.scale[1], 1.8));
+    }
+
+    #[test]
+    fn viewport_transform_keeps_degenerate_bounds_finite() {
+        let t = viewport_transform([5.0, 3.0], [5.0, 3.0], 100, 100, [0.0, 0.0], 1.0);
+        assert!(t.scale[0].is_finite() && t.scale[0] > 0.0);
+        assert!(t.scale[1].is_finite() && t.scale[1] > 0.0);
+        assert!(close(5.0 * t.scale[0] + t.offset[0], 0.0));
+        assert!(close(3.0 * t.scale[1] + t.offset[1], 0.0));
     }
 }

--- a/crates/lsystem-renderer/src/png_export.rs
+++ b/crates/lsystem-renderer/src/png_export.rs
@@ -1,0 +1,331 @@
+use std::error::Error;
+use std::fmt::{Display, Formatter};
+
+use futures_channel::oneshot;
+use lsystem_core::Config;
+
+use crate::line_renderer::LinePipeline;
+use crate::lsystem_bridge::{color_params_from_config, geometry_to_vertices, viewport_transform};
+
+const FORMAT: wgpu::TextureFormat = wgpu::TextureFormat::Rgba8UnormSrgb;
+const MIN_WIDTH: u32 = 256;
+const MAX_DIMENSION: u32 = 4096;
+const BYTES_PER_PIXEL: u32 = 4;
+
+pub struct PngExport {
+    pub width: u32,
+    pub height: u32,
+    pub bytes: Vec<u8>,
+}
+
+#[derive(Debug)]
+pub enum PngExportError {
+    InvalidWidth(u32),
+    InvalidHeight(u32),
+    Map(wgpu::BufferAsyncError),
+    MapChannelClosed,
+    Poll(wgpu::PollError),
+    Png(png::EncodingError),
+}
+
+impl Display for PngExportError {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::InvalidWidth(width) => {
+                write!(
+                    f,
+                    "PNG width must be in {MIN_WIDTH}..={MAX_DIMENSION}, got {width}"
+                )
+            }
+            Self::InvalidHeight(height) => {
+                write!(
+                    f,
+                    "derived PNG height must be in 1..={MAX_DIMENSION}, got {height}"
+                )
+            }
+            Self::Map(err) => write!(f, "failed to map PNG readback buffer: {err}"),
+            Self::MapChannelClosed => write!(f, "PNG readback callback was dropped"),
+            Self::Poll(err) => write!(f, "failed to poll GPU device for PNG readback: {err}"),
+            Self::Png(err) => write!(f, "failed to encode PNG: {err}"),
+        }
+    }
+}
+
+impl Error for PngExportError {}
+
+pub async fn render_png(
+    device: &wgpu::Device,
+    queue: &wgpu::Queue,
+    config: &Config,
+    width: u32,
+) -> Result<PngExport, PngExportError> {
+    validate_width(width)?;
+
+    let data = geometry_to_vertices(lsystem_core::generate(config));
+    let height = derive_height(width, data.bounds_min, data.bounds_max)?;
+    let extent = wgpu::Extent3d {
+        width,
+        height,
+        depth_or_array_layers: 1,
+    };
+
+    let texture = device.create_texture(&wgpu::TextureDescriptor {
+        label: Some("png_export_texture"),
+        size: extent,
+        mip_level_count: 1,
+        sample_count: 1,
+        dimension: wgpu::TextureDimension::D2,
+        format: FORMAT,
+        usage: wgpu::TextureUsages::RENDER_ATTACHMENT | wgpu::TextureUsages::COPY_SRC,
+        view_formats: &[],
+    });
+    let view = texture.create_view(&Default::default());
+
+    let total_segments = (data.vertices.len() / 2) as u32;
+    let color_params = color_params_from_config(&config.colors.line, total_segments);
+    let mut pipeline = LinePipeline::new(device, FORMAT);
+    pipeline.upload(device, queue, &data.vertices, color_params);
+    pipeline.write_transform(
+        queue,
+        viewport_transform(
+            data.bounds_min,
+            data.bounds_max,
+            width,
+            height,
+            [0.0, 0.0],
+            1.0,
+        ),
+    );
+
+    let readback_layout = ReadbackLayout::new(width, height);
+    let readback = device.create_buffer(&wgpu::BufferDescriptor {
+        label: Some("png_export_readback"),
+        size: readback_layout.buffer_size(),
+        usage: wgpu::BufferUsages::COPY_DST | wgpu::BufferUsages::MAP_READ,
+        mapped_at_creation: false,
+    });
+
+    let mut encoder = device.create_command_encoder(&wgpu::CommandEncoderDescriptor {
+        label: Some("png_export_encoder"),
+    });
+    {
+        let [r, g, b] = config.colors.background;
+        let mut pass = encoder
+            .begin_render_pass(&wgpu::RenderPassDescriptor {
+                label: Some("png_export_pass"),
+                color_attachments: &[Some(wgpu::RenderPassColorAttachment {
+                    view: &view,
+                    resolve_target: None,
+                    depth_slice: None,
+                    ops: wgpu::Operations {
+                        load: wgpu::LoadOp::Clear(wgpu::Color {
+                            r: r as f64,
+                            g: g as f64,
+                            b: b as f64,
+                            a: 1.0,
+                        }),
+                        store: wgpu::StoreOp::Store,
+                    },
+                })],
+                depth_stencil_attachment: None,
+                occlusion_query_set: None,
+                timestamp_writes: None,
+                multiview_mask: None,
+            })
+            .forget_lifetime();
+        pipeline.draw(&mut pass);
+    }
+    encoder.copy_texture_to_buffer(
+        texture.as_image_copy(),
+        wgpu::TexelCopyBufferInfo {
+            buffer: &readback,
+            layout: wgpu::TexelCopyBufferLayout {
+                offset: 0,
+                bytes_per_row: Some(readback_layout.padded_bytes_per_row),
+                rows_per_image: None,
+            },
+        },
+        extent,
+    );
+
+    queue.submit([encoder.finish()]);
+
+    let (sender, receiver) = oneshot::channel();
+    readback
+        .slice(..)
+        .map_async(wgpu::MapMode::Read, move |result| {
+            let _ = sender.send(result);
+        });
+    // Native needs polling to drive the map_async callback. On browser WebGPU this is a no-op;
+    // callback completion is driven by the browser event loop.
+    device
+        .poll(wgpu::PollType::Wait {
+            submission_index: None,
+            timeout: None,
+        })
+        .map_err(PngExportError::Poll)?;
+
+    receiver
+        .await
+        .map_err(|_| PngExportError::MapChannelClosed)?
+        .map_err(PngExportError::Map)?;
+    let rgba = {
+        let mapped = readback.slice(..).get_mapped_range();
+        readback_layout.strip_padding(&mapped)
+    };
+    readback.unmap();
+
+    let bytes = encode_png_rgba(width, height, &rgba)?;
+    Ok(PngExport {
+        width,
+        height,
+        bytes,
+    })
+}
+
+fn validate_width(width: u32) -> Result<(), PngExportError> {
+    if (MIN_WIDTH..=MAX_DIMENSION).contains(&width) {
+        Ok(())
+    } else {
+        Err(PngExportError::InvalidWidth(width))
+    }
+}
+
+fn derive_height(
+    width: u32,
+    bounds_min: [f32; 2],
+    bounds_max: [f32; 2],
+) -> Result<u32, PngExportError> {
+    let geom_w = (bounds_max[0] - bounds_min[0]).max(1.0);
+    let geom_h = (bounds_max[1] - bounds_min[1]).max(1.0);
+    let height = (width as f32 * geom_h / geom_w).ceil();
+    if !height.is_finite() {
+        return Err(PngExportError::InvalidHeight(0));
+    }
+    let height = height as u32;
+    if (1..=MAX_DIMENSION).contains(&height) {
+        Ok(height)
+    } else {
+        Err(PngExportError::InvalidHeight(height))
+    }
+}
+
+#[derive(Copy, Clone)]
+struct ReadbackLayout {
+    height: u32,
+    unpadded_bytes_per_row: u32,
+    padded_bytes_per_row: u32,
+}
+
+impl ReadbackLayout {
+    fn new(width: u32, height: u32) -> Self {
+        let unpadded_bytes_per_row = width * BYTES_PER_PIXEL;
+        Self {
+            height,
+            unpadded_bytes_per_row,
+            padded_bytes_per_row: wgpu::util::align_to(
+                unpadded_bytes_per_row,
+                wgpu::COPY_BYTES_PER_ROW_ALIGNMENT,
+            ),
+        }
+    }
+
+    fn buffer_size(self) -> u64 {
+        (self.padded_bytes_per_row * self.height) as u64
+    }
+
+    fn strip_padding(self, padded: &[u8]) -> Vec<u8> {
+        let unpadded_bytes_per_row = self.unpadded_bytes_per_row as usize;
+        let mut rgba = Vec::with_capacity(unpadded_bytes_per_row * self.height as usize);
+        for row in padded
+            .chunks(self.padded_bytes_per_row as usize)
+            .take(self.height as usize)
+        {
+            rgba.extend_from_slice(&row[..unpadded_bytes_per_row]);
+        }
+        rgba
+    }
+}
+
+fn encode_png_rgba(width: u32, height: u32, rgba: &[u8]) -> Result<Vec<u8>, PngExportError> {
+    let mut bytes = Vec::new();
+    {
+        let mut encoder = png::Encoder::new(&mut bytes, width, height);
+        encoder.set_color(png::ColorType::Rgba);
+        encoder.set_depth(png::BitDepth::Eight);
+        let mut writer = encoder.write_header().map_err(PngExportError::Png)?;
+        writer.write_image_data(rgba).map_err(PngExportError::Png)?;
+    }
+    Ok(bytes)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn validates_export_width() {
+        assert!(matches!(
+            validate_width(MIN_WIDTH - 1),
+            Err(PngExportError::InvalidWidth(width)) if width == MIN_WIDTH - 1
+        ));
+        assert!(validate_width(MIN_WIDTH).is_ok());
+        assert!(validate_width(MAX_DIMENSION).is_ok());
+        assert!(matches!(
+            validate_width(MAX_DIMENSION + 1),
+            Err(PngExportError::InvalidWidth(width)) if width == MAX_DIMENSION + 1
+        ));
+    }
+
+    #[test]
+    fn derives_height_from_bounds_with_degenerate_dimensions() {
+        assert_eq!(derive_height(1024, [0.0, 0.0], [2.0, 1.0]).unwrap(), 512);
+        assert_eq!(derive_height(1024, [0.0, 0.0], [10.0, 0.0]).unwrap(), 103);
+        assert_eq!(derive_height(1024, [0.0, 0.0], [0.0, 4.0]).unwrap(), 4096);
+        assert!(matches!(
+            derive_height(1024, [0.0, 0.0], [0.0, 5.0]),
+            Err(PngExportError::InvalidHeight(5120))
+        ));
+    }
+
+    #[test]
+    fn strips_aligned_row_padding() {
+        let width = 64;
+        let height = 2;
+        let row_len = width * BYTES_PER_PIXEL;
+        assert_eq!(row_len, wgpu::COPY_BYTES_PER_ROW_ALIGNMENT);
+        let padded: Vec<_> = (0..row_len * height).map(|i| i as u8).collect();
+        let stripped = ReadbackLayout::new(width, height).strip_padding(&padded);
+        assert_eq!(stripped, padded);
+    }
+
+    #[test]
+    fn strips_unaligned_row_padding() {
+        let width = 3;
+        let height = 2;
+        let padded_row_len = 16;
+        let padded = [
+            1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 99, 99, 99, 99, 13, 14, 15, 16, 17, 18, 19, 20,
+            21, 22, 23, 24, 88, 88, 88, 88,
+        ];
+        let mut layout = ReadbackLayout::new(width, height);
+        layout.padded_bytes_per_row = padded_row_len;
+        let stripped = layout.strip_padding(&padded);
+        assert_eq!(
+            stripped,
+            vec![
+                1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23,
+                24,
+            ]
+        );
+    }
+
+    #[test]
+    fn encodes_png_signature_and_ihdr_dimensions() {
+        let rgba = vec![0, 0, 0, 255, 255, 255, 255, 255];
+        let png = encode_png_rgba(2, 1, &rgba).unwrap();
+        assert_eq!(&png[..8], b"\x89PNG\r\n\x1a\n");
+        assert_eq!(&png[16..20], &2u32.to_be_bytes());
+        assert_eq!(&png[20..24], &1u32.to_be_bytes());
+    }
+}


### PR DESCRIPTION
## Summary
- Adds renderer-backed PNG export using an offscreen wgpu render target and PNG encoding.
- Shares viewport fit and transform logic between app camera and export rendering.
- Moves export request handling out of UI drawing so SVG and PNG exports share platform-specific save and download paths.

## Dependencies
- Enables optional png support in lsystem-renderer with png and futures-channel dependencies.