### PR TITLE
Deploy both web apps

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -32,10 +32,14 @@ jobs:
           targets: wasm32-unknown-unknown
       - uses: Swatinem/rust-cache@v2
       - uses: jdx/mise-action@v3
+      - run: mkdir -p pages/iced
       - run: trunk build --release --public-url /${{ github.event.repository.name }}/ --config crates/lsystem-web-app/Trunk.toml
+      - run: cp -R crates/lsystem-web-app/dist/. pages/
+      - run: trunk build --release --public-url /${{ github.event.repository.name }}/iced/ --config crates/lsystem-app/Trunk.toml
+      - run: cp -R crates/lsystem-app/dist/. pages/iced/
       - uses: actions/configure-pages@v6
       - uses: actions/upload-pages-artifact@v5
         with:
-          path: crates/lsystem-web-app/dist
+          path: pages
       - id: deployment
         uses: actions/deploy-pages@v5


### PR DESCRIPTION
## Summary
- Build both browser apps during the GitHub Pages deploy job.
- Keep the Leptos app at the repository Pages root.
- Publish the Iced app under the /iced/ subpath.

## Details
- Stage both Trunk outputs into a single pages artifact because GitHub Pages deploys one artifact per repository.
- Set each Trunk public URL to match its final hosted path so generated wasm and JS asset URLs resolve correctly.