### PR TITLE
Add 3D L-system support with orbit camera

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -51,14 +51,16 @@ Four-crate workspace under `crates/`:
 | Module | Role |
 |--------|------|
 | `config.rs` | Parses TOML `Config` struct (including `ColorConfig`/`LineColorConfig` for background and line colors); validates axiom, rules, step/angle finiteness, bracket balance |
-| `alphabet.rs` | Reserved symbols (`F f + - \| [ ]`), character set validation |
+| `alphabet.rs` | Reserved symbols (`F f + - \| [ ]` for 2D; additionally `& ^ / \` for 3D), character set validation per `dimensions` |
 | `grammar.rs` | `expand(axiom, rules, iterations)` → lazy `ExpandIter` char iterator; `expand_owned` → `OwnedExpandIter` (same logic, owns its data via `Vec<char>` so callers need no lifetime) |
-| `turtle/mod.rs` | Declares `turtle2d` submodule; documents the 3D extension path (add `Segments3D<I>`, dispatch in `generate()` on `cfg.dimensions`) |
+| `turtle/mod.rs` | Declares `turtle2d` and `turtle3d` submodules |
 | `turtle/turtle2d.rs` | `Segments2D<I>` — pull iterator over `[Vec2; 2]` segments; owns position, heading, and bracket stack; yields one segment per `'F'` without collecting |
+| `turtle/turtle3d.rs` | `Segments3D<I>` — pull iterator over `[Vec3; 2]` segments; uses `glam::Quat` orientation (heading = `orientation * Vec3::X`); dispatches `& ^ / \` pitch/roll symbols in addition to the 2D set |
 | `svg_export.rs` | `export_svg(config) -> String` — generates an SVG string; gated behind the `svg` Cargo feature |
-| `lib.rs` | Public API: `generate(config) -> impl Iterator<Item = [Vec2; 2]>`; exposes `svg_export` as a public module when the `svg` feature is enabled |
+| `lib.rs` | Public API: `generate(config) -> impl Iterator<Item = [Vec2; 2]>` and `generate_3d(config) -> impl Iterator<Item = [Vec3; 2]>`; exposes `svg_export` when the `svg` feature is enabled |
 
-Data flow: `Config` → `OwnedExpandIter` (owned lazy char rewriting) → `Segments2D` → streaming `[Vec2; 2]` segments.
+Data flow (2D): `Config` → `OwnedExpandIter` → `Segments2D` → streaming `[Vec2; 2]` segments.
+Data flow (3D): `Config` → `OwnedExpandIter` → `Segments3D` → streaming `[Vec3; 2]` segments.
 
 ### `lsystem-renderer` — toolkit-independent wgpu renderer
 
@@ -66,12 +68,13 @@ Depends on `lsystem-core` and `wgpu`.
 
 | File | Role |
 |------|------|
-| `camera.rs` | Shared `Camera` pan/zoom state and view transform helpers used by both app crates |
-| `line_renderer.rs` | `Transform` — scale + offset GPU uniform type. `GpuContext` — owns the wgpu surface for non-Iced canvas users; `begin_frame` returns explicit `FrameOutcome` values and `end_frame` submits + presents. `GpuInitError` preserves surface/adapter/device initialization failures. `LinePipeline` (pipeline, bind group, reusable vertex buffer, transform uniform, color-params uniform) — `upload()` grows/reuses the vertex buffer and writes `ColorParams`; `write_transform()` writes the camera transform every frame; `draw()` issues the line-list draw. |
-| `lsystem_bridge.rs` | L-system→GPU adapters. `geometry_to_vertices()` accepts `impl Iterator<Item = [Vec2; 2]>` and produces a flat `Vertex` array with bounding box (`VertexData`). `color_params_from_config()` maps `LineColorConfig` to the `ColorParams` GPU uniform. |
+| `camera.rs` | Shared `Camera` — 2D pan/zoom state and 3D orbit (azimuth, elevation, roll, zoom) state; `compute_transform` for 2D, `compute_mvp_3d` for perspective 3D; `reset()` resets all state, `reset_position()` preserves rotation for scene rebuilds |
+| `line_renderer.rs` | `Vertex2D`/`Vertex3D` GPU vertex types. `GrowableVertexBuffer` — grows to next power-of-two capacity on demand. `LinePipeline2D` — 2D `Transform` uniform + `LinePipeline3D` — `Mvp` (64-byte MVP matrix) uniform; both share `GrowableVertexBuffer` and a private `draw_line_list()` helper. `GpuContext`, `GpuInitError`, `FrameOutcome`, `SurfaceFrame`. `MAX_SEGMENTS` / `MAX_SEGMENTS_3D` caps for segment-count safety. |
+| `lsystem_bridge.rs` | L-system→GPU adapters. `geometry_to_vertices()` for 2D (`VertexData`), `geometry_to_vertices_3d()` for 3D (`VertexData3D`). `color_params_from_config()` maps `LineColorConfig` to the `ColorParams` GPU uniform. |
 | `png_export.rs` | Offscreen wgpu PNG renderer; gated behind the `png` Cargo feature |
 | `wgpu_util.rs` | Shared wgpu instance/device descriptor and uncaptured-error logging helpers; browser wasm creates an instance with a web display handle so wgpu can use WebGPU or fall back to WebGL2, while native and Emscripten use the normal non-web instance path |
-| `shader.wgsl` | Vertex shader applies a `Transform` uniform (scale + offset) and computes per-segment color from a `ColorParams` uniform using `vertex_index / 2`; supports solid, gradient, and HSV hue-cycle modes; fragment shader passes the interpolated color through; topology is `LineList` |
+| `shader.wgsl` | 2D vertex shader: applies `Transform` (scale + offset), computes per-segment color from `ColorParams`; topology `LineList` |
+| `shader3d.wgsl` | 3D vertex shader: applies `Mvp` matrix for perspective projection, same per-segment color logic as `shader.wgsl` |
 
 ### `lsystem-app` — entry points and Iced UI
 
@@ -83,8 +86,8 @@ Depends on `lsystem-core`, `lsystem-renderer`, `iced`, and browser/native export
 | `lib.rs` | Module declarations; `run_native()` starts the Iced app on desktop; `#[wasm_bindgen(start)] start()` starts the same Iced app on web |
 | `ui.rs` | Iced UI module shell and shared UI constants |
 | `ui/app_state.rs` | `FractalApp` state/update/view, preset/config controls, async geometry generation, stale-generation cancellation, exports, and pan/zoom messages |
-| `ui/controls.rs` | Iced control panel widgets |
-| `ui/fractal_canvas.rs` | `iced::widget::shader` integration, `Scene` camera/geometry state, viewport input handling, and GPU upload-by-scene-revision |
+| `ui/controls.rs` | Iced control panel widgets; hides SVG export and shows auto-rotate controls for 3D scenes |
+| `ui/fractal_canvas.rs` | `iced::widget::shader` integration; `Scene` holds either 2D or 3D geometry plus camera; mouse drag orbits in 3D, pans in 2D; GPU upload-by-scene-revision |
 | `export.rs` | Native/browser SVG and PNG export helpers; PNG export creates an offscreen wgpu device instead of borrowing Iced's renderer device |
 
 ### `lsystem-web-app` — browser-first Leptos UI
@@ -97,7 +100,7 @@ Depends on `lsystem-core`, `lsystem-renderer`, `leptos`, and browser `web-sys`/`
 | `app.rs` | DOM controls for presets, TOML, overrides, viewport input, export buttons, and GPU rendering error display |
 | `presets.rs` | Embedded preset loading and effective-config helpers |
 | `export.rs` | Browser SVG/PNG download helpers |
-| `renderer.rs` | `CanvasRenderer` — owns the canvas `GpuContext`, `LinePipeline`, shared `Camera`, current vertices, color params, and background; handles canvas resize, pan, zoom, reset, event-driven rendering, and web surface-loss recovery |
+| `renderer.rs` | `CanvasRenderer` — owns `GpuContext`, `LinePipeline2D`, `LinePipeline3D`, `Camera`, and an `ActiveScene` enum (2D or 3D); dispatches drag to pan (2D) or orbit (3D); handles canvas resize, zoom, orbit, roll, auto-rotate, reset, and surface-loss recovery |
 | `index.html` | Trunk entry that mounts the Leptos app |
 | `Trunk.toml` | Browser app build config, served locally on `127.0.0.1:8081` |
 
@@ -111,13 +114,14 @@ Bundled TOML L-System definitions. New fractals are added here; they are embedde
 - **Lazy expansion**: `ExpandIter` / `OwnedExpandIter` avoid materializing the full rewritten string, keeping memory bounded for high-iteration fractals.
 - **Dual target from day one**: `lsystem-core` has no platform-specific deps so it compiles for both native and `wasm32-unknown-unknown` without feature flags.
 - **Iced/wgpu version coupling**: the workspace `wgpu` dependency is pinned to version 29 and Iced is pinned to a specific upstream git revision that uses the same wgpu major version. Do not independently bump `wgpu` or the Iced git revision; update them in lockstep and verify native + wasm builds.
-- **3D forward-compat seam**: the `dimensions` TOML field (currently validated to `2` only) is the extension point. To add 3D: add `turtle/turtle3d.rs` with a `Segments3D<I>` iterator analogous to `Segments2D`, then dispatch in `lib.rs::generate()` based on `cfg.dimensions`. No other registration is needed.
+- **3D turtle uses quaternion orientation**: `Segments3D<I>` stores a `glam::Quat` orientation instead of a scalar heading angle. Heading = `orientation * Vec3::X`; left = `* Vec3::Y`; up = `* Vec3::Z`. Each rotation symbol applies `orientation *= Quat::from_rotation_*(angle)` in local space, so rotations compose correctly regardless of prior orientation.
 - **Whitespace in axiom/rules is stripped**: whitespace inside `axiom` and rule RHS strings is removed before validation and expansion, allowing multi-line formatting in TOML configs.
 - **Fractal lives in an Iced shader widget**: `lsystem-app` renders the fractal through `iced::widget::shader`. Iced owns the window, surface, event loop, and render pass; the custom primitive owns only the fractal GPU pipeline state.
 - **Async scene generation**: `FractalApp` schedules geometry generation with `Task::perform` when presets, TOML, iterations, or angle change. Each request gets a monotonic generation token; stale results are ignored, so rapid slider changes do not block the UI with outdated work.
 - **Scene-revision uploads**: `FractalApp::schedule_scene_generation()` increments a monotonic generation token whenever geometry is requested. Completed scene builds store that token as `Scene::revision`; the Iced shader pipeline uploads vertices and color params only when the observed revision changes, while camera transforms are written during prepare.
-- **Reusable vertex buffer**: `LinePipeline::upload` grows the GPU vertex buffer to the next power-of-two capacity when needed and otherwise updates it with `Queue::write_buffer`, avoiding a new buffer allocation on every geometry upload.
+- **Reusable vertex buffer**: `GrowableVertexBuffer` grows the GPU vertex buffer to the next power-of-two capacity when needed and otherwise updates it with `Queue::write_buffer`. Both `LinePipeline2D` and `LinePipeline3D` use it via a generic `upload<V: Pod>` method.
+- **2D/3D pipeline split**: `LinePipeline2D` and `LinePipeline3D` are separate structs with different uniform types (`Transform` vs `Mvp`) and different shaders, but share `GrowableVertexBuffer` and a private `draw_line_list()` helper to avoid duplication. `lsystem-web-app`'s `CanvasRenderer` owns both pipelines and keeps both always-initialized; `lsystem-app`'s `Scene` holds an enum that selects the active pipeline at draw time.
 - **DOM browser UI with GPU canvas**: `lsystem-web-app` owns browser UI state in Leptos signals and renders the fractal into a dedicated `<canvas>`. It creates a wgpu surface from `web_sys::HtmlCanvasElement`, reuses `LinePipeline`, and drives rendering from explicit DOM events instead of a continuous repaint loop. On browser wasm targets, `wgpu_util` creates the instance with a web display handle and WebGPU detection so wgpu can use WebGPU when available and fall back to WebGL2 otherwise.
 - **Surface acquisition recovery**: `GpuContext::begin_frame` retries `CurrentSurfaceTexture::Outdated` once after reconfiguring the surface. Timeout and occlusion are quiet skip reasons, validation/repeated-outdated are explicit skip reasons, and true surface loss is reported to callers. The Leptos web renderer rebuilds `GpuContext` and `LinePipeline` after surface loss while preserving CPU-side scene/camera/color state and marking geometry for reupload.
-- **SVG export is a `lsystem-core` Cargo feature**: The `svg` feature adds `svg_export::export_svg(config) -> String`. It collects segments into a `Vec` (the only allocation — acceptable for export), computes a padded bounding box, and builds SVG XML. The Y-axis flip (turtle is Y-up, SVG is Y-down) is handled by a `<g transform="matrix(1 0 0 -1 0 0)">` group so turtle coordinates are written as-is; the viewBox compensates. `stroke-width`, `stroke-linecap`, and `fill` are set on the `<g>` and inherited by children. Solid mode emits a single `<path>`; gradient and hue-cycle modes emit per-segment `<line>` elements to match the shader's segment-index-based coloring exactly. On native, `rfd::FileDialog` handles the save dialog; on WASM, a programmatic Blob download is triggered via `web-sys`.
+- **SVG export is 2D-only**: SVG export is a `lsystem-core` Cargo feature (`svg`). `export_svg(config) -> String` collects 2D segments, computes a padded bounding box, and builds SVG XML. The Y-axis flip is handled by a `<g transform="matrix(1 0 0 -1 0 0)">` group. Both apps hide the SVG export button when `config.dimensions == 3`.
 - **Strict CI**: `clippy -D warnings` and `cargo fmt --check` must pass. CI tests the workspace with all features/all targets, checks and lints native default/all-features builds, checks and lints `wasm32-unknown-unknown` default/all-features builds, and builds both Trunk web apps. GitHub Pages deploys the Leptos browser app.

--- a/README.md
+++ b/README.md
@@ -36,6 +36,8 @@ Each `F` is replaced; `+` has no rule, so it passes through unchanged.
 Every character in the axiom and in rule right-hand sides must be one of the
 following:
 
+**2D and 3D symbols** (valid for any `dimensions` value):
+
 | Symbol | Name | Effect |
 |--------|------|--------|
 | `F` | Forward (draw) | Move one step forward and draw a line segment. |
@@ -47,6 +49,15 @@ following:
 | `]` | Pop state | Restore the most recently saved position and heading. |
 | `A`–`Z`, `a`–`z` | Non-terminal | Rewritten by rules during expansion. Any letter that has no rule and is not a reserved symbol above is silently skipped by the turtle. |
 
+**3D-only symbols** (only valid when `dimensions = 3`):
+
+| Symbol | Name | Effect |
+|--------|------|--------|
+| `&` | Pitch down | Rotate the heading downward by `angle` (around the left axis). |
+| `^` | Pitch up | Rotate the heading upward by `angle`. |
+| `/` | Roll right | Roll clockwise by `angle` (around the heading axis). |
+| `\` | Roll left | Roll counter-clockwise by `angle`. |
+
 Any other character is a validation error.
 
 ### Config format
@@ -55,7 +66,7 @@ Each L-System is defined in a TOML file:
 
 ```toml
 name = "Koch Snowflake"
