### PR TITLE
Add WebGL fallback for wasm

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -4,7 +4,7 @@ This file provides guidance to AI coding agents when working with code in this r
 
 ## Project Overview
 
-**Grow Your Own Fractal** — an interactive L-System (Lindenmayer system) visualizer in Rust. The browser-first app (`lsystem-web-app`) uses Leptos/DOM controls with a WebGPU canvas backed by the toolkit-independent `lsystem-renderer` crate. The `lsystem-app` crate uses Iced for native desktop and retained wasm builds; its fractal viewport is an `iced::widget::shader` custom primitive backed by the shared wgpu line pipeline.
+**Grow Your Own Fractal** — an interactive L-System (Lindenmayer system) visualizer in Rust. The browser-first app (`lsystem-web-app`) uses Leptos/DOM controls with a wgpu canvas that uses WebGPU with a WebGL2 fallback on browser wasm targets, backed by the toolkit-independent `lsystem-renderer` crate. The `lsystem-app` crate uses Iced for native desktop and retained wasm builds; its fractal viewport is an `iced::widget::shader` custom primitive backed by the shared wgpu line pipeline.
 
 ## Common Commands
 
@@ -70,7 +70,7 @@ Depends on `lsystem-core` and `wgpu`.
 | `line_renderer.rs` | `Transform` — scale + offset GPU uniform type. `GpuContext` — owns the wgpu surface for non-Iced canvas users; `begin_frame` returns explicit `FrameOutcome` values and `end_frame` submits + presents. `GpuInitError` preserves surface/adapter/device initialization failures. `LinePipeline` (pipeline, bind group, reusable vertex buffer, transform uniform, color-params uniform) — `upload()` grows/reuses the vertex buffer and writes `ColorParams`; `write_transform()` writes the camera transform every frame; `draw()` issues the line-list draw. |
 | `lsystem_bridge.rs` | L-system→GPU adapters. `geometry_to_vertices()` accepts `impl Iterator<Item = [Vec2; 2]>` and produces a flat `Vertex` array with bounding box (`VertexData`). `color_params_from_config()` maps `LineColorConfig` to the `ColorParams` GPU uniform. |
 | `png_export.rs` | Offscreen wgpu PNG renderer; gated behind the `png` Cargo feature |
-| `wgpu_util.rs` | Shared wgpu instance/device descriptor and uncaptured-error logging helpers |
+| `wgpu_util.rs` | Shared wgpu instance/device descriptor and uncaptured-error logging helpers; browser wasm creates an instance with a web display handle so wgpu can use WebGPU or fall back to WebGL2, while native and Emscripten use the normal non-web instance path |
 | `shader.wgsl` | Vertex shader applies a `Transform` uniform (scale + offset) and computes per-segment color from a `ColorParams` uniform using `vertex_index / 2`; supports solid, gradient, and HSV hue-cycle modes; fragment shader passes the interpolated color through; topology is `LineList` |
 
 ### `lsystem-app` — entry points and Iced UI
