### PR TITLE
Simplify fractal presets

### DIFF
--- a/crates/lsystem-app/src/ui.rs
+++ b/crates/lsystem-app/src/ui.rs
@@ -75,7 +75,6 @@ pub struct UiState {
     pub iterations: u32,
     pub max_iterations: u32,
     pub angle: f32,
-    pub step: f32,
     pub png_width: u32,
     pub error: Option<String>,
     /// Set to true when geometry needs regenerating.
@@ -98,7 +97,6 @@ impl UiState {
             iterations: 4,
             max_iterations: 10,
             angle: 60.0,
-            step: 1.0,
             png_width: 2048,
             error: None,
             dirty: true,
@@ -118,7 +116,6 @@ impl UiState {
                 .max(1);
                 self.iterations = cfg.iterations.min(self.max_iterations);
                 self.angle = cfg.angle;
-                self.step = cfg.step;
                 self.base_config = Some(cfg);
                 self.error = None;
                 self.dirty = true;
@@ -133,7 +130,6 @@ impl UiState {
         self.base_config.clone().map(|mut c| {
             c.iterations = self.iterations;
             c.angle = self.angle;
-            c.step = self.step;
             c
         })
     }
@@ -232,16 +228,6 @@ impl UiState {
                             .step_by(0.5),
                     );
                     if self.angle != prev_angle {
-                        self.dirty = true;
-                    }
-
-                    let prev_step = self.step;
-                    ui.add(
-                        egui::Slider::new(&mut self.step, 0.1..=10.0)
-                            .text("Step")
-                            .step_by(0.1),
-                    );
-                    if self.step != prev_step {
                         self.dirty = true;
                     }
 

--- a/crates/lsystem-core/src/config.rs
+++ b/crates/lsystem-core/src/config.rs
@@ -175,6 +175,7 @@ struct RawConfig {
     axiom: String,
     iterations: u32,
     angle: f32,
+    #[serde(default = "default_step")]
     step: f32,
     #[serde(default)]
     initial_heading: f32,
@@ -211,6 +212,10 @@ fn default_dimensions() -> u8 {
     2
 }
 
+fn default_step() -> f32 {
+    1.0
+}
+
 fn default_line_color() -> [f32; 3] {
     [0.0, 0.9, 0.5]
 }
@@ -226,6 +231,7 @@ fn default_value() -> f32 {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use std::path::Path;
 
     const KOCH_TOML: &str = r#"
 name = "Koch Snowflake"
@@ -244,8 +250,40 @@ F = "F-F++F-F"
         let cfg = Config::parse(KOCH_TOML).unwrap();
         assert_eq!(cfg.axiom, "F++F++F");
         assert_eq!(cfg.angle, 60.0);
+        assert_eq!(cfg.step, 1.0);
         assert_eq!(cfg.iterations, 4);
         assert_eq!(cfg.rules[&'F'], "F-F++F-F");
+    }
+
+    #[test]
+    fn defaults_missing_step() {
+        let toml = r#"
+name = "test"
+axiom = "F"
+iterations = 1
+angle = 90.0
+"#;
+        let cfg = Config::parse(toml).unwrap();
+        assert_eq!(cfg.step, 1.0);
+    }
+
+    #[test]
+    fn bundled_presets_are_parseable() {
+        let presets_dir = Path::new(env!("CARGO_MANIFEST_DIR")).join("../../presets");
+        let mut preset_paths: Vec<_> = std::fs::read_dir(&presets_dir)
+            .unwrap_or_else(|err| panic!("failed to read {}: {err}", presets_dir.display()))
+            .map(|entry| entry.expect("failed to read preset dir entry").path())
+            .filter(|path| path.extension().and_then(|ext| ext.to_str()) == Some("toml"))
+            .collect();
+        preset_paths.sort();
+
+        assert!(!preset_paths.is_empty(), "no preset TOML files found");
+        for path in preset_paths {
+            let toml = std::fs::read_to_string(&path)
+                .unwrap_or_else(|err| panic!("failed to read {}: {err}", path.display()));
+            Config::parse(&toml)
+                .unwrap_or_else(|err| panic!("failed to parse {}: {err}", path.display()));
+        }
     }
 
     #[test]

--- a/crates/lsystem-web-app/src/app.rs
+++ b/crates/lsystem-web-app/src/app.rs
@@ -29,7 +29,6 @@ pub(crate) fn App() -> impl IntoView {
         signal(initial.config.iterations.min(initial.max_iterations));
     let (max_iterations, set_max_iterations) = signal(initial.max_iterations.max(1));
     let (angle, set_angle) = signal(initial.config.angle);
-    let (step, set_step) = signal(initial.config.step);
     let (png_width, set_png_width) = signal(2048u32);
     let (unsupported, set_unsupported) = signal(false);
 
@@ -43,8 +42,7 @@ pub(crate) fn App() -> impl IntoView {
             let Some(canvas) = canvas_ref.get() else {
                 return;
             };
-            let Some(config) =
-                effective_config(base_config.get(), iterations.get(), angle.get(), step.get())
+            let Some(config) = effective_config(base_config.get(), iterations.get(), angle.get())
             else {
                 return;
             };
@@ -81,7 +79,6 @@ pub(crate) fn App() -> impl IntoView {
                 set_max_iterations.set(max);
                 set_iterations.set(applied.config.iterations.min(max));
                 set_angle.set(applied.config.angle);
-                set_step.set(applied.config.step);
                 set_base_config.set(Some(applied.config));
                 set_error.set(None);
                 render_current();
@@ -192,27 +189,6 @@ pub(crate) fn App() -> impl IntoView {
                         <output>{move || format!("{:.1}", angle.get())}</output>
                     </div>
 
-                    <label for="step">"Step"</label>
-                    <div class="row">
-                        <input
-                            id="step"
-                            type="range"
-                            min="0.1"
-                            max="10"
-                            step="0.1"
-                            prop:value=move || step.get().to_string()
-                            on:input={
-                                let render_current = Rc::clone(&render_current);
-                                move |ev| {
-                                    let next = input_value(ev).parse::<f32>().unwrap_or(1.0);
-                                    set_step.set(next.clamp(0.1, 10.0));
-                                    render_current();
-                                }
-                            }
-                        />
-                        <output>{move || format!("{:.1}", step.get())}</output>
-                    </div>
-
                     <label for="png-width">"PNG width"</label>
                     <input
                         id="png-width"
@@ -228,7 +204,7 @@ pub(crate) fn App() -> impl IntoView {
                     />
 
                     <div class="export-row">
-                        <button type="button" on:click=move |_| export_svg(base_config.get(), iterations.get(), angle.get(), step.get())>
+                        <button type="button" on:click=move |_| export_svg(base_config.get(), iterations.get(), angle.get())>
                             "Export SVG"
                         </button>
                         <button
@@ -241,7 +217,6 @@ pub(crate) fn App() -> impl IntoView {
                                         base_config.get(),
                                         iterations.get(),
                                         angle.get(),
-                                        step.get(),
                                         png_width.get(),
                                     );
                                 }

--- a/crates/lsystem-web-app/src/export.rs
+++ b/crates/lsystem-web-app/src/export.rs
@@ -7,8 +7,8 @@ use wasm_bindgen::JsCast;
 use crate::presets::effective_config;
 use crate::renderer::CanvasRenderer;
 
-pub(crate) fn export_svg(config: Option<Config>, iterations: u32, angle: f32, step: f32) {
-    let Some(config) = effective_config(config, iterations, angle, step) else {
+pub(crate) fn export_svg(config: Option<Config>, iterations: u32, angle: f32) {
+    let Some(config) = effective_config(config, iterations, angle) else {
         return;
     };
     let filename = sanitize_filename(&config.name, "svg");
@@ -27,10 +27,9 @@ pub(crate) fn export_png(
     config: Option<Config>,
     iterations: u32,
     angle: f32,
-    step: f32,
     width: u32,
 ) {
-    let Some(config) = effective_config(config, iterations, angle, step) else {
+    let Some(config) = effective_config(config, iterations, angle) else {
         return;
     };
     let Some((device, queue)) = renderer

--- a/crates/lsystem-web-app/src/presets.rs
+++ b/crates/lsystem-web-app/src/presets.rs
@@ -41,12 +41,10 @@ pub(crate) fn effective_config(
     config: Option<Config>,
     iterations: u32,
     angle: f32,
-    step: f32,
 ) -> Option<Config> {
     config.map(|mut config| {
         config.iterations = iterations;
         config.angle = angle;
-        config.step = step;
         config
     })
 }

--- a/presets/dragon_curve.toml
+++ b/presets/dragon_curve.toml
@@ -3,14 +3,9 @@ dimensions = 2
 axiom = "FX"
 iterations = 16
 angle = 90.0
-step = 1.0
-initial_heading = 0.0
 
 [line_color]
 mode = "hue_cycle"
-start_hue = 0.0
-saturation = 1.0
-value = 0.9
 
 [rules]
 X = "X+YF+"

--- a/presets/gosper_curve.toml
+++ b/presets/gosper_curve.toml
@@ -3,14 +3,9 @@ dimensions = 2
 axiom = "XF"
 iterations = 4
 angle = 60.0
-step = 1.0
-initial_heading = 0.0
 
 [line_color]
 mode = "hue_cycle"
-start_hue = 0.0
-saturation = 1.0
-value = 0.9
 
 [rules]
 X = "X+YF++YF-FX--FXFX-YF+"

--- a/presets/hilbert_curve.toml
+++ b/presets/hilbert_curve.toml
@@ -3,14 +3,9 @@ dimensions = 2
 axiom = "A"
 iterations = 5
 angle = 90.0
-step = 1.0
-initial_heading = 0.0
 
 [line_color]
 mode = "hue_cycle"
-start_hue = 0.0
-saturation = 1.0
-value = 0.9
 
 [rules]
 A = "-BF+AFA+FB-"

--- a/presets/koch_snowflake.toml
+++ b/presets/koch_snowflake.toml
@@ -3,14 +3,9 @@ dimensions = 2
 axiom = "F++F++F"
 iterations = 6
 angle = 60.0
-step = 1.0
-initial_heading = 0.0
 
 [line_color]
 mode = "hue_cycle"
-start_hue = 180.0
-saturation = 1.0
-value = 0.9
 
 [rules]
 F = "F-F++F-F"

--- a/presets/peano_curve.toml
+++ b/presets/peano_curve.toml
@@ -3,14 +3,9 @@ dimensions = 2
 axiom = "L"
 iterations = 4
 angle = 90.0
-step = 1.0
-initial_heading = 0
 
 [line_color]
 mode = "hue_cycle"
-start_hue = 0.0
-saturation = 1.0
-value = 0.9
 
 [rules]
 L = "LFRFL-F-RFLFR+F+LFRFL"

--- a/presets/plant_a.toml
+++ b/presets/plant_a.toml
@@ -3,7 +3,6 @@ dimensions = 2
 axiom = "X"
 iterations = 7
 angle = 25.0
-step = 1.0
 initial_heading = 90.0
 
 [line_color]

--- a/presets/sierpinski_curve.toml
+++ b/presets/sierpinski_curve.toml
@@ -3,14 +3,9 @@ dimensions = 2
 axiom = "F+XF+F+XF"
 iterations = 5
 angle = 90.0
-step = 1.0
-initial_heading = 0.0
 
 [line_color]
 mode = "hue_cycle"
-start_hue = 0.0
-saturation = 1.0
-value = 0.9
 
 [rules]
 X = "XF-F+F-XF+F+XF-F+F-X"

--- a/presets/sierpinski_triangle.toml
+++ b/presets/sierpinski_triangle.toml
@@ -3,14 +3,9 @@ dimensions = 2
 axiom = "FXF-FF-FF"
 iterations = 9
 angle = 120.0
-step = 1.0
-initial_heading = 0.0
 
 [line_color]
 mode = "hue_cycle"
-start_hue = 0.0
-saturation = 1.0
-value = 0.9
 
 [rules]
 F = "FF"

--- a/presets/snowflake.toml
+++ b/presets/snowflake.toml
@@ -3,14 +3,6 @@ dimensions = 2
 axiom = "[F]+[F]+[F]+[F]+[F]+[F]"
 iterations = 4
 angle = 60.0
-step = 1.0
-initial_heading = 0.0
-
-[line_color]
-mode = "hue_cycle"
-start_hue = 180.0
-saturation = 1.0
-value = 0.9
 
 [rules]
 F = "F[+FF][-FF]FF[+F][-F]FF"


### PR DESCRIPTION
## Summary
- Default omitted L-system step values to 1.0 during config parsing.
- Remove the step override controls from the native and browser UIs so step stays TOML-driven.
- Trim bundled preset TOML by relying on parser defaults for step, zero initial heading, and default line-color fields.
- Add coverage that parses every bundled preset so invalid preset TOML is caught directly.

## Notes
- The public Config.step field remains a concrete f32 after parsing.
- Presets can still opt into non-default values explicitly, such as Plant A's initial heading and gradient colors.