-dimensions = 2          # must be 2
+dimensions = 2          # 2 (default) or 3
 axiom = "F++F++F"
 iterations = 4          # number of times the rules are applied
 angle = 60.0            # degrees; used by + - and |
@@ -94,18 +105,31 @@ you can break long rules across lines for readability.
 
 ### Controls
 
+**2D**
+
 | Input | Action |
 |-------|--------|
 | Drag (left button) | Pan |
 | Scroll wheel | Zoom in / out toward the cursor |
 | `F` | Reset view to fit the fractal |
 
+**3D** (when `dimensions = 3`)
+
+| Input | Action |
+|-------|--------|
+| Drag (left button) | Orbit (rotate azimuth / elevation) |
+| Scroll wheel | Zoom in / out |
+| Arrow keys | Rotate azimuth (left / right) or elevation (up / down) by 5° |
+| `Q` / `E` | Roll counter-clockwise / clockwise by 5° |
+| `F` | Reset camera to fit the fractal |
+| Auto-rotate toggle | Continuously orbit around the Y axis at the configured speed |
+
 ### Exporting
 
-The **Export SVG** button saves the current fractal, including the active
-iteration and angle overrides, as a resolution-independent SVG file.
-The **Export PNG** button renders the same effective config to a raster PNG
-using the selected PNG width.
+The **Export SVG** button saves the current fractal as a resolution-independent
+SVG file. SVG export is only available for 2D fractals.
+The **Export PNG** button renders the fractal to a raster PNG using the selected
+PNG width. For 3D fractals, PNG captures the current camera orientation.
 
 ### Bundled presets
 
@@ -120,6 +144,8 @@ using the selected PNG width.
 | `presets/sierpinski_curve.toml` | Sierpinski Curve | Space-filling curve traced along the boundary of a Sierpinski triangle. |
 | `presets/sierpinski_triangle.toml` | Sierpinski Triangle | Self-similar triangle subdivided into progressively smaller triangular holes. |
 | `presets/snowflake.toml` | Snowflake | Branching snowflake pattern with six-fold symmetry and recursive side branches. |
+| `presets/plant_3d.toml` | 3D Plant | Branching 3D plant using pitch symbols to spread branches in all directions. |
+| `presets/tree_3d.toml` | 3D Spiral Tree | Spiral tree using pitch and roll symbols to wind branches around the trunk. |
 
 ---
 
@@ -195,15 +221,17 @@ crates/
       grammar.rs            axiom + rule expansion (N iterations); OwnedExpandIter for lifetime-free streaming
       turtle/
         turtle2d.rs         Segments2D<I>: pull iterator yielding [Vec2; 2] segments lazily
+        turtle3d.rs         Segments3D<I>: pull iterator yielding [Vec3; 2] segments using Quat orientation
       svg_export.rs         SVG export — export_svg(config) -> String (enabled by the `svg` Cargo feature)
   lsystem-renderer/         toolkit-independent wgpu renderer (no egui)
     src/
-      camera.rs             shared pan/zoom state and view transform
-      line_renderer.rs      Transform/Vertex/ColorParams types, LinePipeline, GpuContext, surface errors/status
-      lsystem_bridge.rs     L-system→GPU adapters: geometry_to_vertices (accepts segment iterator), color_params_from_config
+      camera.rs             shared pan/zoom/orbit state and view transform (2D and 3D)
+      line_renderer.rs      Vertex2D/Vertex3D, LinePipeline2D/LinePipeline3D, GrowableVertexBuffer, GpuContext
+      lsystem_bridge.rs     L-system→GPU adapters: geometry_to_vertices, geometry_to_vertices_3d, color_params_from_config
       png_export.rs         offscreen wgpu PNG renderer (enabled by the `png` Cargo feature)
       wgpu_util.rs          shared wgpu instance/device/error-handler helpers
-      shader.wgsl           vertex + fragment shaders
+      shader.wgsl           2D vertex + fragment shaders
+      shader3d.wgsl         3D vertex + fragment shaders with MVP matrix uniform
   lsystem-app/              Iced native app, plus retained Iced web entry point
     src/
       main.rs               native entry point

--- a/crates/lsystem-app/src/export.rs
+++ b/crates/lsystem-app/src/export.rs
@@ -1,4 +1,5 @@
 use lsystem_core::Config;
+use lsystem_renderer::camera::Camera;
 
 #[cfg(not(target_arch = "wasm32"))]
 use std::path::PathBuf;
@@ -43,11 +44,16 @@ pub(crate) enum ExportRequest {
         config: Config,
         width: u32,
         path: PathBuf,
+        camera: Camera,
     },
     #[cfg(target_arch = "wasm32")]
     Svg(Config),
     #[cfg(target_arch = "wasm32")]
-    Png { config: Config, width: u32 },
+    Png {
+        config: Config,
+        width: u32,
+        camera: Camera,
+    },
 }
 
 #[derive(Debug, Clone)]
@@ -70,7 +76,8 @@ pub(crate) async fn handle_export(request: ExportRequest) -> ExportOutcome {
             config,
             width,
             path,
-        } => save_png(config, width, path).await,
+            camera,
+        } => save_png(config, width, path, camera).await,
         #[cfg(target_arch = "wasm32")]
         ExportRequest::Svg(config) => {
             let filename = suggested_filename(&config, ExportKind::Svg);
@@ -78,9 +85,13 @@ pub(crate) async fn handle_export(request: ExportRequest) -> ExportOutcome {
             save_svg(svg, filename)
         }
         #[cfg(target_arch = "wasm32")]
-        ExportRequest::Png { config, width } => {
+        ExportRequest::Png {
+            config,
+            width,
+            camera,
+        } => {
             let filename = suggested_filename(&config, ExportKind::Png);
-            save_png(config, width, filename).await
+            save_png(config, width, camera, filename).await
         }
     }
 }
@@ -120,8 +131,8 @@ fn save_svg(svg: String, path: PathBuf) -> ExportOutcome {
 }
 
 #[cfg(not(target_arch = "wasm32"))]