@@ -94,10 +94,10 @@ Depends on `lsystem-core`, `lsystem-renderer`, `leptos`, and browser `web-sys`/`
 | File | Role |
 |------|------|
 | `lib.rs` | Leptos CSR entry point |
-| `app.rs` | DOM controls for presets, TOML, overrides, viewport input, export buttons, and WebGPU error display |
+| `app.rs` | DOM controls for presets, TOML, overrides, viewport input, export buttons, and GPU rendering error display |
 | `presets.rs` | Embedded preset loading and effective-config helpers |
 | `export.rs` | Browser SVG/PNG download helpers |
-| `renderer.rs` | `CanvasRenderer` — owns the WebGPU canvas `GpuContext`, `LinePipeline`, shared `Camera`, current vertices, color params, and background; handles canvas resize, pan, zoom, reset, event-driven rendering, and web surface-loss recovery |
+| `renderer.rs` | `CanvasRenderer` — owns the canvas `GpuContext`, `LinePipeline`, shared `Camera`, current vertices, color params, and background; handles canvas resize, pan, zoom, reset, event-driven rendering, and web surface-loss recovery |
 | `index.html` | Trunk entry that mounts the Leptos app |
 | `Trunk.toml` | Browser app build config, served locally on `127.0.0.1:8081` |
 
@@ -117,7 +117,7 @@ Bundled TOML L-System definitions. New fractals are added here; they are embedde
 - **Async scene generation**: `FractalApp` schedules geometry generation with `Task::perform` when presets, TOML, iterations, or angle change. Each request gets a monotonic generation token; stale results are ignored, so rapid slider changes do not block the UI with outdated work.
 - **Scene-revision uploads**: `FractalApp::schedule_scene_generation()` increments a monotonic generation token whenever geometry is requested. Completed scene builds store that token as `Scene::revision`; the Iced shader pipeline uploads vertices and color params only when the observed revision changes, while camera transforms are written during prepare.
 - **Reusable vertex buffer**: `LinePipeline::upload` grows the GPU vertex buffer to the next power-of-two capacity when needed and otherwise updates it with `Queue::write_buffer`, avoiding a new buffer allocation on every geometry upload.
-- **DOM browser UI with GPU canvas**: `lsystem-web-app` owns browser UI state in Leptos signals and renders the fractal into a dedicated `<canvas>`. It creates a WebGPU surface from `web_sys::HtmlCanvasElement`, reuses `LinePipeline`, and drives rendering from explicit DOM events instead of a continuous repaint loop.
+- **DOM browser UI with GPU canvas**: `lsystem-web-app` owns browser UI state in Leptos signals and renders the fractal into a dedicated `<canvas>`. It creates a wgpu surface from `web_sys::HtmlCanvasElement`, reuses `LinePipeline`, and drives rendering from explicit DOM events instead of a continuous repaint loop. On browser wasm targets, `wgpu_util` creates the instance with a web display handle and WebGPU detection so wgpu can use WebGPU when available and fall back to WebGL2 otherwise.
 - **Surface acquisition recovery**: `GpuContext::begin_frame` retries `CurrentSurfaceTexture::Outdated` once after reconfiguring the surface. Timeout and occlusion are quiet skip reasons, validation/repeated-outdated are explicit skip reasons, and true surface loss is reported to callers. The Leptos web renderer rebuilds `GpuContext` and `LinePipeline` after surface loss while preserving CPU-side scene/camera/color state and marking geometry for reupload.
 - **SVG export is a `lsystem-core` Cargo feature**: The `svg` feature adds `svg_export::export_svg(config) -> String`. It collects segments into a `Vec` (the only allocation — acceptable for export), computes a padded bounding box, and builds SVG XML. The Y-axis flip (turtle is Y-up, SVG is Y-down) is handled by a `<g transform="matrix(1 0 0 -1 0 0)">` group so turtle coordinates are written as-is; the viewBox compensates. `stroke-width`, `stroke-linecap`, and `fill` are set on the `<g>` and inherited by children. Solid mode emits a single `<path>`; gradient and hue-cycle modes emit per-segment `<line>` elements to match the shader's segment-index-based coloring exactly. On native, `rfd::FileDialog` handles the save dialog; on WASM, a programmatic Blob download is triggered via `web-sys`.
 - **Strict CI**: `clippy -D warnings` and `cargo fmt --check` must pass. CI tests the workspace with all features/all targets, checks and lints native default/all-features builds, checks and lints `wasm32-unknown-unknown` default/all-features builds, and builds both Trunk web apps. GitHub Pages deploys the Leptos browser app.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4719,6 +4719,7 @@ dependencies = [
  "thiserror 2.0.18",
  "wgpu-core-deps-apple",
  "wgpu-core-deps-emscripten",
+ "wgpu-core-deps-wasm",
  "wgpu-core-deps-windows-linux-android",
  "wgpu-hal",
  "wgpu-naga-bridge",
@@ -4739,6 +4740,15 @@ name = "wgpu-core-deps-emscripten"
 version = "29.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3487cd6293a963bc5c0c0396f6a2192043c50003c07f4efdccbad3d90ec9d819"
+dependencies = [
+ "wgpu-hal",
+]
+
+[[package]]
+name = "wgpu-core-deps-wasm"
+version = "29.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0c2f2fb042f36920771deb0b966543c5751b18f3d327760ffc90f74e20b2dcd4"
 dependencies = [
  "wgpu-hal",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,4 +23,4 @@ lsystem-renderer = { path = "crates/lsystem-renderer" }
 wasm-bindgen = "0.2"
 wasm-bindgen-futures = "0.4"
 web-sys = "0.3"
-wgpu = "29"
+wgpu = { version = "29", features = ["webgl"] }

--- a/README.md
+++ b/README.md
@@ -1,9 +1,10 @@
 # Grow Your Own Fractal
 
 An interactive [L-System](https://en.wikipedia.org/wiki/L-system) (Lindenmayer
-system) visualizer built with Rust, WebGPU, and WebAssembly. The workspace
+system) visualizer built with Rust, wgpu, and WebAssembly. The workspace
 includes an Iced native/wasm app and a browser-first Leptos app with DOM
-controls and a WebGPU canvas.
+controls and a GPU canvas that uses WebGPU with a WebGL2 fallback on browser
+wasm targets.
 
 ---
 
@@ -130,7 +131,7 @@ using the selected PNG width.
 |------|---------|
 | [Rust](https://rustup.rs/) stable | compiler (version pinned in `rust-toolchain.toml`) |
 | [mise](https://mise.jdx.dev/) | installs pinned tools — trunk (version pinned in `mise.toml`) |
-| Chrome ≥ 113 / Edge | WebGPU support in the browser |
+| Modern browser | WebGPU support, or WebGL2 for the fallback renderer |
 
 ```sh
 mise install   # installs trunk at the version pinned in mise.toml
