### PR TITLE
Honor 3D initial heading

### DIFF
--- a/crates/lsystem-core/src/config.rs
+++ b/crates/lsystem-core/src/config.rs
@@ -88,7 +88,8 @@ pub struct Config {
     pub angle: f32,
     /// Length of each forward step.
     pub step: f32,
-    /// Turtle heading at the start, in degrees (0 = +X, counter-clockwise positive). 2D only.
+    /// Turtle heading at the start, in degrees (0 = +X, counter-clockwise positive).
+    /// In 3D this is the initial yaw in the XY plane.
     pub initial_heading: f32,
     /// Production rules: single ASCII letter → replacement string.
     pub rules: HashMap<char, String>,

--- a/crates/lsystem-core/src/lib.rs
+++ b/crates/lsystem-core/src/lib.rs
@@ -29,5 +29,5 @@ pub fn generate_3d(config: &Config) -> impl Iterator<Item = [Vec3; 2]> {
         config.rules.clone(),
         config.iterations,
     );
-    turtle::turtle3d::Segments3D::new(chars, config.angle, config.step)
+    turtle::turtle3d::Segments3D::new(chars, config.angle, config.step, config.initial_heading)
 }

--- a/crates/lsystem-core/src/turtle/turtle3d.rs
+++ b/crates/lsystem-core/src/turtle/turtle3d.rs
@@ -11,13 +11,13 @@ pub(crate) struct Segments3D<I: Iterator<Item = char>> {
 }
 
 impl<I: Iterator<Item = char>> Segments3D<I> {
-    pub(crate) fn new(chars: I, angle_deg: f32, step: f32) -> Self {
+    pub(crate) fn new(chars: I, angle_deg: f32, step: f32, initial_heading_deg: f32) -> Self {
         Self {
             chars,
             angle_rad: angle_deg.to_radians(),
             step,
             position: Vec3::ZERO,
-            orientation: Quat::IDENTITY,
+            orientation: Quat::from_rotation_z(initial_heading_deg.to_radians()),
             stack: Vec::new(),
         }
     }
@@ -79,9 +79,14 @@ impl<I: Iterator<Item = char>> Iterator for Segments3D<I> {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::Config;
 
     fn make(axiom: &str, angle_deg: f32) -> Vec<[Vec3; 2]> {
-        Segments3D::new(axiom.chars(), angle_deg, 1.0).collect()
+        make_with_heading(axiom, angle_deg, 0.0)
+    }
+
+    fn make_with_heading(axiom: &str, angle_deg: f32, initial_heading_deg: f32) -> Vec<[Vec3; 2]> {
+        Segments3D::new(axiom.chars(), angle_deg, 1.0, initial_heading_deg).collect()
     }
 
     #[test]
@@ -91,6 +96,37 @@ mod tests {
         let [a, b] = segs[0];
         assert!(a.distance(Vec3::ZERO) < 1e-5);
         assert!(b.distance(Vec3::X) < 1e-5);
+    }
+
+    #[test]
+    fn initial_heading_turns_initial_direction() {
+        let segs = make_with_heading("F", 90.0, 90.0);
+        assert_eq!(segs.len(), 1);
+        let [a, b] = segs[0];
+        assert!(a.distance(Vec3::ZERO) < 1e-5);
+        assert!(b.distance(Vec3::Y) < 1e-5, "end: {b}");
+    }
+
+    #[test]
+    fn generate_3d_uses_config_initial_heading() {
+        let cfg = Config::parse(
+            r#"
+name = "t"
+dimensions = 3
+axiom = "F"
+iterations = 0
+angle = 90.0
+step = 1.0
+initial_heading = 90.0
+"#,
+        )
+        .expect("valid test config");
+
+        let segments: Vec<[Vec3; 2]> = crate::generate_3d(&cfg).collect();
+        assert_eq!(segments.len(), 1);
+        let [a, b] = segments[0];
+        assert!(a.distance(Vec3::ZERO) < 1e-5);
+        assert!(b.distance(Vec3::Y) < 1e-5, "end: {b}");
     }
 
     #[test]

--- a/presets/plant_3d.toml
+++ b/presets/plant_3d.toml
@@ -1,13 +1,14 @@
 name = "3D Plant"
 dimensions = 3
 axiom = "X"
-iterations = 5
-angle = 25.7
+iterations = 6
+angle = 30
+initial_heading = 90.0
 
 [line_color]
 mode = "gradient"
-start = [0.05, 0.25, 0.05]
-end = [0.2, 0.75, 0.15]
+start = [0.35, 0.35, 0.05]
+end = [0.2, 0.85, 0.25]
 
 [rules]
 X = "F[+X][-X][&X][^X]"

--- a/presets/ternary_tree_3d.toml
+++ b/presets/ternary_tree_3d.toml
@@ -3,6 +3,7 @@ dimensions = 3
 axiom = "FA"
 iterations = 8
 angle = 40.0
+initial_heading = 90.0
 
 [line_color]
 mode = "gradient"

--- a/presets/tree_3d.toml
+++ b/presets/tree_3d.toml
@@ -3,6 +3,7 @@ dimensions = 3
 axiom = "A"
 iterations = 7
 angle = 40.0
+initial_heading = 90.0
 
 [line_color]
 mode = "hue_cycle"


### PR DESCRIPTION
## Summary
- Apply initial_heading as the 3D turtle's initial yaw so 90 degrees points the first segment along +Y.
- Update tree-like 3D presets to start growing upward, including the adjusted 3D Plant parameters.
- Add coverage for default 3D heading behavior and config-driven initial_heading wiring.

## Notes
- Existing 3D configs without initial_heading keep the default 0 degree orientation.