-async fn save_png(cfg: Config, width: u32, path: PathBuf) -> ExportOutcome {
-    match lsystem_renderer::png_export::render_png_standalone(&cfg, width).await {
+async fn save_png(cfg: Config, width: u32, path: PathBuf, camera: Camera) -> ExportOutcome {
+    match lsystem_renderer::png_export::render_png_standalone(&cfg, width, &camera).await {
         Ok(png) => match std::fs::write(&path, png.bytes) {
             Ok(()) => ExportOutcome::Saved(ExportKind::Png.label()),
             Err(e) => ExportOutcome::Failed(e.to_string()),
@@ -147,8 +158,13 @@ fn save_svg(svg: String, suggested_name: String) -> ExportOutcome {
 }
 
 #[cfg(target_arch = "wasm32")]
-async fn save_png(cfg: Config, width: u32, suggested_name: String) -> ExportOutcome {
-    match lsystem_renderer::png_export::render_png_standalone(&cfg, width).await {
+async fn save_png(
+    cfg: Config,
+    width: u32,
+    camera: Camera,
+    suggested_name: String,
+) -> ExportOutcome {
+    match lsystem_renderer::png_export::render_png_standalone(&cfg, width, &camera).await {
         Ok(png) => {
             let array = js_sys::Array::new();
             let bytes = js_sys::Uint8Array::from(png.bytes.as_slice());

--- a/crates/lsystem-app/src/ui/app_state.rs
+++ b/crates/lsystem-app/src/ui/app_state.rs
@@ -1,6 +1,6 @@
 use iced::keyboard;
 use iced::widget::row;
-use iced::{Element, Event, Length, Point, Size, Subscription, Task, event};
+use iced::{Element, Event, Length, Point, Size, Subscription, Task, event, window};
 use include_dir::{Dir, include_dir};
 use lsystem_core::Config;
 use std::sync::{
@@ -16,6 +16,9 @@ use super::fractal_canvas::{Scene, SceneBuildResult, build_scene};
 use super::{PNG_MAX_WIDTH, PNG_MIN_WIDTH};
 
 static PRESETS_DIR: Dir<'_> = include_dir!("$CARGO_MANIFEST_DIR/../../presets");
+
+const ROTATION_STEP_DEG: f32 = 5.0;
+const AUTO_ROTATE_DT_SECS: f32 = 1.0 / 60.0;
 
 #[derive(Debug, Clone)]
 pub(super) enum Message {
@@ -35,11 +38,23 @@ pub(super) enum Message {
         dy: f32,
         size: Size,
     },
+    FractalOrbit {
+        dx: f32,
+        dy: f32,
+    },
     FractalZoom {
         delta_y: f32,
         cursor: Point,
         size: Size,
     },
+    RotateBy {
+        d_az: f32,
+        d_el: f32,
+    },
+    RollBy(f32),
+    ToggleAutoRotate,
+    SetAutoRotateSpeed(f32),
+    AnimationTick,
 }
 
 pub(super) struct FractalApp {
@@ -56,6 +71,8 @@ pub(super) struct FractalApp {
     pub(super) export_status: Option<String>,
     pub(super) scene_pending: bool,
     pub(super) scene: Scene,
+    pub(super) auto_rotate: bool,
+    pub(super) auto_rotate_speed: f32,
     scene_generation: Arc<AtomicU64>,
 }
 
@@ -83,6 +100,8 @@ impl FractalApp {
             export_status: None,
             scene_pending: false,
             scene: Scene::default(),
+            auto_rotate: false,
+            auto_rotate_speed: 45.0,
             scene_generation: Arc::new(AtomicU64::new(0)),
         };
         let task = app.apply_config();
@@ -121,7 +140,12 @@ impl FractalApp {
                 }
                 Task::none()
             }
-            Message::ExportSvg => self.export(ExportKind::Svg),
+            Message::ExportSvg => {
+                if self.scene.is_3d() {
+                    return Task::none();
+                }
+                self.export(ExportKind::Svg)
+            }
             Message::ExportPng => self.export(ExportKind::Png),
             Message::ExportFinished(outcome) => {
                 self.export_status = Some(match outcome {
@@ -148,12 +172,41 @@ impl FractalApp {
                 self.scene.pan_by_pixels(dx, dy, size);
                 Task::none()
             }
+            Message::FractalOrbit { dx, dy } => {
+                self.scene.orbit_by_pixels(dx, dy);
+                Task::none()
+            }
             Message::FractalZoom {
                 delta_y,
                 cursor,
                 size,
             } => {
                 self.scene.zoom_toward_cursor(delta_y, cursor, size);
+                Task::none()
+            }
+            Message::RotateBy { d_az, d_el } => {
+                if self.scene.is_3d() {
+                    self.scene.orbit_by(d_az, d_el);
+                }
+                Task::none()
+            }
+            Message::RollBy(degrees) => {
+                if self.scene.is_3d() {
+                    self.scene.roll_by(degrees);
+                }
+                Task::none()
+            }
+            Message::ToggleAutoRotate => {
+                self.auto_rotate = !self.auto_rotate;
+                Task::none()
+            }
+            Message::SetAutoRotateSpeed(speed) => {
+                self.auto_rotate_speed = speed;
+                Task::none()
+            }
+            Message::AnimationTick => {
+                self.scene
+                    .auto_rotate_by(self.auto_rotate_speed * AUTO_ROTATE_DT_SECS);
                 Task::none()
             }
         }
@@ -166,29 +219,72 @@ impl FractalApp {
     }
 
     pub(super) fn subscription(&self) -> Subscription<Message> {
-        event::listen_with(|event, status, _window| {
+        let is_3d = self.scene.is_3d();
+        let auto_rotate = self.auto_rotate;
+
+        let key_sub = event::listen_with(|event, status, _window| {
             if status == event::Status::Captured {
                 return None;
             }
             match event {
-                Event::Keyboard(keyboard::Event::KeyPressed {
-                    key: keyboard::Key::Character(ch),
-                    repeat: false,
-                    ..
-                }) if ch.eq_ignore_ascii_case("f") => Some(Message::Fit),
+                Event::Keyboard(keyboard::Event::KeyPressed { key, .. }) => match &key {
+                    keyboard::Key::Character(ch) if ch.eq_ignore_ascii_case("f") => {
+                        Some(Message::Fit)
+                    }
+                    keyboard::Key::Named(keyboard::key::Named::ArrowLeft) => {
+                        Some(Message::RotateBy {
+                            d_az: -ROTATION_STEP_DEG,
+                            d_el: 0.0,
+                        })
+                    }
+                    keyboard::Key::Named(keyboard::key::Named::ArrowRight) => {
+                        Some(Message::RotateBy {
+                            d_az: ROTATION_STEP_DEG,
+                            d_el: 0.0,
+                        })
+                    }
+                    keyboard::Key::Named(keyboard::key::Named::ArrowUp) => {
+                        Some(Message::RotateBy {
+                            d_az: 0.0,
+                            d_el: ROTATION_STEP_DEG,
+                        })
+                    }
+                    keyboard::Key::Named(keyboard::key::Named::ArrowDown) => {
+                        Some(Message::RotateBy {
+                            d_az: 0.0,
+                            d_el: -ROTATION_STEP_DEG,
+                        })
+                    }
+                    keyboard::Key::Character(ch) if ch.eq_ignore_ascii_case("q") => {
+                        Some(Message::RollBy(-ROTATION_STEP_DEG))
+                    }
+                    keyboard::Key::Character(ch) if ch.eq_ignore_ascii_case("e") => {
+                        Some(Message::RollBy(ROTATION_STEP_DEG))
+                    }
+                    _ => None,
+                },
                 _ => None,
             }
-        })
+        });
+
+        if is_3d && auto_rotate {
+            let frames = window::frames().map(|_| Message::AnimationTick);
+            Subscription::batch([key_sub, frames])
+        } else {
+            key_sub
+        }
     }
 
     fn apply_config(&mut self) -> Task<Message> {
         match Config::parse(&self.toml.text()) {
             Ok(config) => {
-                self.max_iterations = lsystem_core::max_safe_iterations(
-                    &config.axiom,
-                    &config.rules,
-                    lsystem_renderer::line_renderer::MAX_SEGMENTS,
-                ) as u32;
+                let max_seg = if config.dimensions == 3 {
+                    lsystem_renderer::line_renderer::MAX_SEGMENTS_3D
+                } else {
+                    lsystem_renderer::line_renderer::MAX_SEGMENTS
+                };
+                self.max_iterations =
+                    lsystem_core::max_safe_iterations(&config.axiom, &config.rules, max_seg) as u32;
                 self.iterations = config.iterations.min(self.max_iterations);
                 self.angle = config.angle;
                 self.base_config = Some(config);
@@ -226,8 +322,9 @@ impl FractalApp {
         self.scene_pending = true;
         self.export_status = None;
 
+        let prev_camera = self.scene.camera.clone();
         Task::perform(
-            build_scene(config, generation, token),
+            build_scene(config, generation, token, prev_camera),
             Message::SceneGenerated,
         )
     }

--- a/crates/lsystem-app/src/ui/app_state.rs
+++ b/crates/lsystem-app/src/ui/app_state.rs
@@ -365,6 +365,7 @@ impl FractalApp {
                     config,
                     width: png_width,
                     path,
+                    camera: self.scene.camera.clone(),
                 },
             }
         };
@@ -375,6 +376,7 @@ impl FractalApp {
             ExportKind::Png => ExportRequest::Png {
                 config,
                 width: png_width,
+                camera: self.scene.camera.clone(),
             },
         };
 

--- a/crates/lsystem-app/src/ui/controls.rs
+++ b/crates/lsystem-app/src/ui/controls.rs
@@ -29,6 +29,8 @@ impl FractalApp {
         ]
         .spacing(10);
 
+        let is_3d = self.scene.is_3d();
+
         if self.base_config.is_some() {
             controls = controls
                 .push(text("Overrides").size(13))
@@ -45,14 +47,32 @@ impl FractalApp {
                     text_input("2048", &self.png_width_text)
                         .on_input(Message::PngWidthChanged)
                         .width(Length::Fill),
-                )
-                .push(
-                    row![
-                        button("Export SVG").on_press(Message::ExportSvg),
-                        button("Export PNG").on_press(Message::ExportPng),
-                    ]
-                    .spacing(8),
                 );
+
+            let mut export_row = row![button("Export PNG").on_press(Message::ExportPng)].spacing(8);
+            if !is_3d {
+                export_row = export_row.push(button("Export SVG").on_press(Message::ExportSvg));
+            }
+            controls = controls.push(export_row);
+
+            if is_3d {
+                let auto_rotate_label = if self.auto_rotate {
+                    "Auto-rotate: On"
+                } else {
+                    "Auto-rotate: Off"
+                };
+                controls = controls
+                    .push(button(auto_rotate_label).on_press(Message::ToggleAutoRotate))
+                    .push(text(format!("Speed: {:.0} °/s", self.auto_rotate_speed)).size(13))
+                    .push(
+                        slider(
+                            10.0..=360.0,
+                            self.auto_rotate_speed,
+                            Message::SetAutoRotateSpeed,
+                        )
+                        .step(10.0),
+                    );
+            }
         }
 
         if let Some(status) = &self.export_status {
@@ -63,7 +83,12 @@ impl FractalApp {
             controls = controls.push(text("Rendering...").size(13));
         }
 
-        controls = controls.push(text("Drag to pan · Scroll to zoom · F to fit").size(12));
+        let hint = if is_3d {
+            "Drag to orbit · Scroll to zoom · F to fit\nArrows to rotate · Q/E to roll"
+        } else {
+            "Drag to pan · Scroll to zoom · F to fit"
+        };
+        controls = controls.push(text(hint).size(12));
 
         container(scrollable(controls.padding(16).spacing(12)))
             .width(CONTROL_WIDTH)

--- a/crates/lsystem-app/src/ui/fractal_canvas.rs
+++ b/crates/lsystem-app/src/ui/fractal_canvas.rs
@@ -3,8 +3,12 @@ use iced::widget::{container, shader};
 use iced::{Background, Color, Element, Event, Length, Point, Rectangle, Size, Theme};
 use lsystem_core::Config;
 use lsystem_renderer::camera::Camera;
-use lsystem_renderer::line_renderer::{ColorParams, LinePipeline, Vertex};
-use lsystem_renderer::lsystem_bridge::{VertexData, VertexDataBuilder, color_params_from_config};
+use lsystem_renderer::line_renderer::{
+    ColorParams, LinePipeline2D, LinePipeline3D, Vertex2D, Vertex3D,
+};
+use lsystem_renderer::lsystem_bridge::{
+    VertexData, VertexData3D, VertexDataBuilder, VertexDataBuilder3D, color_params_from_config,
+};
 use std::fmt;
 use std::sync::{
     Arc,
@@ -16,29 +20,73 @@ use super::app_state::{FractalApp, Message};
 const CANCELLATION_CHECK_INTERVAL: usize = 4096;
 
 #[derive(Clone)]
+enum SceneGeometry {
+    TwoD {
+        vertices: Arc<Vec<Vertex2D>>,
+        bounds_min: [f32; 2],
+        bounds_max: [f32; 2],
+    },
+    ThreeD {
+        vertices: Arc<Vec<Vertex3D>>,
+        bounds_min: [f32; 3],
+        bounds_max: [f32; 3],
+    },
+}
+
+
+
+#[derive(Clone)]
 pub(super) struct Scene {
-    vertices: Arc<Vec<Vertex>>,
-    bounds_min: [f32; 2],
-    bounds_max: [f32; 2],
+    geometry: SceneGeometry,
     color_params: ColorParams,
     background: [f32; 3],
-    camera: Camera,
+    pub(super) camera: Camera,
     revision: u64,
 }
 
 impl Scene {
-    fn from_vertex_data(config: &Config, data: VertexData, revision: u64) -> Self {
+    fn from_vertex_data_2d(
+        config: &Config,
+        data: VertexData,
+        camera: Camera,
+        revision: u64,
+    ) -> Self {
         let total_segments = (data.vertices.len() / 2) as u32;
-
         Self {
-            vertices: Arc::new(data.vertices),
-            bounds_min: data.bounds_min,
-            bounds_max: data.bounds_max,
+            geometry: SceneGeometry::TwoD {
+                vertices: Arc::new(data.vertices),
+                bounds_min: data.bounds_min,
+                bounds_max: data.bounds_max,
+            },
             color_params: color_params_from_config(&config.colors.line, total_segments),
             background: config.colors.background,
-            camera: Camera::new(),
+            camera,
             revision,
         }
+    }
+
+    fn from_vertex_data_3d(
+        config: &Config,
+        data: VertexData3D,
+        camera: Camera,
+        revision: u64,
+    ) -> Self {
+        let total_segments = (data.vertices.len() / 2) as u32;
+        Self {
+            geometry: SceneGeometry::ThreeD {
+                vertices: Arc::new(data.vertices),
+                bounds_min: data.bounds_min,
+                bounds_max: data.bounds_max,
+            },
+            color_params: color_params_from_config(&config.colors.line, total_segments),
+            background: config.colors.background,
+            camera,
+            revision,
+        }
+    }
+
+    pub(super) fn is_3d(&self) -> bool {
+        matches!(self.geometry, SceneGeometry::ThreeD { .. })
     }
 
     pub(super) fn reset_camera(&mut self) {
@@ -46,33 +94,65 @@ impl Scene {
     }
 
     pub(super) fn pan_by_pixels(&mut self, dx: f32, dy: f32, size: Size) {
-        self.camera.pan_by_pixels(
-            dx,
-            dy,
-            self.bounds_min,
-            self.bounds_max,
-            size.width.max(1.0) as u32,
-            size.height.max(1.0) as u32,
-        );
+        if let SceneGeometry::TwoD {
+            bounds_min,
+            bounds_max,
+            ..
+        } = self.geometry
+        {
+            self.camera.pan_by_pixels(
+                dx,
+                dy,
+                bounds_min,
+                bounds_max,
+                size.width.max(1.0) as u32,
+                size.height.max(1.0) as u32,
+            );
+        }
+    }
+
+    pub(super) fn orbit_by_pixels(&mut self, dx: f32, dy: f32) {
+        self.camera.orbit_by_pixels(dx, dy);
+    }
+
+    pub(super) fn orbit_by(&mut self, d_az: f32, d_el: f32) {
+        self.camera.orbit_by(d_az, d_el);
+    }
+
+    pub(super) fn roll_by(&mut self, degrees: f32) {
+        self.camera.roll_by(degrees);
+    }
+
+    pub(super) fn auto_rotate_by(&mut self, degrees: f32) {
+        self.camera.auto_rotate_by(degrees);
     }
 
     pub(super) fn zoom_toward_cursor(&mut self, delta_y: f32, cursor: Point, size: Size) {
         let factor = 1.1_f32.powf(-delta_y / 100.0);
-        self.camera.zoom_toward_cursor(
-            factor,
-            [cursor.x, cursor.y],
-            self.bounds_min,
-            self.bounds_max,
-            size.width.max(1.0) as u32,
-            size.height.max(1.0) as u32,
-        );
+        match self.geometry {
+            SceneGeometry::TwoD {
+                bounds_min,
+                bounds_max,
+                ..
+            } => {
+                self.camera.zoom_toward_cursor(
+                    factor,
+                    [cursor.x, cursor.y],
+                    bounds_min,
+                    bounds_max,
+                    size.width.max(1.0) as u32,
+                    size.height.max(1.0) as u32,
+                );
+            }
+            SceneGeometry::ThreeD { .. } => {
+                self.camera.zoom_3d(factor);
+            }
+        }
     }
 
     fn snapshot(&self) -> SceneSnapshot {
         SceneSnapshot {
-            vertices: Arc::clone(&self.vertices),
-            bounds_min: self.bounds_min,
-            bounds_max: self.bounds_max,
+            geometry: self.geometry.clone(),
             color_params: self.color_params,
             camera: self.camera.clone(),
             revision: self.revision,
@@ -89,11 +169,16 @@ pub(super) enum SceneBuildResult {
 impl fmt::Debug for SceneBuildResult {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
-            Self::Ready { generation, scene } => f
-                .debug_struct("Ready")
-                .field("generation", generation)
-                .field("vertices", &scene.vertices.len())
-                .finish(),
+            Self::Ready { generation, scene } => {
+                let vertex_count = match &scene.geometry {
+                    SceneGeometry::TwoD { vertices, .. } => vertices.len(),
+                    SceneGeometry::ThreeD { vertices, .. } => vertices.len(),
+                };
+                f.debug_struct("Ready")
+                    .field("generation", generation)
+                    .field("vertices", &vertex_count)
+                    .finish()
+            }
             Self::Cancelled => f.write_str("Cancelled"),
         }
     }
@@ -103,32 +188,63 @@ pub(super) async fn build_scene(
     config: Config,
     generation: u64,
     current_generation: Arc<AtomicU64>,
+    prev_camera: Camera,
 ) -> SceneBuildResult {
-    let mut builder = VertexDataBuilder::new();
-    let mut segments_seen = 0usize;
+    let mut camera = prev_camera;
+    camera.reset_position();
 
-    for segment in lsystem_core::generate(&config) {
-        if segments_seen.is_multiple_of(CANCELLATION_CHECK_INTERVAL) {
-            if is_cancelled(generation, &current_generation) {
-                return SceneBuildResult::Cancelled;
+    if config.dimensions == 3 {
+        let mut builder = VertexDataBuilder3D::new();
+        let mut segments_seen = 0usize;
+
+        for segment in lsystem_core::generate_3d(&config) {
+            if segments_seen.is_multiple_of(CANCELLATION_CHECK_INTERVAL) {
+                if is_cancelled(generation, &current_generation) {
+                    return SceneBuildResult::Cancelled;
+                }
+                yield_generation().await;
+                if is_cancelled(generation, &current_generation) {
+                    return SceneBuildResult::Cancelled;
+                }
             }
-            yield_generation().await;
-            if is_cancelled(generation, &current_generation) {
-                return SceneBuildResult::Cancelled;
-            }
+            builder.push_segment(segment);
+            segments_seen = segments_seen.wrapping_add(1);
         }
 
-        builder.push_segment(segment);
-        segments_seen = segments_seen.wrapping_add(1);
-    }
+        if is_cancelled(generation, &current_generation) {
+            return SceneBuildResult::Cancelled;
+        }
 
-    if is_cancelled(generation, &current_generation) {
-        return SceneBuildResult::Cancelled;
-    }
+        SceneBuildResult::Ready {
+            generation,
+            scene: Scene::from_vertex_data_3d(&config, builder.finish(), camera, generation),
+        }
+    } else {
+        let mut builder = VertexDataBuilder::new();
+        let mut segments_seen = 0usize;
 
-    SceneBuildResult::Ready {
-        generation,
-        scene: Scene::from_vertex_data(&config, builder.finish(), generation),
+        for segment in lsystem_core::generate(&config) {
+            if segments_seen.is_multiple_of(CANCELLATION_CHECK_INTERVAL) {
+                if is_cancelled(generation, &current_generation) {
+                    return SceneBuildResult::Cancelled;
+                }
+                yield_generation().await;
+                if is_cancelled(generation, &current_generation) {
+                    return SceneBuildResult::Cancelled;
+                }
+            }
+            builder.push_segment(segment);
+            segments_seen = segments_seen.wrapping_add(1);
+        }
+
+        if is_cancelled(generation, &current_generation) {
+            return SceneBuildResult::Cancelled;
+        }
+
+        SceneBuildResult::Ready {
+            generation,
+            scene: Scene::from_vertex_data_2d(&config, builder.finish(), camera, generation),
+        }
     }
 }
 
@@ -170,9 +286,11 @@ async fn yield_generation() {
 impl Default for Scene {
     fn default() -> Self {
         Self {
-            vertices: Arc::new(Vec::new()),
-            bounds_min: [-1.0, -1.0],
-            bounds_max: [1.0, 1.0],
+            geometry: SceneGeometry::TwoD {
+                vertices: Arc::new(Vec::new()),
+                bounds_min: [-1.0, -1.0],
+                bounds_max: [1.0, 1.0],
+            },
             color_params: ColorParams::default(),
             background: [0.0, 0.0, 0.0],
             camera: Camera::new(),
@@ -205,12 +323,16 @@ impl FractalApp {
 
 #[derive(Clone)]
 struct SceneSnapshot {
-    vertices: Arc<Vec<Vertex>>,
-    bounds_min: [f32; 2],
-    bounds_max: [f32; 2],
+    geometry: SceneGeometry,
     color_params: ColorParams,
     camera: Camera,
     revision: u64,
+}
+
+impl SceneSnapshot {
+    fn is_3d(&self) -> bool {
+        matches!(self.geometry, SceneGeometry::ThreeD { .. })
+    }
 }
 
 struct FractalProgram {
@@ -234,6 +356,7 @@ impl shader::Program<Message> for FractalProgram {
         bounds: Rectangle,
         cursor: mouse::Cursor,
     ) -> Option<shader::Action<Message>> {
+        let is_3d = self.scene.is_3d();
         match event {
             Event::Mouse(mouse::Event::ButtonPressed(mouse::Button::Left)) => {
                 let position = cursor_over(cursor, bounds)?;
@@ -249,14 +372,18 @@ impl shader::Program<Message> for FractalProgram {
             Event::Mouse(mouse::Event::CursorMoved { .. }) if state.dragging => {
                 let position = cursor_position(cursor)?;
                 let previous = state.last_cursor.replace(position).unwrap_or(position);
-                Some(
-                    shader::Action::publish(Message::FractalPan {
-                        dx: position.x - previous.x,
-                        dy: position.y - previous.y,
+                let dx = position.x - previous.x;
+                let dy = position.y - previous.y;
+                let msg = if is_3d {
+                    Message::FractalOrbit { dx, dy }
+                } else {
+                    Message::FractalPan {
+                        dx,
+                        dy,
                         size: bounds.size(),
-                    })
-                    .and_capture(),
-                )
+                    }
+                };
+                Some(shader::Action::publish(msg).and_capture())
             }
             Event::Mouse(mouse::Event::WheelScrolled { delta }) => {
                 let position = cursor_over(cursor, bounds)?;
@@ -300,7 +427,6 @@ impl shader::Program<Message> for FractalProgram {
 
 fn cursor_over(cursor: mouse::Cursor, bounds: Rectangle) -> Option<Point> {
     let position = cursor_position(cursor)?;
-
     bounds.contains(position).then_some(position)
 }
 
@@ -322,11 +448,11 @@ struct FractalPrimitive {
     scene: SceneSnapshot,
 }
 
-impl std::fmt::Debug for FractalPrimitive {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+impl fmt::Debug for FractalPrimitive {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         f.debug_struct("FractalPrimitive")
             .field("revision", &self.scene.revision)
-            .field("vertices", &self.scene.vertices.len())
+            .field("is_3d", &self.scene.is_3d())
             .finish()
     }
 }
@@ -345,37 +471,65 @@ impl shader::Primitive for FractalPrimitive {
         let scale_factor = viewport.scale_factor();
         let width = (bounds.width * scale_factor).round().max(1.0) as u32;
         let height = (bounds.height * scale_factor).round().max(1.0) as u32;
-        let transform = self.scene.camera.compute_transform(
-            self.scene.bounds_min,
-            self.scene.bounds_max,
-            width,
-            height,
-        );
 
-        if pipeline.uploaded_revision != Some(self.scene.revision) {
-            pipeline
-                .line
-                .upload(device, queue, &self.scene.vertices, self.scene.color_params);
-            pipeline.uploaded_revision = Some(self.scene.revision);
+        match &self.scene.geometry {
+            SceneGeometry::TwoD {
+                vertices,
+                bounds_min,
+                bounds_max,
+            } => {
+                let transform =
+                    self.scene
+                        .camera
+                        .compute_transform(*bounds_min, *bounds_max, width, height);
+                if pipeline.uploaded_revision != Some(self.scene.revision) {
+                    pipeline
+                        .pipeline_2d
+                        .upload(device, queue, vertices, self.scene.color_params);
+                    pipeline.uploaded_revision = Some(self.scene.revision);
+                }
+                pipeline.pipeline_2d.write_transform(queue, transform);
+            }
+            SceneGeometry::ThreeD {
+                vertices,
+                bounds_min,
+                bounds_max,
+            } => {
+                let mvp = self
+                    .scene
+                    .camera
+                    .compute_mvp_3d(*bounds_min, *bounds_max, width, height);
+                if pipeline.uploaded_revision != Some(self.scene.revision) {
+                    pipeline
+                        .pipeline_3d
+                        .upload(device, queue, vertices, self.scene.color_params);
+                    pipeline.uploaded_revision = Some(self.scene.revision);
+                }
+                pipeline.pipeline_3d.write_mvp(queue, mvp);
+            }
         }
-        pipeline.line.write_transform(queue, transform);
     }
 
     fn draw(&self, pipeline: &Self::Pipeline, render_pass: &mut wgpu::RenderPass<'_>) -> bool {
-        pipeline.line.draw(render_pass);
+        match &self.scene.geometry {
+            SceneGeometry::TwoD { .. } => pipeline.pipeline_2d.draw(render_pass),
+            SceneGeometry::ThreeD { .. } => pipeline.pipeline_3d.draw(render_pass),
+        }
         true
     }
 }
 
 struct FractalPipeline {
-    line: LinePipeline,
+    pipeline_2d: LinePipeline2D,
+    pipeline_3d: LinePipeline3D,
     uploaded_revision: Option<u64>,
 }
 
 impl shader::Pipeline for FractalPipeline {
     fn new(device: &wgpu::Device, _queue: &wgpu::Queue, format: wgpu::TextureFormat) -> Self {
         Self {
-            line: LinePipeline::new(device, format),
+            pipeline_2d: LinePipeline2D::new(device, format),
+            pipeline_3d: LinePipeline3D::new(device, format),
             uploaded_revision: None,
         }
     }

--- a/crates/lsystem-app/src/ui/fractal_canvas.rs
+++ b/crates/lsystem-app/src/ui/fractal_canvas.rs
@@ -33,8 +33,6 @@ enum SceneGeometry {
     },
 }
 
-
-
 #[derive(Clone)]
 pub(super) struct Scene {
     geometry: SceneGeometry,

--- a/crates/lsystem-core/src/alphabet.rs
+++ b/crates/lsystem-core/src/alphabet.rs
@@ -1,13 +1,17 @@
 use crate::config::ConfigError;
 
 const TERMINALS_UNIVERSAL: &str = "Ff+-|[]";
+const TERMINALS_3D: &str = "&^/\\";
 
-pub fn validate_symbols(chars: &str, field: &str) -> Result<(), ConfigError> {
+pub fn validate_symbols(chars: &str, field: &str, dimensions: u8) -> Result<(), ConfigError> {
     for (position, ch) in chars.chars().enumerate() {
         if ch.is_ascii_alphabetic() {
             continue;
         }
         if TERMINALS_UNIVERSAL.contains(ch) {
+            continue;
+        }
+        if dimensions == 3 && TERMINALS_3D.contains(ch) {
             continue;
         }
         return Err(ConfigError::InvalidSymbol {

--- a/crates/lsystem-core/src/config.rs
+++ b/crates/lsystem-core/src/config.rs
@@ -20,7 +20,7 @@ pub enum ConfigError {
         position: usize,
     },
 
-    #[error("unsupported dimensions value {0} (must be 2)")]
+    #[error("unsupported dimensions value {0} (must be 2 or 3)")]
     InvalidDimensions(u8),
 
     #[error("unmatched `]` at position {position} in `{field}`")]
@@ -80,13 +80,15 @@ impl Default for ColorConfig {
 #[derive(Debug, Clone)]
 pub struct Config {
     pub name: String,
+    /// Number of spatial dimensions: 2 or 3.
+    pub dimensions: u8,
     pub axiom: String,
     pub iterations: u32,
     /// Turn angle in degrees.
     pub angle: f32,
     /// Length of each forward step.
     pub step: f32,
-    /// Turtle heading at the start, in degrees (0 = +X, counter-clockwise positive).
+    /// Turtle heading at the start, in degrees (0 = +X, counter-clockwise positive). 2D only.
     pub initial_heading: f32,
     /// Production rules: single ASCII letter → replacement string.
     pub rules: HashMap<char, String>,
@@ -97,7 +99,7 @@ impl Config {
     pub fn parse(toml_str: &str) -> Result<Self, ConfigError> {
         let raw: RawConfig = toml::from_str(toml_str)?;
 
-        if raw.dimensions != 2 {
+        if raw.dimensions != 2 && raw.dimensions != 3 {
             return Err(ConfigError::InvalidDimensions(raw.dimensions));
         }
         if !raw.step.is_finite() || raw.step <= 0.0 {
@@ -112,7 +114,7 @@ impl Config {
 
         // Strip whitespace from axiom and rule RHS, then validate symbols.
         let axiom: String = raw.axiom.chars().filter(|c| !c.is_whitespace()).collect();
-        validate_symbols(&axiom, "axiom")?;
+        validate_symbols(&axiom, "axiom", raw.dimensions)?;
         validate_bracket_balance(&axiom, "axiom")?;
 
         let mut rules = HashMap::with_capacity(raw.rules.len());
@@ -129,7 +131,7 @@ impl Config {
             }
 
             let rhs: String = rhs_raw.chars().filter(|c| !c.is_whitespace()).collect();
-            validate_symbols(&rhs, &format!("rules.{key}"))?;
+            validate_symbols(&rhs, &format!("rules.{key}"), raw.dimensions)?;
             validate_bracket_balance(&rhs, &format!("rules.{key}"))?;
             rules.insert(key, rhs);
         }
@@ -156,6 +158,7 @@ impl Config {
 
         Ok(Config {
             name: raw.name,
+            dimensions: raw.dimensions,
             axiom,
             iterations: raw.iterations,
             angle: raw.angle,
@@ -320,16 +323,6 @@ step = 1.0
     }
 
     #[test]
-    fn rejects_unsupported_symbol() {
-        let toml = "name=\"bad\"\naxiom=\"F&F\"\niterations=1\nangle=90.0\nstep=1.0";
-        let err = Config::parse(toml).unwrap_err();
-        assert!(
-            matches!(err, ConfigError::InvalidSymbol { ch: '&', .. }),
-            "unexpected error: {err}"
-        );
-    }
-
-    #[test]
     fn rejects_multi_char_rule_key() {
         let toml = r#"
 name = "bad"
@@ -350,7 +343,7 @@ FF = "FFF"
 
     #[test]
     fn rejects_invalid_dimensions() {
-        for bad_dim in [3u8, 4] {
+        for bad_dim in [1u8, 4] {
             let toml = format!(
                 "name=\"bad\"\ndimensions={bad_dim}\naxiom=\"F\"\niterations=1\nangle=90.0\nstep=1.0"
             );
@@ -360,6 +353,23 @@ FF = "FFF"
                 "dim={bad_dim}: unexpected error: {err}"
             );
         }
+    }
+
+    #[test]
+    fn accepts_dimensions_3_with_3d_symbols() {
+        let toml =
+            "name=\"t\"\ndimensions=3\naxiom=\"F&F^F/F\"\niterations=0\nangle=90.0\nstep=1.0";
+        Config::parse(toml).expect("3D config with 3D symbols should be valid");
+    }
+
+    #[test]
+    fn rejects_3d_symbols_in_2d_config() {
+        let toml = "name=\"bad\"\naxiom=\"F&F\"\niterations=1\nangle=90.0\nstep=1.0";
+        let err = Config::parse(toml).unwrap_err();
+        assert!(
+            matches!(err, ConfigError::InvalidSymbol { ch: '&', .. }),
+            "unexpected error: {err}"
+        );
     }
 
     #[test]

--- a/crates/lsystem-core/src/lib.rs
+++ b/crates/lsystem-core/src/lib.rs
@@ -9,7 +9,7 @@ pub(crate) mod turtle;
 pub use config::{ColorConfig, Config, ConfigError, LineColorConfig};
 pub use grammar::max_safe_iterations;
 
-use glam::Vec2;
+use glam::{Vec2, Vec3};
 
 /// Expand the grammar and run the 2D turtle, returning a lazy iterator of
 /// line segments. The iterator owns all its state and does not borrow from `config`.
@@ -20,4 +20,14 @@ pub fn generate(config: &Config) -> impl Iterator<Item = [Vec2; 2]> {
         config.iterations,
     );
     turtle::turtle2d::Segments2D::new(chars, config.angle, config.step, config.initial_heading)
+}
+
+/// Like `generate` but runs the 3D turtle; the iterator owns all its state.
+pub fn generate_3d(config: &Config) -> impl Iterator<Item = [Vec3; 2]> {
+    let chars = grammar::expand_owned(
+        config.axiom.clone(),
+        config.rules.clone(),
+        config.iterations,
+    );
+    turtle::turtle3d::Segments3D::new(chars, config.angle, config.step)
 }

--- a/crates/lsystem-core/src/turtle/mod.rs
+++ b/crates/lsystem-core/src/turtle/mod.rs
@@ -1,4 +1,2 @@
-// To add a 3D interpreter: add turtle/turtle3d.rs with Segments3D<I> analogous
-// to Segments2D, then dispatch in lib.rs::generate based on cfg.dimensions.
-// The `dimensions` field in Config is already parsed and validated.
 pub(crate) mod turtle2d;
+pub(crate) mod turtle3d;

--- a/crates/lsystem-core/src/turtle/turtle3d.rs
+++ b/crates/lsystem-core/src/turtle/turtle3d.rs
@@ -1,0 +1,124 @@
+use glam::{Quat, Vec3};
+
+/// Heading = `orientation * Vec3::X`, left = `* Vec3::Y`, up = `* Vec3::Z`.
+pub(crate) struct Segments3D<I: Iterator<Item = char>> {
+    chars: I,
+    angle_rad: f32,
+    step: f32,
+    position: Vec3,
+    orientation: Quat,
+    stack: Vec<(Vec3, Quat)>,
+}
+
+impl<I: Iterator<Item = char>> Segments3D<I> {
+    pub(crate) fn new(chars: I, angle_deg: f32, step: f32) -> Self {
+        Self {
+            chars,
+            angle_rad: angle_deg.to_radians(),
+            step,
+            position: Vec3::ZERO,
+            orientation: Quat::IDENTITY,
+            stack: Vec::new(),
+        }
+    }
+}
+
+impl<I: Iterator<Item = char>> Iterator for Segments3D<I> {
+    type Item = [Vec3; 2];
+
+    fn next(&mut self) -> Option<[Vec3; 2]> {
+        loop {
+            match self.chars.next()? {
+                'F' => {
+                    let forward = self.orientation * Vec3::X;
+                    let next = self.position + forward * self.step;
+                    let seg = [self.position, next];
+                    self.position = next;
+                    return Some(seg);
+                }
+                'f' => {
+                    let forward = self.orientation * Vec3::X;
+                    self.position += forward * self.step;
+                }
+                '+' => {
+                    self.orientation *= Quat::from_rotation_z(self.angle_rad);
+                }
+                '-' => {
+                    self.orientation *= Quat::from_rotation_z(-self.angle_rad);
+                }
+                '&' => {
+                    self.orientation *= Quat::from_rotation_y(self.angle_rad);
+                }
+                '^' => {
+                    self.orientation *= Quat::from_rotation_y(-self.angle_rad);
+                }
+                '/' => {
+                    self.orientation *= Quat::from_rotation_x(self.angle_rad);
+                }
+                '\\' => {
+                    self.orientation *= Quat::from_rotation_x(-self.angle_rad);
+                }
+                '|' => {
+                    self.orientation *= Quat::from_rotation_z(std::f32::consts::PI);
+                }
+                '[' => self.stack.push((self.position, self.orientation)),
+                ']' => {
+                    let state = self.stack.pop();
+                    debug_assert!(state.is_some(), "unmatched ] in validated program");
+                    if let Some((pos, orient)) = state {
+                        self.position = pos;
+                        self.orientation = orient;
+                    }
+                }
+                _ => {}
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn make(axiom: &str, angle_deg: f32) -> Vec<[Vec3; 2]> {
+        Segments3D::new(axiom.chars(), angle_deg, 1.0).collect()
+    }
+
+    #[test]
+    fn single_f_draws_along_x() {
+        let segs = make("F", 90.0);
+        assert_eq!(segs.len(), 1);
+        let [a, b] = segs[0];
+        assert!(a.distance(Vec3::ZERO) < 1e-5);
+        assert!(b.distance(Vec3::X) < 1e-5);
+    }
+
+    #[test]
+    fn plus_yaws_left_into_y() {
+        let segs = make("F+F", 90.0);
+        assert_eq!(segs.len(), 2);
+        let [a, b] = segs[1];
+        assert!(a.distance(Vec3::X) < 1e-5, "start at X: {a}");
+        assert!(b.distance(Vec3::X + Vec3::Y) < 1e-5, "end at X+Y: {b}");
+    }
+
+    #[test]
+    fn ampersand_pitches_down_into_neg_z() {
+        let segs = make("F&F", 90.0);
+        assert_eq!(segs.len(), 2);
+        let [_, b] = segs[1];
+        // After & (90° pitch down): heading was +X, now -Z
+        assert!(b.distance(Vec3::X - Vec3::Z) < 1e-5, "end at X-Z: {b}");
+    }
+
+    #[test]
+    fn bracket_saves_and_restores() {
+        // [+F] saves (1,0,0) facing +X, turns left, draws to (1,1,0), restores.
+        // After ], heading is back to +X. - turns right to -Y. F draws to (1,-1,0).
+        let segs = make("F[+F]-F", 90.0);
+        assert_eq!(segs.len(), 3);
+        let [a, b] = segs[2];
+        assert!(a.distance(Vec3::X) < 1e-5, "restored position: {a}");
+        assert!(b.distance(Vec3::new(1.0, -1.0, 0.0)) < 1e-5, "end: {b}");
+    }
+}

--- a/crates/lsystem-renderer/src/camera.rs
+++ b/crates/lsystem-renderer/src/camera.rs
@@ -1,10 +1,18 @@
-use crate::line_renderer::Transform;
+use glam::{Mat4, Quat, Vec3};
+
+use crate::line_renderer::{Mvp, Transform};
 use crate::lsystem_bridge::{fitted_pixels_per_unit, viewport_transform};
+
+const ORBIT_DEG_PER_PIXEL: f32 = 0.3;
+const FOV_Y_RAD: f32 = std::f32::consts::FRAC_PI_4; // 45°
 
 #[derive(Clone, Debug)]
 pub struct Camera {
     pan: [f32; 2],
     zoom: f32,
+    pub azimuth: f32,
+    pub elevation: f32,
+    pub roll: f32,
 }
 
 impl Camera {
@@ -12,10 +20,22 @@ impl Camera {
         Self {
             pan: [0.0, 0.0],
             zoom: 1.0,
+            azimuth: 0.0,
+            elevation: 20.0,
+            roll: 0.0,
         }
     }
 
     pub fn reset(&mut self) {
+        self.pan = [0.0, 0.0];
+        self.zoom = 1.0;
+        self.azimuth = 0.0;
+        self.elevation = 20.0;
+        self.roll = 0.0;
+    }
+
+    /// Preserves azimuth/elevation/roll; only resets pan and zoom.
+    pub fn reset_position(&mut self) {
         self.pan = [0.0, 0.0];
         self.zoom = 1.0;
     }
@@ -80,6 +100,74 @@ impl Camera {
         self.pan[0] -= ndc_x / sx * (1.0 - 1.0 / actual);
         self.pan[1] -= ndc_y / sy * (1.0 - 1.0 / actual);
         self.zoom = clamped;
+    }
+
+    pub fn orbit_by_pixels(&mut self, dx: f32, dy: f32) {
+        self.orbit_by(dx * ORBIT_DEG_PER_PIXEL, -dy * ORBIT_DEG_PER_PIXEL);
+    }
+
+    pub fn orbit_by(&mut self, d_azimuth: f32, d_elevation: f32) {
+        self.azimuth += d_azimuth;
+        self.elevation = (self.elevation + d_elevation).clamp(-89.0, 89.0);
+    }
+
+    /// Roll the camera view by degrees (positive = counter-clockwise).
+    pub fn roll_by(&mut self, degrees: f32) {
+        self.roll += degrees;
+    }
+
+    pub fn auto_rotate_by(&mut self, degrees: f32) {
+        self.azimuth += degrees;
+    }
+
+    /// Zoom in/out for 3D (same zoom field, affects view distance).
+    pub fn zoom_3d(&mut self, factor: f32) {
+        if factor > 0.0 {
+            self.zoom = (self.zoom * factor).clamp(1e-4, 1e4);
+        }
+    }
+
+    pub fn compute_mvp_3d(
+        &self,
+        bounds_min: [f32; 3],
+        bounds_max: [f32; 3],
+        width: u32,
+        height: u32,
+    ) -> Mvp {
+        let min = Vec3::from(bounds_min);
+        let max = Vec3::from(bounds_max);
+        let center = (min + max) * 0.5;
+        let extent = max - min;
+        let radius = (extent.length() * 0.5).max(1.0);
+
+        // Base distance to frame the geometry at 45° FOV, then apply zoom.
+        let base_distance = radius / (FOV_Y_RAD * 0.5).tan();
+        let distance = (base_distance / self.zoom).max(radius * 0.01);
+
+        let az = self.azimuth.to_radians();
+        let el = self.elevation.to_radians();
+        let eye_dir = Vec3::new(el.cos() * az.sin(), el.sin(), el.cos() * az.cos());
+        let eye = center + eye_dir * distance;
+
+        // Up vector: world Y unless camera is near zenith/nadir.
+        let world_up = if (self.elevation.abs() - 89.0).abs() < 1.0 {
+            // Near pole: use a stable fallback derived from azimuth.
+            Vec3::new(-az.sin(), 0.0, -az.cos())
+        } else {
+            Vec3::Y
+        };
+        let roll_quat = Quat::from_axis_angle(eye_dir, self.roll.to_radians());
+        let up = roll_quat * world_up;
+
+        let view = Mat4::look_at_rh(eye, center, up);
+        let aspect = (width as f32 / height as f32).max(0.001);
+        let z_near = distance * 0.001;
+        let z_far = distance * 10.0;
+        let proj = Mat4::perspective_rh(FOV_Y_RAD, aspect, z_near, z_far);
+
+        Mvp {
+            matrix: (proj * view).to_cols_array_2d(),
+        }
     }
 }
 
@@ -193,5 +281,25 @@ mod tests {
         let t = cam.compute_transform(bounds_min, bounds_max, w, h);
         let ndc_center = t.offset[0];
         assert!(ndc_center > 0.0, "ndc center x = {ndc_center}");
+    }
+
+    #[test]
+    fn mvp_3d_produces_finite_matrix() {
+        let cam = Camera::new();
+        let mvp = cam.compute_mvp_3d([-5.0, -5.0, -5.0], [5.0, 5.0, 5.0], 800, 600);
+        for row in &mvp.matrix {
+            for &v in row {
+                assert!(v.is_finite(), "MVP contains non-finite value: {v}");
+            }
+        }
+    }
+
+    #[test]
+    fn orbit_clamps_elevation() {
+        let mut cam = Camera::new();
+        cam.orbit_by(0.0, 999.0);
+        assert!(cam.elevation <= 89.0, "elevation={}", cam.elevation);
+        cam.orbit_by(0.0, -999.0);
+        assert!(cam.elevation >= -89.0, "elevation={}", cam.elevation);
     }
 }

--- a/crates/lsystem-renderer/src/line_renderer.rs
+++ b/crates/lsystem-renderer/src/line_renderer.rs
@@ -9,20 +9,50 @@ use crate::wgpu_util;
 
 #[repr(C)]
 #[derive(Copy, Clone, Pod, Zeroable)]
+pub struct Vertex2D {
+    pub position: [f32; 2],
+}
+
+#[repr(C)]
+#[derive(Copy, Clone, Pod, Zeroable)]
+pub struct Vertex3D {
+    pub position: [f32; 3],
+}
+
+#[repr(C)]
+#[derive(Copy, Clone, Pod, Zeroable)]
 pub struct Transform {
     pub scale: [f32; 2],
     pub offset: [f32; 2],
 }
 
+/// Column-major MVP matrix uniform.
 #[repr(C)]
 #[derive(Copy, Clone, Pod, Zeroable)]
-pub struct Vertex {
-    pub position: [f32; 2],
+pub struct Mvp {
+    pub matrix: [[f32; 4]; 4],
+}
+
+impl Default for Mvp {
+    fn default() -> Self {
+        Self {
+            matrix: [
+                [1.0, 0.0, 0.0, 0.0],
+                [0.0, 1.0, 0.0, 0.0],
+                [0.0, 0.0, 1.0, 0.0],
+                [0.0, 0.0, 0.0, 1.0],
+            ],
+        }
+    }
 }
 
 /// Maximum number of line segments that fit in a 256 MiB vertex buffer (wgpu's guaranteed limit).
-/// Each segment occupies 2 vertices × `size_of::<Vertex>()` bytes.
-pub const MAX_SEGMENTS: u64 = 268_435_456 / (2 * std::mem::size_of::<Vertex>() as u64);
+/// Each 2D segment occupies 2 vertices × `size_of::<Vertex2D>()` bytes.
+pub const MAX_SEGMENTS: u64 = 268_435_456 / (2 * std::mem::size_of::<Vertex2D>() as u64);
+
+/// Maximum number of 3D line segments that fit in a 256 MiB vertex buffer.
+/// Each 3D segment occupies 2 vertices × `size_of::<Vertex3D>()` bytes.
+pub const MAX_SEGMENTS_3D: u64 = 268_435_456 / (2 * std::mem::size_of::<Vertex3D>() as u64);
 
 /// Per-frame color parameters written to the GPU as a uniform.
 /// Layout mirrors `ColorParams` in `shader.wgsl`; padding keeps vec4 alignment.
@@ -41,26 +71,83 @@ pub struct ColorParams {
     pub _pad2: f32,
 }
 
-/// GPU pipeline for rendering colored line-list geometry.
-pub struct LinePipeline {
+struct GrowableVertexBuffer {
+    buffer: Option<wgpu::Buffer>,
+    capacity: u64,
+    count: u32,
+}
+
+impl GrowableVertexBuffer {
+    fn new() -> Self {
+        Self {
+            buffer: None,
+            capacity: 0,
+            count: 0,
+        }
+    }
+
+    fn upload<V: bytemuck::Pod>(
+        &mut self,
+        device: &wgpu::Device,
+        queue: &wgpu::Queue,
+        vertices: &[V],
+        label: &str,
+    ) {
+        let required = std::mem::size_of_val(vertices) as u64;
+        if required > 0 {
+            if self.capacity < required {
+                self.capacity = required.next_power_of_two();
+                self.buffer = Some(device.create_buffer(&wgpu::BufferDescriptor {
+                    label: Some(label),
+                    size: self.capacity,
+                    usage: wgpu::BufferUsages::VERTEX | wgpu::BufferUsages::COPY_DST,
+                    mapped_at_creation: false,
+                }));
+            }
+            if let Some(buffer) = &self.buffer {
+                queue.write_buffer(buffer, 0, bytemuck::cast_slice(vertices));
+            }
+        }
+        self.count = vertices.len() as u32;
+    }
+}
+
+fn draw_line_list(
+    render_pass: &mut wgpu::RenderPass<'_>,
+    pipeline: &wgpu::RenderPipeline,
+    bind_group: &wgpu::BindGroup,
+    vertex_buffer: &GrowableVertexBuffer,
+    debug_label: &str,
+) {
+    render_pass.push_debug_group(debug_label);
+    render_pass.set_pipeline(pipeline);
+    render_pass.set_bind_group(0, bind_group, &[]);
+    if vertex_buffer.count > 0
+        && let Some(buf) = &vertex_buffer.buffer
+    {
+        render_pass.set_vertex_buffer(0, buf.slice(..));
+        render_pass.draw(0..vertex_buffer.count, 0..1);
+    }
+    render_pass.pop_debug_group();
+}
+
+pub struct LinePipeline2D {
     pipeline: wgpu::RenderPipeline,
     uniform_buffer: wgpu::Buffer,
     color_params_buffer: wgpu::Buffer,
     bind_group: wgpu::BindGroup,
-    vertex_buffer: Option<wgpu::Buffer>,
-    vertex_capacity: u64,
-    vertex_count: u32,
+    vertex_buffer: GrowableVertexBuffer,
 }
 
-impl LinePipeline {
+impl LinePipeline2D {
     pub fn new(device: &wgpu::Device, format: wgpu::TextureFormat) -> Self {
         let shader = device.create_shader_module(wgpu::ShaderModuleDescriptor {
-            label: Some("lsystem_line_shader"),
+            label: Some("lsystem_2d_shader"),
             source: wgpu::ShaderSource::Wgsl(include_str!("shader.wgsl").into()),
         });
 
         let uniform_buffer = device.create_buffer_init(&wgpu::util::BufferInitDescriptor {
-            label: Some("lsystem_line_transform_uniform"),
+            label: Some("lsystem_2d_transform_uniform"),
             contents: bytemuck::bytes_of(&Transform {
                 scale: [1.0, 1.0],
                 offset: [0.0, 0.0],
@@ -69,38 +156,43 @@ impl LinePipeline {
         });
 
         let color_params_buffer = device.create_buffer_init(&wgpu::util::BufferInitDescriptor {
-            label: Some("lsystem_line_color_uniform"),
+            label: Some("lsystem_2d_color_uniform"),
             contents: bytemuck::bytes_of(&ColorParams::default()),
             usage: wgpu::BufferUsages::UNIFORM | wgpu::BufferUsages::COPY_DST,
         });
 
-        let uniform_entry = wgpu::BindGroupLayoutEntry {
-            binding: 0,
-            visibility: wgpu::ShaderStages::VERTEX,
-            ty: wgpu::BindingType::Buffer {
-                ty: wgpu::BufferBindingType::Uniform,
-                has_dynamic_offset: false,
-                min_binding_size: wgpu::BufferSize::new(std::mem::size_of::<Transform>() as u64),
-            },
-            count: None,
-        };
-        let color_entry = wgpu::BindGroupLayoutEntry {
-            binding: 1,
-            visibility: wgpu::ShaderStages::VERTEX,
-            ty: wgpu::BindingType::Buffer {
-                ty: wgpu::BufferBindingType::Uniform,
-                has_dynamic_offset: false,
-                min_binding_size: wgpu::BufferSize::new(std::mem::size_of::<ColorParams>() as u64),
-            },
-            count: None,
-        };
         let bgl = device.create_bind_group_layout(&wgpu::BindGroupLayoutDescriptor {
-            label: Some("lsystem_line_bind_group_layout"),
-            entries: &[uniform_entry, color_entry],
+            label: Some("lsystem_2d_bind_group_layout"),
+            entries: &[
+                wgpu::BindGroupLayoutEntry {
+                    binding: 0,
+                    visibility: wgpu::ShaderStages::VERTEX,
+                    ty: wgpu::BindingType::Buffer {
+                        ty: wgpu::BufferBindingType::Uniform,
+                        has_dynamic_offset: false,
+                        min_binding_size: wgpu::BufferSize::new(
+                            std::mem::size_of::<Transform>() as u64
+                        ),
+                    },
+                    count: None,
+                },
+                wgpu::BindGroupLayoutEntry {
+                    binding: 1,
+                    visibility: wgpu::ShaderStages::VERTEX,
+                    ty: wgpu::BindingType::Buffer {
+                        ty: wgpu::BufferBindingType::Uniform,
+                        has_dynamic_offset: false,
+                        min_binding_size: wgpu::BufferSize::new(
+                            std::mem::size_of::<ColorParams>() as u64
+                        ),
+                    },
+                    count: None,
+                },
+            ],
         });
 
         let bind_group = device.create_bind_group(&wgpu::BindGroupDescriptor {
-            label: Some("lsystem_line_bind_group"),
+            label: Some("lsystem_2d_bind_group"),
             layout: &bgl,
             entries: &[
                 wgpu::BindGroupEntry {
@@ -115,19 +207,19 @@ impl LinePipeline {
         });
 
         let pipeline_layout = device.create_pipeline_layout(&wgpu::PipelineLayoutDescriptor {
-            label: Some("lsystem_line_pipeline_layout"),
+            label: Some("lsystem_2d_pipeline_layout"),
             bind_group_layouts: &[Some(&bgl)],
             immediate_size: 0,
         });
 
         let pipeline = device.create_render_pipeline(&wgpu::RenderPipelineDescriptor {
-            label: Some("lsystem_line_pipeline"),
+            label: Some("lsystem_2d_pipeline"),
             layout: Some(&pipeline_layout),
             vertex: wgpu::VertexState {
                 module: &shader,
                 entry_point: Some("vs_main"),
                 buffers: &[wgpu::VertexBufferLayout {
-                    array_stride: std::mem::size_of::<Vertex>() as wgpu::BufferAddress,
+                    array_stride: std::mem::size_of::<Vertex2D>() as wgpu::BufferAddress,
                     step_mode: wgpu::VertexStepMode::Vertex,
                     attributes: &wgpu::vertex_attr_array![0 => Float32x2],
                 }],
@@ -158,9 +250,7 @@ impl LinePipeline {
             uniform_buffer,
             color_params_buffer,
             bind_group,
-            vertex_buffer: None,
-            vertex_capacity: 0,
-            vertex_count: 0,
+            vertex_buffer: GrowableVertexBuffer::new(),
         }
     }
 
@@ -168,25 +258,11 @@ impl LinePipeline {
         &mut self,
         device: &wgpu::Device,
         queue: &wgpu::Queue,
-        vertices: &[Vertex],
+        vertices: &[Vertex2D],
         color_params: ColorParams,
     ) {
-        let required_size = std::mem::size_of_val(vertices) as u64;
-        if required_size > 0 {
-            if self.vertex_capacity < required_size {
-                self.vertex_capacity = required_size.next_power_of_two();
-                self.vertex_buffer = Some(device.create_buffer(&wgpu::BufferDescriptor {
-                    label: Some("lsystem_line_vertices"),
-                    size: self.vertex_capacity,
-                    usage: wgpu::BufferUsages::VERTEX | wgpu::BufferUsages::COPY_DST,
-                    mapped_at_creation: false,
-                }));
-            }
-            if let Some(buffer) = &self.vertex_buffer {
-                queue.write_buffer(buffer, 0, bytemuck::cast_slice(vertices));
-            }
-        }
-        self.vertex_count = vertices.len() as u32;
+        self.vertex_buffer
+            .upload(device, queue, vertices, "lsystem_2d_vertices");
         queue.write_buffer(
             &self.color_params_buffer,
             0,
@@ -199,16 +275,162 @@ impl LinePipeline {
     }
 
     pub fn draw(&self, render_pass: &mut wgpu::RenderPass<'_>) {
-        render_pass.push_debug_group("lsystem_line_draw");
-        render_pass.set_pipeline(&self.pipeline);
-        render_pass.set_bind_group(0, &self.bind_group, &[]);
-        if self.vertex_count > 0
-            && let Some(vertex_buffer) = &self.vertex_buffer
-        {
-            render_pass.set_vertex_buffer(0, vertex_buffer.slice(..));
-            render_pass.draw(0..self.vertex_count, 0..1);
+        draw_line_list(
+            render_pass,
+            &self.pipeline,
+            &self.bind_group,
+            &self.vertex_buffer,
+            "lsystem_2d_line_draw",
+        );
+    }
+}
+
+pub struct LinePipeline3D {
+    pipeline: wgpu::RenderPipeline,
+    mvp_buffer: wgpu::Buffer,
+    color_params_buffer: wgpu::Buffer,
+    bind_group: wgpu::BindGroup,
+    vertex_buffer: GrowableVertexBuffer,
+}
+
+impl LinePipeline3D {
+    pub fn new(device: &wgpu::Device, format: wgpu::TextureFormat) -> Self {
+        let shader = device.create_shader_module(wgpu::ShaderModuleDescriptor {
+            label: Some("lsystem_3d_shader"),
+            source: wgpu::ShaderSource::Wgsl(include_str!("shader3d.wgsl").into()),
+        });
+
+        let mvp_buffer = device.create_buffer_init(&wgpu::util::BufferInitDescriptor {
+            label: Some("lsystem_3d_mvp_uniform"),
+            contents: bytemuck::bytes_of(&Mvp::default()),
+            usage: wgpu::BufferUsages::UNIFORM | wgpu::BufferUsages::COPY_DST,
+        });
+
+        let color_params_buffer = device.create_buffer_init(&wgpu::util::BufferInitDescriptor {
+            label: Some("lsystem_3d_color_uniform"),
+            contents: bytemuck::bytes_of(&ColorParams::default()),
+            usage: wgpu::BufferUsages::UNIFORM | wgpu::BufferUsages::COPY_DST,
+        });
+
+        let bgl = device.create_bind_group_layout(&wgpu::BindGroupLayoutDescriptor {
+            label: Some("lsystem_3d_bind_group_layout"),
+            entries: &[
+                wgpu::BindGroupLayoutEntry {
+                    binding: 0,
+                    visibility: wgpu::ShaderStages::VERTEX,
+                    ty: wgpu::BindingType::Buffer {
+                        ty: wgpu::BufferBindingType::Uniform,
+                        has_dynamic_offset: false,
+                        min_binding_size: wgpu::BufferSize::new(std::mem::size_of::<Mvp>() as u64),
+                    },
+                    count: None,
+                },
+                wgpu::BindGroupLayoutEntry {
+                    binding: 1,
+                    visibility: wgpu::ShaderStages::VERTEX,
+                    ty: wgpu::BindingType::Buffer {
+                        ty: wgpu::BufferBindingType::Uniform,
+                        has_dynamic_offset: false,
+                        min_binding_size: wgpu::BufferSize::new(
+                            std::mem::size_of::<ColorParams>() as u64
+                        ),
+                    },
+                    count: None,
+                },
+            ],
+        });
+
+        let bind_group = device.create_bind_group(&wgpu::BindGroupDescriptor {
+            label: Some("lsystem_3d_bind_group"),
+            layout: &bgl,
+            entries: &[
+                wgpu::BindGroupEntry {
+                    binding: 0,
+                    resource: mvp_buffer.as_entire_binding(),
+                },
+                wgpu::BindGroupEntry {
+                    binding: 1,
+                    resource: color_params_buffer.as_entire_binding(),
+                },
+            ],
+        });
+
+        let pipeline_layout = device.create_pipeline_layout(&wgpu::PipelineLayoutDescriptor {
+            label: Some("lsystem_3d_pipeline_layout"),
+            bind_group_layouts: &[Some(&bgl)],
+            immediate_size: 0,
+        });
+
+        let pipeline = device.create_render_pipeline(&wgpu::RenderPipelineDescriptor {
+            label: Some("lsystem_3d_pipeline"),
+            layout: Some(&pipeline_layout),
+            vertex: wgpu::VertexState {
+                module: &shader,
+                entry_point: Some("vs_main"),
+                buffers: &[wgpu::VertexBufferLayout {
+                    array_stride: std::mem::size_of::<Vertex3D>() as wgpu::BufferAddress,
+                    step_mode: wgpu::VertexStepMode::Vertex,
+                    attributes: &wgpu::vertex_attr_array![0 => Float32x3],
+                }],
+                compilation_options: Default::default(),
+            },
+            fragment: Some(wgpu::FragmentState {
+                module: &shader,
+                entry_point: Some("fs_main"),
+                targets: &[Some(wgpu::ColorTargetState {
+                    format,
+                    blend: Some(wgpu::BlendState::REPLACE),
+                    write_mask: wgpu::ColorWrites::ALL,
+                })],
+                compilation_options: Default::default(),
+            }),
+            primitive: wgpu::PrimitiveState {
+                topology: wgpu::PrimitiveTopology::LineList,
+                ..Default::default()
+            },
+            depth_stencil: None,
+            multisample: wgpu::MultisampleState::default(),
+            multiview_mask: None,
+            cache: None,
+        });
+
+        Self {
+            pipeline,
+            mvp_buffer,
+            color_params_buffer,
+            bind_group,
+            vertex_buffer: GrowableVertexBuffer::new(),
         }
-        render_pass.pop_debug_group();
+    }
+
+    pub fn upload(
+        &mut self,
+        device: &wgpu::Device,
+        queue: &wgpu::Queue,
+        vertices: &[Vertex3D],
+        color_params: ColorParams,
+    ) {
+        self.vertex_buffer
+            .upload(device, queue, vertices, "lsystem_3d_vertices");
+        queue.write_buffer(
+            &self.color_params_buffer,
+            0,
+            bytemuck::bytes_of(&color_params),
+        );
+    }
+
+    pub fn write_mvp(&self, queue: &wgpu::Queue, mvp: Mvp) {
+        queue.write_buffer(&self.mvp_buffer, 0, bytemuck::bytes_of(&mvp));
+    }
+
+    pub fn draw(&self, render_pass: &mut wgpu::RenderPass<'_>) {
+        draw_line_list(
+            render_pass,
+            &self.pipeline,
+            &self.bind_group,
+            &self.vertex_buffer,
+            "lsystem_3d_line_draw",
+        );
     }
 }
 

--- a/crates/lsystem-renderer/src/lsystem_bridge.rs
+++ b/crates/lsystem-renderer/src/lsystem_bridge.rs
@@ -1,10 +1,10 @@
-use glam::Vec2;
+use glam::{Vec2, Vec3};
 use lsystem_core::LineColorConfig;
 
-use crate::line_renderer::{ColorParams, Transform, Vertex};
+use crate::line_renderer::{ColorParams, Transform, Vertex2D, Vertex3D};
 
 pub struct VertexData {
-    pub vertices: Vec<Vertex>,
+    pub vertices: Vec<Vertex2D>,
     pub bounds_min: [f32; 2],
     pub bounds_max: [f32; 2],
 }
@@ -14,7 +14,7 @@ pub struct VertexDataBuilder {
     min_y: f32,
     max_x: f32,
     max_y: f32,
-    vertices: Vec<Vertex>,
+    vertices: Vec<Vertex2D>,
 }
 
 impl VertexDataBuilder {
@@ -33,10 +33,10 @@ impl VertexDataBuilder {
         self.min_y = self.min_y.min(a.y).min(b.y);
         self.max_x = self.max_x.max(a.x).max(b.x);
         self.max_y = self.max_y.max(a.y).max(b.y);
-        self.vertices.push(Vertex {
+        self.vertices.push(Vertex2D {
             position: [a.x, a.y],
         });
-        self.vertices.push(Vertex {
+        self.vertices.push(Vertex2D {
             position: [b.x, b.y],
         });
     }
@@ -64,6 +64,82 @@ impl Default for VertexDataBuilder {
 
 pub fn geometry_to_vertices(segments: impl Iterator<Item = [Vec2; 2]>) -> VertexData {
     let mut builder = VertexDataBuilder::new();
+    for segment in segments {
+        builder.push_segment(segment);
+    }
+    builder.finish()
+}
+
+pub struct VertexData3D {
+    pub vertices: Vec<Vertex3D>,
+    pub bounds_min: [f32; 3],
+    pub bounds_max: [f32; 3],
+}
+
+pub struct VertexDataBuilder3D {
+    min_x: f32,
+    min_y: f32,
+    min_z: f32,
+    max_x: f32,
+    max_y: f32,
+    max_z: f32,
+    vertices: Vec<Vertex3D>,
+}
+
+impl VertexDataBuilder3D {
+    pub fn new() -> Self {
+        Self {
+            min_x: f32::INFINITY,
+            min_y: f32::INFINITY,
+            min_z: f32::INFINITY,
+            max_x: f32::NEG_INFINITY,
+            max_y: f32::NEG_INFINITY,
+            max_z: f32::NEG_INFINITY,
+            vertices: Vec::new(),
+        }
+    }
+
+    pub fn push_segment(&mut self, [a, b]: [Vec3; 2]) {
+        self.min_x = self.min_x.min(a.x).min(b.x);
+        self.min_y = self.min_y.min(a.y).min(b.y);
+        self.min_z = self.min_z.min(a.z).min(b.z);
+        self.max_x = self.max_x.max(a.x).max(b.x);
+        self.max_y = self.max_y.max(a.y).max(b.y);
+        self.max_z = self.max_z.max(a.z).max(b.z);
+        self.vertices.push(Vertex3D {
+            position: [a.x, a.y, a.z],
+        });
+        self.vertices.push(Vertex3D {
+            position: [b.x, b.y, b.z],
+        });
+    }
+
+    pub fn finish(self) -> VertexData3D {
+        let (bounds_min, bounds_max) = if self.min_x.is_infinite() {
+            ([-1.0, -1.0, -1.0], [1.0, 1.0, 1.0])
+        } else {
+            (
+                [self.min_x, self.min_y, self.min_z],
+                [self.max_x, self.max_y, self.max_z],
+            )
+        };
+
+        VertexData3D {
+            vertices: self.vertices,
+            bounds_min,
+            bounds_max,
+        }
+    }
+}
+
+impl Default for VertexDataBuilder3D {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+pub fn geometry_to_vertices_3d(segments: impl Iterator<Item = [Vec3; 2]>) -> VertexData3D {
+    let mut builder = VertexDataBuilder3D::new();
     for segment in segments {
         builder.push_segment(segment);
     }

--- a/crates/lsystem-renderer/src/png_export.rs
+++ b/crates/lsystem-renderer/src/png_export.rs
@@ -4,7 +4,7 @@ use std::fmt::{Display, Formatter};
 use futures_channel::oneshot;
 use lsystem_core::Config;
 
-use crate::line_renderer::LinePipeline;
+use crate::line_renderer::LinePipeline2D;
 use crate::lsystem_bridge::{color_params_from_config, geometry_to_vertices, viewport_transform};
 use crate::wgpu_util;
 
@@ -119,7 +119,7 @@ pub async fn render_png(
 
     let total_segments = (data.vertices.len() / 2) as u32;
     let color_params = color_params_from_config(&config.colors.line, total_segments);
-    let mut pipeline = LinePipeline::new(device, FORMAT);
+    let mut pipeline = LinePipeline2D::new(device, FORMAT);
     pipeline.upload(device, queue, &data.vertices, color_params);
     pipeline.write_transform(
         queue,

--- a/crates/lsystem-renderer/src/png_export.rs
+++ b/crates/lsystem-renderer/src/png_export.rs
@@ -4,8 +4,11 @@ use std::fmt::{Display, Formatter};
 use futures_channel::oneshot;
 use lsystem_core::Config;
 
-use crate::line_renderer::LinePipeline2D;
-use crate::lsystem_bridge::{color_params_from_config, geometry_to_vertices, viewport_transform};
+use crate::camera::Camera;
+use crate::line_renderer::{LinePipeline2D, LinePipeline3D};
+use crate::lsystem_bridge::{
+    color_params_from_config, geometry_to_vertices, geometry_to_vertices_3d, viewport_transform,
+};
 use crate::wgpu_util;
 
 const FORMAT: wgpu::TextureFormat = wgpu::TextureFormat::Rgba8UnormSrgb;
@@ -61,6 +64,7 @@ impl Error for PngExportError {}
 pub async fn render_png_standalone(
     config: &Config,
     width: u32,
+    camera: &Camera,
 ) -> Result<PngExport, PngExportError> {
     let instance = wgpu_util::new_instance().await;
     let adapter = instance
@@ -83,7 +87,7 @@ pub async fn render_png_standalone(
         .map_err(PngExportError::RequestDevice)?;
     wgpu_util::install_uncaptured_error_handler(&device, "PNG export");
 
-    render_png(&device, &queue, config, width).await
+    render_png(&device, &queue, config, width, camera).await
 }
 
 pub async fn render_png(
@@ -91,17 +95,77 @@ pub async fn render_png(
     queue: &wgpu::Queue,
     config: &Config,
     width: u32,
+    camera: &Camera,
 ) -> Result<PngExport, PngExportError> {
     validate_width(width)?;
 
-    let data = geometry_to_vertices(lsystem_core::generate(config));
-    let height = derive_height(width, data.bounds_min, data.bounds_max)?;
+    if config.dimensions == 3 {
+        let data = geometry_to_vertices_3d(lsystem_core::generate_3d(config));
+        let height = width; // square viewport for perspective
+        let total_segments = (data.vertices.len() / 2) as u32;
+        let color_params = color_params_from_config(&config.colors.line, total_segments);
+        let mut pipeline = LinePipeline3D::new(device, FORMAT);
+        pipeline.upload(device, queue, &data.vertices, color_params);
+        pipeline.write_mvp(
+            queue,
+            camera.compute_mvp_3d(data.bounds_min, data.bounds_max, width, height),
+        );
+        finish_render(
+            device,
+            queue,
+            width,
+            height,
+            config.colors.background,
+            |pass| {
+                pipeline.draw(pass);
+            },
+        )
+        .await
+    } else {
+        let data = geometry_to_vertices(lsystem_core::generate(config));
+        let height = derive_height(width, data.bounds_min, data.bounds_max)?;
+        let total_segments = (data.vertices.len() / 2) as u32;
+        let color_params = color_params_from_config(&config.colors.line, total_segments);
+        let mut pipeline = LinePipeline2D::new(device, FORMAT);
+        pipeline.upload(device, queue, &data.vertices, color_params);
+        pipeline.write_transform(
+            queue,
+            viewport_transform(
+                data.bounds_min,
+                data.bounds_max,
+                width,
+                height,
+                [0.0, 0.0],
+                1.0,
+            ),
+        );
+        finish_render(
+            device,
+            queue,
+            width,
+            height,
+            config.colors.background,
+            |pass| {
+                pipeline.draw(pass);
+            },
+        )
+        .await
+    }
+}
+
+async fn finish_render(
+    device: &wgpu::Device,
+    queue: &wgpu::Queue,
+    width: u32,
+    height: u32,
+    background: [f32; 3],
+    draw: impl FnOnce(&mut wgpu::RenderPass<'_>),
+) -> Result<PngExport, PngExportError> {
     let extent = wgpu::Extent3d {
         width,
         height,
         depth_or_array_layers: 1,
     };
-
     let texture = device.create_texture(&wgpu::TextureDescriptor {
         label: Some("png_export_texture"),
         size: extent,
@@ -117,22 +181,6 @@ pub async fn render_png(
         ..Default::default()
     });
 
-    let total_segments = (data.vertices.len() / 2) as u32;
-    let color_params = color_params_from_config(&config.colors.line, total_segments);
-    let mut pipeline = LinePipeline2D::new(device, FORMAT);
-    pipeline.upload(device, queue, &data.vertices, color_params);
-    pipeline.write_transform(
-        queue,
-        viewport_transform(
-            data.bounds_min,
-            data.bounds_max,
-            width,
-            height,
-            [0.0, 0.0],
-            1.0,
-        ),
-    );
-
     let readback_layout = ReadbackLayout::new(width, height);
     let readback = device.create_buffer(&wgpu::BufferDescriptor {
         label: Some("png_export_readback"),
@@ -145,7 +193,7 @@ pub async fn render_png(
         label: Some("png_export_encoder"),
     });
     {
-        let [r, g, b] = config.colors.background;
+        let [r, g, b] = background;
         let mut pass = encoder.begin_render_pass(&wgpu::RenderPassDescriptor {
             label: Some("png_export_pass"),
             color_attachments: &[Some(wgpu::RenderPassColorAttachment {
@@ -167,7 +215,7 @@ pub async fn render_png(
             timestamp_writes: None,
             multiview_mask: None,
         });
-        pipeline.draw(&mut pass);
+        draw(&mut pass);
     }
     encoder.copy_texture_to_buffer(
         texture.as_image_copy(),

--- a/crates/lsystem-renderer/src/shader3d.wgsl
+++ b/crates/lsystem-renderer/src/shader3d.wgsl
@@ -1,0 +1,80 @@
+struct Mvp {
+    matrix: mat4x4<f32>,
+}
+
+struct ColorParams {
+    mode: u32,
+    total_segments: u32,
+    _pad0: u32,
+    _pad1: u32,
+    color_start: vec4<f32>,
+    color_end: vec4<f32>,
+    hue_start: f32,
+    saturation: f32,
+    value: f32,
+    _pad2: f32,
+}
+
+@group(0) @binding(0)
+var<uniform> mvp: Mvp;
+
+@group(0) @binding(1)
+var<uniform> color_params: ColorParams;
+
+fn hsv_to_rgb(h: f32, s: f32, v: f32) -> vec3<f32> {
+    let h6 = (h % 360.0) / 60.0;
+    let i = u32(h6) % 6u;
+    let f = h6 - floor(h6);
+    let p = v * (1.0 - s);
+    let q = v * (1.0 - f * s);
+    let t = v * (1.0 - (1.0 - f) * s);
+    switch i {
+        case 0u: { return vec3<f32>(v, t, p); }
+        case 1u: { return vec3<f32>(q, v, p); }
+        case 2u: { return vec3<f32>(p, v, t); }
+        case 3u: { return vec3<f32>(p, q, v); }
+        case 4u: { return vec3<f32>(t, p, v); }
+        default: { return vec3<f32>(v, p, q); }
+    }
+}
+
+struct VertexOutput {
+    @builtin(position) clip_position: vec4<f32>,
+    @location(0) color: vec4<f32>,
+}
+
+@vertex
+fn vs_main(
+    @builtin(vertex_index) vi: u32,
+    @location(0) position: vec3<f32>,
+) -> VertexOutput {
+    let denom = max(color_params.total_segments, 2u) - 1u;
+    let t = f32(vi / 2u) / f32(denom);
+
+    var color: vec4<f32>;
+    switch color_params.mode {
+        case 1u: {
+            color = mix(color_params.color_start, color_params.color_end, t);
+        }
+        case 2u: {
+            let hue = color_params.hue_start + t * 360.0;
+            color = vec4<f32>(
+                hsv_to_rgb(hue, color_params.saturation, color_params.value),
+                1.0,
+            );
+        }
+        default: {
+            color = color_params.color_start;
+        }
+    }
+
+    var out: VertexOutput;
+    out.clip_position = mvp.matrix * vec4<f32>(position, 1.0);
+    out.color = color;
+    return out;
+}
+
+@fragment
+fn fs_main(in: VertexOutput) -> @location(0) vec4<f32> {
+    return in.color;
+}

--- a/crates/lsystem-web-app/src/app.rs
+++ b/crates/lsystem-web-app/src/app.rs
@@ -1,4 +1,4 @@
-use std::cell::RefCell;
+use std::cell::{Cell, RefCell};
 use std::rc::Rc;
 use std::sync::Arc;
 
@@ -11,6 +11,9 @@ use wasm_bindgen::closure::Closure;
 use crate::export::{export_png, export_svg};
 use crate::presets::{apply_toml, effective_config, load_presets};
 use crate::renderer::{CanvasRenderer, RenderStatus};
+
+const ROTATION_STEP_DEG: f32 = 5.0;
+const AUTO_ROTATE_DT_MS: f32 = 16.0;
 
 #[component]
 pub(crate) fn App() -> impl IntoView {
@@ -32,10 +35,20 @@ pub(crate) fn App() -> impl IntoView {
     let (angle, set_angle) = signal(initial.config.angle);
     let (png_width, set_png_width) = signal(2048u32);
     let (gpu_error, set_gpu_error) = signal(None::<String>);
+    let (auto_rotate, set_auto_rotate) = signal(false);
+    let (auto_rotate_speed, set_auto_rotate_speed) = signal(45.0f32);
+
+    let is_3d = move || {
+        base_config
+            .get()
+            .map(|c| c.dimensions == 3)
+            .unwrap_or(false)
+    };
 
     let canvas_ref = NodeRef::<Canvas>::new();
     let renderer = Rc::new(RefCell::new(None::<CanvasRenderer>));
     let last_pointer = Rc::new(RefCell::new(None::<(i32, f64, f64)>));
+    let interval_id: Rc<Cell<Option<i32>>> = Rc::new(Cell::new(None));
 
     let recover_after_render = {
         let renderer = Rc::clone(&renderer);
@@ -152,6 +165,52 @@ pub(crate) fn App() -> impl IntoView {
     };
     let apply_text = Rc::new(apply_text);
 
+    let toggle_auto_rotate = {
+        let renderer = Rc::clone(&renderer);
+        let recover_after_render = Rc::clone(&recover_after_render);
+        let interval_id = Rc::clone(&interval_id);
+        move |_: web_sys::MouseEvent| {
+            if auto_rotate.get() {
+                if let Some(id) = interval_id.take()
+                    && let Some(window) = web_sys::window()
+                {
+                    window.clear_interval_with_handle(id);
+                }
+                set_auto_rotate.set(false);
+            } else {
+                set_auto_rotate.set(true);
+                let renderer = Rc::clone(&renderer);
+                let recover_after_render = Rc::clone(&recover_after_render);
+                let interval_id_store = Rc::clone(&interval_id);
+                let interval_id_cancel = Rc::clone(&interval_id);
+                let closure = Closure::<dyn FnMut()>::new(move || {
+                    let degrees = auto_rotate_speed.get() * (AUTO_ROTATE_DT_MS / 1000.0);
+                    if let Some(canvas) = canvas_ref.get() {
+                        with_renderer(canvas, &renderer, &recover_after_render, |r, c| {
+                            r.auto_rotate_and_render(c, degrees)
+                        });
+                    }
+                    // Stop if auto_rotate signal was turned off from outside.
+                    if !auto_rotate.get()
+                        && let Some(id) = interval_id_cancel.take()
+                        && let Some(window) = web_sys::window()
+                    {
+                        window.clear_interval_with_handle(id);
+                    }
+                });
+                if let Some(window) = web_sys::window()
+                    && let Ok(id) = window.set_interval_with_callback_and_timeout_and_arguments_0(
+                        closure.as_ref().unchecked_ref(),
+                        AUTO_ROTATE_DT_MS as i32,
+                    )
+                {
+                    interval_id_store.set(Some(id));
+                }
+                closure.forget();
+            }
+        }
+    };
+
     let preset_options = presets
         .iter()
         .enumerate()
@@ -266,7 +325,11 @@ pub(crate) fn App() -> impl IntoView {
                     />
 
                     <div class="export-row">
-                        <button type="button" on:click=move |_| export_svg(base_config.get(), iterations.get(), angle.get())>
+                        <button
+                            type="button"
+                            class:hidden=move || is_3d()
+                            on:click=move |_| export_svg(base_config.get(), iterations.get(), angle.get())
+                        >
                             "Export SVG"
                         </button>
                         <button
@@ -286,6 +349,31 @@ pub(crate) fn App() -> impl IntoView {
                         >
                             "Export PNG"
                         </button>
+                    </div>
+
+                    <div class:hidden=move || !is_3d()>
+                        <button
+                            type="button"
+                            on:click=toggle_auto_rotate
+                        >
+                            {move || if auto_rotate.get() { "Auto-rotate: On" } else { "Auto-rotate: Off" }}
+                        </button>
+                        <label for="auto-rotate-speed">"Speed (°/s)"</label>
+                        <div class="row">
+                            <input
+                                id="auto-rotate-speed"
+                                type="range"
+                                min="10"
+                                max="360"
+                                step="10"
+                                prop:value=move || auto_rotate_speed.get().to_string()
+                                on:input=move |ev| {
+                                    let next = input_value(ev).parse::<f32>().unwrap_or(45.0);
+                                    set_auto_rotate_speed.set(next.clamp(10.0, 360.0));
+                                }
+                            />
+                            <output>{move || format!("{:.0}", auto_rotate_speed.get())}</output>
+                        </div>
                     </div>
                 </div>
             </aside>
@@ -332,7 +420,7 @@ pub(crate) fn App() -> impl IntoView {
                                     &renderer,
                                     &recover_after_render,
                                     |renderer, canvas| {
-                                        renderer.pan_and_render(canvas, dx as f32, dy as f32)
+                                        renderer.drag_and_render(canvas, dx as f32, dy as f32)
                                     },
                                 );
                             }
@@ -378,15 +466,46 @@ pub(crate) fn App() -> impl IntoView {
                         let renderer = Rc::clone(&renderer);
                         let recover_after_render = Rc::clone(&recover_after_render);
                         move |ev: web_sys::KeyboardEvent| {
-                            if ev.key().eq_ignore_ascii_case("f")
-                                && let Some(canvas) = canvas_ref.get()
-                            {
+                            let Some(canvas) = canvas_ref.get() else { return };
+                            let key = ev.key();
+                            if key.eq_ignore_ascii_case("f") {
                                 with_renderer(
                                     canvas,
                                     &renderer,
                                     &recover_after_render,
                                     |renderer, canvas| renderer.reset_and_render(canvas),
                                 );
+                            } else if is_3d() {
+                                let handled = match key.as_str() {
+                                    "ArrowLeft" => {
+                                        with_renderer(canvas, &renderer, &recover_after_render, |r, c| r.orbit_and_render(c, -ROTATION_STEP_DEG, 0.0));
+                                        true
+                                    }
+                                    "ArrowRight" => {
+                                        with_renderer(canvas, &renderer, &recover_after_render, |r, c| r.orbit_and_render(c, ROTATION_STEP_DEG, 0.0));
+                                        true
+                                    }
+                                    "ArrowUp" => {
+                                        with_renderer(canvas, &renderer, &recover_after_render, |r, c| r.orbit_and_render(c, 0.0, ROTATION_STEP_DEG));
+                                        true
+                                    }
+                                    "ArrowDown" => {
+                                        with_renderer(canvas, &renderer, &recover_after_render, |r, c| r.orbit_and_render(c, 0.0, -ROTATION_STEP_DEG));
+                                        true
+                                    }
+                                    "q" | "Q" => {
+                                        with_renderer(canvas, &renderer, &recover_after_render, |r, c| r.roll_and_render(c, -ROTATION_STEP_DEG));
+                                        true
+                                    }
+                                    "e" | "E" => {
+                                        with_renderer(canvas, &renderer, &recover_after_render, |r, c| r.roll_and_render(c, ROTATION_STEP_DEG));
+                                        true
+                                    }
+                                    _ => false,
+                                };
+                                if handled {
+                                    ev.prevent_default();
+                                }
                             }
                         }
                     }

--- a/crates/lsystem-web-app/src/app.rs
+++ b/crates/lsystem-web-app/src/app.rs
@@ -148,14 +148,24 @@ pub(crate) fn App() -> impl IntoView {
 
     let apply_text = {
         let render_current = Rc::clone(&render_current);
+        let interval_id = Rc::clone(&interval_id);
         move |text: String| match apply_toml(&text) {
             Ok(applied) => {
                 let max = applied.max_iterations;
+                let new_is_3d = applied.config.dimensions == 3;
                 set_max_iterations.set(max);
                 set_iterations.set(applied.config.iterations.min(max));
                 set_angle.set(applied.config.angle);
                 set_base_config.set(Some(applied.config));
                 set_error.set(None);
+                if !new_is_3d && auto_rotate.get() {
+                    if let Some(id) = interval_id.take()
+                        && let Some(window) = web_sys::window()
+                    {
+                        window.clear_interval_with_handle(id);
+                    }
+                    set_auto_rotate.set(false);
+                }
                 render_current();
             }
             Err(err) => {

--- a/crates/lsystem-web-app/src/export.rs
+++ b/crates/lsystem-web-app/src/export.rs
@@ -32,16 +32,17 @@ pub(crate) fn export_png(
     let Some(config) = effective_config(config, iterations, angle) else {
         return;
     };
-    let Some((device, queue)) = renderer
-        .borrow()
-        .as_ref()
-        .map(|renderer| renderer.device_queue())
-    else {
+    let Some((device, queue, camera)) = renderer.borrow().as_ref().map(|renderer| {
+        let (device, queue) = renderer.device_queue();
+        (device, queue, renderer.camera())
+    }) else {
         return;
     };
     let filename = sanitize_filename(&config.name, "png");
     wasm_bindgen_futures::spawn_local(async move {
-        match lsystem_renderer::png_export::render_png(&device, &queue, &config, width).await {
+        match lsystem_renderer::png_export::render_png(&device, &queue, &config, width, &camera)
+            .await
+        {
             Ok(png) => {
                 let array = js_sys::Array::new();
                 let bytes = js_sys::Uint8Array::from(png.bytes.as_slice());

--- a/crates/lsystem-web-app/src/presets.rs
+++ b/crates/lsystem-web-app/src/presets.rs
@@ -26,11 +26,12 @@ pub(crate) fn load_presets() -> Vec<(String, &'static str)> {
 
 pub(crate) fn apply_toml(text: &str) -> Result<AppliedConfig, lsystem_core::ConfigError> {
     let config = Config::parse(text)?;
-    let max_iterations = lsystem_core::max_safe_iterations(
-        &config.axiom,
-        &config.rules,
-        lsystem_renderer::line_renderer::MAX_SEGMENTS,
-    );
+    let max_seg = if config.dimensions == 3 {
+        lsystem_renderer::line_renderer::MAX_SEGMENTS_3D
+    } else {
+        lsystem_renderer::line_renderer::MAX_SEGMENTS
+    };
+    let max_iterations = lsystem_core::max_safe_iterations(&config.axiom, &config.rules, max_seg);
     Ok(AppliedConfig {
         config,
         max_iterations,

--- a/crates/lsystem-web-app/src/renderer.rs
+++ b/crates/lsystem-web-app/src/renderer.rs
@@ -3,20 +3,33 @@ use std::sync::Arc;
 use lsystem_core::Config;
 use lsystem_renderer::camera::Camera;
 use lsystem_renderer::line_renderer::{
-    ColorParams, FrameOutcome, FrameSkipReason, GpuContext, GpuInitError, LinePipeline,
-    SurfaceFrame, Vertex,
+    ColorParams, FrameOutcome, FrameSkipReason, GpuContext, GpuInitError, LinePipeline2D,
+    LinePipeline3D, SurfaceFrame, Vertex2D, Vertex3D,
 };
 use lsystem_renderer::lsystem_bridge::{
-    VertexData, color_params_from_config, geometry_to_vertices,
+    VertexData, VertexData3D, color_params_from_config, geometry_to_vertices,
+    geometry_to_vertices_3d,
 };
+
+enum ActiveScene {
+    TwoD {
+        vertices: Vec<Vertex2D>,
+        bounds_min: [f32; 2],
+        bounds_max: [f32; 2],
+    },
+    ThreeD {
+        vertices: Vec<Vertex3D>,
+        bounds_min: [f32; 3],
+        bounds_max: [f32; 3],
+    },
+}
 
 pub struct CanvasRenderer {
     gpu: GpuContext,
-    pipeline: LinePipeline,
+    pipeline_2d: LinePipeline2D,
+    pipeline_3d: LinePipeline3D,
     camera: Camera,
-    vertices: Vec<Vertex>,
-    bounds_min: [f32; 2],
-    bounds_max: [f32; 2],
+    scene: ActiveScene,
     color_params: ColorParams,
     background: wgpu::Color,
     needs_upload: bool,
@@ -33,14 +46,18 @@ impl CanvasRenderer {
     pub async fn new(canvas: web_sys::HtmlCanvasElement) -> Result<Self, GpuInitError> {
         let (width, height, _) = sync_canvas_size(&canvas);
         let gpu = GpuContext::new(wgpu::SurfaceTarget::Canvas(canvas), width, height).await?;
-        let pipeline = LinePipeline::new(&gpu.device, gpu.surface_format());
+        let pipeline_2d = LinePipeline2D::new(&gpu.device, gpu.surface_format());
+        let pipeline_3d = LinePipeline3D::new(&gpu.device, gpu.surface_format());
         Ok(Self {
             gpu,
-            pipeline,
+            pipeline_2d,
+            pipeline_3d,
             camera: Camera::new(),
-            vertices: Vec::new(),
-            bounds_min: [-1.0, -1.0],
-            bounds_max: [1.0, 1.0],
+            scene: ActiveScene::TwoD {
+                vertices: Vec::new(),
+                bounds_min: [-1.0, -1.0],
+                bounds_max: [1.0, 1.0],
+            },
             color_params: ColorParams::default(),
             background: wgpu::Color::BLACK,
             needs_upload: false,
@@ -52,13 +69,33 @@ impl CanvasRenderer {
         canvas: &web_sys::HtmlCanvasElement,
         config: &Config,
     ) -> RenderStatus {
-        let VertexData {
-            vertices,
-            bounds_min,
-            bounds_max,
-        } = geometry_to_vertices(lsystem_core::generate(config));
+        let total_segments;
+        if config.dimensions == 3 {
+            let VertexData3D {
+                vertices,
+                bounds_min,
+                bounds_max,
+            } = geometry_to_vertices_3d(lsystem_core::generate_3d(config));
+            total_segments = (vertices.len() / 2) as u32;
+            self.scene = ActiveScene::ThreeD {
+                vertices,
+                bounds_min,
+                bounds_max,
+            };
+        } else {
+            let VertexData {
+                vertices,
+                bounds_min,
+                bounds_max,
+            } = geometry_to_vertices(lsystem_core::generate(config));
+            total_segments = (vertices.len() / 2) as u32;
+            self.scene = ActiveScene::TwoD {
+                vertices,
+                bounds_min,
+                bounds_max,
+            };
+        }
 
-        let total_segments = (vertices.len() / 2) as u32;
         self.color_params = color_params_from_config(&config.colors.line, total_segments);
         let [r, g, b] = config.colors.background;
         self.background = wgpu::Color {
@@ -67,31 +104,40 @@ impl CanvasRenderer {
             b: b as f64,
             a: 1.0,
         };
-        self.vertices = vertices;
-        self.bounds_min = bounds_min;
-        self.bounds_max = bounds_max;
         self.camera.reset();
         self.needs_upload = true;
         self.render(canvas)
     }
 
-    pub fn pan_and_render(
+    pub fn drag_and_render(
         &mut self,
         canvas: &web_sys::HtmlCanvasElement,
         css_dx: f32,
         css_dy: f32,
     ) -> RenderStatus {
-        let (_, _, dpr) = sync_canvas_size(canvas);
-        let width = canvas.width().max(1);
-        let height = canvas.height().max(1);
-        self.camera.pan_by_pixels(
-            css_dx * dpr,
-            css_dy * dpr,
-            self.bounds_min,
-            self.bounds_max,
-            width,
-            height,
-        );
+        match &self.scene {
+            ActiveScene::TwoD {
+                bounds_min,
+                bounds_max,
+                ..
+            } => {
+                let (_, _, dpr) = sync_canvas_size(canvas);
+                let width = canvas.width().max(1);
+                let height = canvas.height().max(1);
+                self.camera.pan_by_pixels(
+                    css_dx * dpr,
+                    css_dy * dpr,
+                    *bounds_min,
+                    *bounds_max,
+                    width,
+                    height,
+                );
+            }
+            ActiveScene::ThreeD { .. } => {
+                let (_, _, dpr) = sync_canvas_size(canvas);
+                self.camera.orbit_by_pixels(css_dx * dpr, css_dy * dpr);
+            }
+        }
         self.render(canvas)
     }
 
@@ -105,20 +151,59 @@ impl CanvasRenderer {
     ) -> RenderStatus {
         let (_, _, dpr) = sync_canvas_size(canvas);
         let rect = canvas.get_bounding_client_rect();
-        let cursor = [
-            (client_x as f64 - rect.left()) as f32 * dpr,
-            (client_y as f64 - rect.top()) as f32 * dpr,
-        ];
         let pixel_delta_y = normalize_wheel_delta_y(delta_y, delta_mode, rect.height() as f32);
         let factor = 1.1_f32.powf(-pixel_delta_y / 100.0);
-        self.camera.zoom_toward_cursor(
-            factor,
-            cursor,
-            self.bounds_min,
-            self.bounds_max,
-            canvas.width().max(1),
-            canvas.height().max(1),
-        );
+        match &self.scene {
+            ActiveScene::TwoD {
+                bounds_min,
+                bounds_max,
+                ..
+            } => {
+                let cursor = [
+                    (client_x as f64 - rect.left()) as f32 * dpr,
+                    (client_y as f64 - rect.top()) as f32 * dpr,
+                ];
+                self.camera.zoom_toward_cursor(
+                    factor,
+                    cursor,
+                    *bounds_min,
+                    *bounds_max,
+                    canvas.width().max(1),
+                    canvas.height().max(1),
+                );
+            }
+            ActiveScene::ThreeD { .. } => {
+                self.camera.zoom_3d(factor);
+            }
+        }
+        self.render(canvas)
+    }
+
+    pub fn orbit_and_render(
+        &mut self,
+        canvas: &web_sys::HtmlCanvasElement,
+        d_az: f32,
+        d_el: f32,
+    ) -> RenderStatus {
+        self.camera.orbit_by(d_az, d_el);
+        self.render(canvas)
+    }
+
+    pub fn roll_and_render(
+        &mut self,
+        canvas: &web_sys::HtmlCanvasElement,
+        degrees: f32,
+    ) -> RenderStatus {
+        self.camera.roll_by(degrees);
+        self.render(canvas)
+    }
+
+    pub fn auto_rotate_and_render(
+        &mut self,
+        canvas: &web_sys::HtmlCanvasElement,
+        degrees: f32,
+    ) -> RenderStatus {
+        self.camera.auto_rotate_by(degrees);
         self.render(canvas)
     }
 
@@ -150,7 +235,8 @@ impl CanvasRenderer {
         let (width, height, _) = sync_canvas_size(&canvas);
         let gpu =
             GpuContext::new(wgpu::SurfaceTarget::Canvas(canvas.clone()), width, height).await?;
-        self.pipeline = LinePipeline::new(&gpu.device, gpu.surface_format());
+        self.pipeline_2d = LinePipeline2D::new(&gpu.device, gpu.surface_format());
+        self.pipeline_3d = LinePipeline3D::new(&gpu.device, gpu.surface_format());
         self.gpu = gpu;
         self.needs_upload = true;
         Ok(self.render(&canvas))
@@ -168,24 +254,56 @@ impl CanvasRenderer {
             reconfigure_after_present,
         } = frame;
 
-        if self.needs_upload {
-            self.pipeline.upload(
-                &self.gpu.device,
-                &self.gpu.queue,
-                &self.vertices,
-                self.color_params,
-            );
-            self.needs_upload = false;
+        match &self.scene {
+            ActiveScene::TwoD {
+                vertices,
+                bounds_min,
+                bounds_max,
+            } => {
+                if self.needs_upload {
+                    self.pipeline_2d.upload(
+                        &self.gpu.device,
+                        &self.gpu.queue,
+                        vertices,
+                        self.color_params,
+                    );
+                    self.needs_upload = false;
+                }
+                self.pipeline_2d.write_transform(
+                    &self.gpu.queue,
+                    self.camera.compute_transform(
+                        *bounds_min,
+                        *bounds_max,
+                        width.max(1),
+                        height.max(1),
+                    ),
+                );
+            }
+            ActiveScene::ThreeD {
+                vertices,
+                bounds_min,
+                bounds_max,
+            } => {
+                if self.needs_upload {
+                    self.pipeline_3d.upload(
+                        &self.gpu.device,
+                        &self.gpu.queue,
+                        vertices,
+                        self.color_params,
+                    );
+                    self.needs_upload = false;
+                }
+                self.pipeline_3d.write_mvp(
+                    &self.gpu.queue,
+                    self.camera.compute_mvp_3d(
+                        *bounds_min,
+                        *bounds_max,
+                        width.max(1),
+                        height.max(1),
+                    ),
+                );
+            }
         }
-        self.pipeline.write_transform(
-            &self.gpu.queue,
-            self.camera.compute_transform(
-                self.bounds_min,
-                self.bounds_max,
-                width.max(1),
-                height.max(1),
-            ),
-        );
 
         {
             let mut pass = encoder.begin_render_pass(&wgpu::RenderPassDescriptor {
@@ -204,7 +322,10 @@ impl CanvasRenderer {
                 timestamp_writes: None,
                 multiview_mask: None,
             });
-            self.pipeline.draw(&mut pass);
+            match &self.scene {
+                ActiveScene::TwoD { .. } => self.pipeline_2d.draw(&mut pass),
+                ActiveScene::ThreeD { .. } => self.pipeline_3d.draw(&mut pass),
+            }
         }
 
         self.gpu

--- a/crates/lsystem-web-app/src/renderer.rs
+++ b/crates/lsystem-web-app/src/renderer.rs
@@ -246,6 +246,10 @@ impl CanvasRenderer {
         (Arc::clone(&self.gpu.device), Arc::clone(&self.gpu.queue))
     }
 
+    pub fn camera(&self) -> Camera {
+        self.camera.clone()
+    }
+
     fn render_frame(&mut self, width: u32, height: u32, frame: SurfaceFrame) {
         let SurfaceFrame {
             frame,

--- a/presets/plant_3d.toml
+++ b/presets/plant_3d.toml
@@ -1,0 +1,14 @@
+name = "3D Plant"
+dimensions = 3
+axiom = "X"
+iterations = 5
+angle = 25.7
+
+[line_color]
+mode = "gradient"
+start = [0.05, 0.25, 0.05]
+end = [0.2, 0.75, 0.15]
+
+[rules]
+X = "F[+X][-X][&X][^X]"
+F = "FF"

--- a/presets/tree_3d.toml
+++ b/presets/tree_3d.toml
@@ -1,0 +1,12 @@
+name = "3D Spiral Tree"
+dimensions = 3
+axiom = "A"
+iterations = 6
+angle = 22.5
+
+[line_color]
+mode = "hue_cycle"
+
+[rules]
+A = "F[&+A][&-A][&/A][&\\A]"
+F = "FF"


### PR DESCRIPTION
## Summary

- Adds `Segments3D<I>` turtle using `glam::Quat` orientation for the 3D-only symbols `& ^ / \` (pitch down/up, roll right/left) alongside the existing 2D set
- Renderer gains `LinePipeline3D` with `Vertex3D` and a 64-byte MVP matrix uniform for perspective projection; `GrowableVertexBuffer` and a shared `draw_line_list()` eliminate duplication with `LinePipeline2D`
- `Camera` extended with orbit (azimuth/elevation), roll, zoom-3D, and auto-rotate; existing 2D pan/zoom is unchanged; `reset_position()` preserves rotation across scene rebuilds while `reset()` (Fit) resets everything
- Both apps updated: mouse drag orbits in 3D instead of panning; arrow keys rotate ±5°; Q/E rolls ±5°; auto-rotate toggle with configurable speed (deg/s); SVG export hidden for 3D configs; PNG export uses the current camera orientation
- Two bundled presets added: `3D Plant` (branching, gradient color) and `3D Spiral Tree` (hue-cycle)
- README updated with 3D alphabet, controls, exporting notes, and new presets; AGENTS.md updated to reflect the implemented architecture