@@ -212,13 +213,13 @@ crates/
       ui/controls.rs        Iced controls and side panel layout
       ui/fractal_canvas.rs  Iced shader widget integration and viewport input handling
       export.rs             native/browser SVG and PNG export helpers
-  lsystem-web-app/          browser-first Leptos app with DOM controls and a WebGPU canvas
+  lsystem-web-app/          browser-first Leptos app with DOM controls and a GPU canvas
     src/
       lib.rs                wasm entry point
-      app.rs                Leptos app, DOM controls, viewport input, WebGPU error display
+      app.rs                Leptos app, DOM controls, viewport input, GPU error display
       presets.rs            embedded preset loading and effective-config helpers
       export.rs             browser SVG/PNG download helpers
-      renderer.rs           canvas-owned WebGPU renderer using lsystem-renderer, including surface recovery
+      renderer.rs           canvas-owned wgpu renderer using lsystem-renderer, including surface recovery
 
 crates/lsystem-app/index.html         Iced web Trunk entry
 crates/lsystem-app/Trunk.toml         Iced web Trunk config

--- a/crates/lsystem-app/Cargo.toml
+++ b/crates/lsystem-app/Cargo.toml
@@ -20,7 +20,7 @@ env_logger = "0.11"
 rfd = "0.17"
 
 [target.'cfg(target_arch = "wasm32")'.dependencies]
-iced = { workspace = true, features = ["advanced", "wgpu", "web-colors", "fira-sans", "crisp"] }
+iced = { workspace = true, features = ["advanced", "wgpu", "webgl", "web-colors", "fira-sans", "crisp"] }
 console_error_panic_hook.workspace = true
 console_log.workspace = true
 js-sys.workspace = true

--- a/crates/lsystem-renderer/src/line_renderer.rs
+++ b/crates/lsystem-renderer/src/line_renderer.rs
@@ -255,10 +255,10 @@ pub enum GpuInitError {
 impl Display for GpuInitError {
     fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
         match self {
-            Self::CreateSurface(err) => write!(f, "failed to create WebGPU surface: {err}"),
-            Self::RequestAdapter(err) => write!(f, "failed to request WebGPU adapter: {err}"),
-            Self::RequestDevice(err) => write!(f, "failed to request WebGPU device: {err}"),
-            Self::NoSurfaceConfig => write!(f, "WebGPU surface has no supported texture formats"),
+            Self::CreateSurface(err) => write!(f, "failed to create GPU surface: {err}"),
+            Self::RequestAdapter(err) => write!(f, "failed to request GPU adapter: {err}"),
+            Self::RequestDevice(err) => write!(f, "failed to request GPU device: {err}"),
+            Self::NoSurfaceConfig => write!(f, "GPU surface has no supported texture formats"),
         }
     }
 }
@@ -289,7 +289,7 @@ impl GpuContext {
         width: u32,
         height: u32,
     ) -> Result<Self, GpuInitError> {
-        let instance = wgpu_util::new_instance();
+        let instance = wgpu_util::new_instance().await;
         let surface = instance
             .create_surface(target)
             .map_err(GpuInitError::CreateSurface)?;
@@ -301,8 +301,17 @@ impl GpuContext {
             })
             .await
             .map_err(GpuInitError::RequestAdapter)?;
+        let adapter_info = adapter.get_info();
+        log::info!(
+            "Selected surface GPU adapter: {} ({})",
+            adapter_info.name,
+            adapter_info.backend
+        );
         let (device, queue) = adapter
-            .request_device(&wgpu_util::device_descriptor("lsystem_surface_device"))
+            .request_device(&wgpu_util::device_descriptor(
+                "lsystem_surface_device",
+                &adapter,
+            ))
             .await
             .map_err(GpuInitError::RequestDevice)?;
         wgpu_util::install_uncaptured_error_handler(&device, "surface renderer");

--- a/crates/lsystem-renderer/src/png_export.rs
+++ b/crates/lsystem-renderer/src/png_export.rs
@@ -62,7 +62,7 @@ pub async fn render_png_standalone(
     config: &Config,
     width: u32,
 ) -> Result<PngExport, PngExportError> {
-    let instance = wgpu_util::new_instance();
+    let instance = wgpu_util::new_instance().await;
     let adapter = instance
         .request_adapter(&wgpu::RequestAdapterOptions {
             power_preference: wgpu::PowerPreference::default(),
@@ -71,8 +71,14 @@ pub async fn render_png_standalone(
         })
         .await
         .map_err(|_| PngExportError::NoAdapter)?;
+    let adapter_info = adapter.get_info();
+    log::info!(
+        "Selected PNG export GPU adapter: {} ({})",
+        adapter_info.name,
+        adapter_info.backend
+    );
     let (device, queue) = adapter
-        .request_device(&wgpu_util::device_descriptor("png_export_device"))
+        .request_device(&wgpu_util::device_descriptor("png_export_device", &adapter))
         .await
         .map_err(PngExportError::RequestDevice)?;
     wgpu_util::install_uncaptured_error_handler(&device, "PNG export");

--- a/crates/lsystem-renderer/src/wgpu_util.rs
+++ b/crates/lsystem-renderer/src/wgpu_util.rs
@@ -1,13 +1,52 @@
 use std::sync::Arc;
 
-pub(crate) fn new_instance() -> wgpu::Instance {
-    wgpu::Instance::new(wgpu::InstanceDescriptor::new_without_display_handle())
-}
+#[cfg(all(target_arch = "wasm32", not(target_os = "emscripten")))]
+use browser_wasm as platform;
+#[cfg(any(not(target_arch = "wasm32"), target_os = "emscripten"))]
+use non_browser_wasm as platform;
 
-pub(crate) fn device_descriptor(label: &'static str) -> wgpu::DeviceDescriptor<'static> {
+pub(crate) use platform::new_instance;
+
+pub(crate) fn device_descriptor(
+    label: &'static str,
+    adapter: &wgpu::Adapter,
+) -> wgpu::DeviceDescriptor<'static> {
     wgpu::DeviceDescriptor {
         label: Some(label),
+        required_limits: platform::device_limits(adapter),
         ..Default::default()
+    }
+}
+
+#[cfg(all(target_arch = "wasm32", not(target_os = "emscripten")))]
+mod browser_wasm {
+    pub(crate) async fn new_instance() -> wgpu::Instance {
+        let descriptor = wgpu::InstanceDescriptor::new_with_display_handle(Box::new(WebDisplay));
+        wgpu::util::new_instance_with_webgpu_detection(descriptor).await
+    }
+
+    pub(crate) fn device_limits(adapter: &wgpu::Adapter) -> wgpu::Limits {
+        wgpu::Limits::downlevel_webgl2_defaults().using_resolution(adapter.limits())
+    }
+
+    #[derive(Debug)]
+    struct WebDisplay;
+
+    impl wgpu::rwh::HasDisplayHandle for WebDisplay {
+        fn display_handle(&self) -> Result<wgpu::rwh::DisplayHandle<'_>, wgpu::rwh::HandleError> {
+            Ok(wgpu::rwh::DisplayHandle::web())
+        }
+    }
+}
+
+#[cfg(any(not(target_arch = "wasm32"), target_os = "emscripten"))]
+mod non_browser_wasm {
+    pub(crate) async fn new_instance() -> wgpu::Instance {
+        wgpu::Instance::new(wgpu::InstanceDescriptor::new_without_display_handle())
+    }
+
+    pub(crate) fn device_limits(_adapter: &wgpu::Adapter) -> wgpu::Limits {
+        wgpu::Limits::default()
     }
 }
 

--- a/crates/lsystem-web-app/src/app.rs
+++ b/crates/lsystem-web-app/src/app.rs
@@ -43,10 +43,10 @@ pub(crate) fn App() -> impl IntoView {
             RenderStatus::Rendered
             | RenderStatus::Skipped(FrameSkipReason::Timeout | FrameSkipReason::Occluded) => {}
             RenderStatus::Skipped(reason) => {
-                log::error!("Skipped WebGPU frame: {reason}");
+                log::error!("Skipped GPU frame: {reason}");
             }
             RenderStatus::SurfaceLost => {
-                log::error!("WebGPU surface was lost; attempting to recreate it");
+                log::error!("GPU surface was lost; attempting to recreate it");
                 let renderer = Rc::clone(&renderer);
                 wasm_bindgen_futures::spawn_local(async move {
                     let Some(mut renderer_state) = renderer.borrow_mut().take() else {
@@ -65,18 +65,18 @@ pub(crate) fn App() -> impl IntoView {
                             *renderer.borrow_mut() = Some(renderer_state);
                         }
                         Ok(RenderStatus::Skipped(reason)) => {
-                            log::error!("Skipped WebGPU frame after surface recovery: {reason}");
+                            log::error!("Skipped GPU frame after surface recovery: {reason}");
                             set_gpu_error.set(None);
                             *renderer.borrow_mut() = Some(renderer_state);
                         }
                         Ok(RenderStatus::SurfaceLost) => {
-                            log::error!("WebGPU surface was lost again after recovery");
+                            log::error!("GPU surface was lost again after recovery");
                             set_gpu_error.set(Some(
-                                "WebGPU surface was lost again after recovery".to_string(),
+                                "GPU surface was lost again after recovery".to_string(),
                             ));
                         }
                         Err(err) => {
-                            log::error!("Failed to recover WebGPU surface: {err}");
+                            log::error!("Failed to recover GPU surface: {err}");
                             set_gpu_error.set(Some(err.to_string()));
                         }
                     }
@@ -119,7 +119,7 @@ pub(crate) fn App() -> impl IntoView {
                         render_current();
                     }
                     Err(err) => {
-                        log::error!("Failed to initialize WebGPU renderer: {err}");
+                        log::error!("Failed to initialize GPU renderer: {err}");
                         set_gpu_error.set(Some(err.to_string()));
                     }
                 }
@@ -393,8 +393,8 @@ pub(crate) fn App() -> impl IntoView {
                 />
                 <div class:hidden=move || gpu_error.get().is_none() class="unsupported">
                     <div>
-                        <h2>"WebGPU is not available in this browser."</h2>
-                        <p>{move || gpu_error.get().unwrap_or_else(|| "Try the latest Chrome, Edge, or Firefox Nightly with WebGPU enabled.".to_string())}</p>
+                        <h2>"GPU rendering is not available in this browser."</h2>
+                        <p>{move || gpu_error.get().unwrap_or_else(|| "Try a browser with WebGPU or WebGL2 enabled.".to_string())}</p>
                     </div>
                 </div>
             </section>


### PR DESCRIPTION
## Summary
- Enable WebGL support in the existing wgpu and Iced feature graph for browser builds.
- Use wgpu browser WebGPU detection so the shared renderer can fall back to WebGL2 when WebGPU is unavailable.
- Provide the web display handle and WebGL2-safe limits required by the Leptos canvas renderer.
- Generalize user-facing GPU error messages away from WebGPU-only wording.

## Notes
- Native and Emscripten-style targets continue to use the default wgpu instance and limits.
- The lockfile change only adds the wasm WebGL backend dependency required by wgpu.