### PR TITLE
Add nested config schema

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -52,17 +52,17 @@ Four-crate workspace under `crates/`:
 
 | Module | Role |
 |--------|------|
-| `config.rs` | Parses TOML `Config` struct (including `ColorConfig`/`LineColorConfig` for background and line colors); validates axiom, rules, step/angle finiteness, bracket balance |
+| `config.rs` | Parses nested TOML into a format-preserving `ConfigDocument` backed by `toml_edit::DocumentMut`, validates to `Config` (`GenerationConfig` plus `ColorConfig`/`LineColorConfig`), serializes unchanged documents byte-for-byte, and validates symbols, rules, step/angle finiteness, bracket balance, and per-component RGB color ranges |
 | `alphabet.rs` | Reserved symbols (`F f + - \| [ ]` for 2D; additionally `& ^ / \` for 3D), character set validation per `dimensions` |
 | `grammar.rs` | `expand(axiom, rules, iterations)` → lazy `ExpandIter` char iterator; `expand_owned` → `OwnedExpandIter` (same logic, owns its data via `Vec<char>` so callers need no lifetime) |
 | `turtle/mod.rs` | Declares `turtle2d` and `turtle3d` submodules |
 | `turtle/turtle2d.rs` | `Segments2D<I>` — pull iterator over `[Vec2; 2]` segments; owns position, heading, and bracket stack; yields one segment per `'F'` without collecting |
 | `turtle/turtle3d.rs` | `Segments3D<I>` — pull iterator over `[Vec3; 2]` segments; uses `glam::Quat` orientation (heading = `orientation * Vec3::X`); dispatches `& ^ / \` pitch/roll symbols in addition to the 2D set |
 | `svg_export.rs` | `export_svg(config) -> String` — generates an SVG string; gated behind the `svg` Cargo feature |
-| `lib.rs` | Public API: `generate(config) -> impl Iterator<Item = [Vec2; 2]>` and `generate_3d(config) -> impl Iterator<Item = [Vec3; 2]>`; exposes `svg_export` when the `svg` feature is enabled |
+| `lib.rs` | Public API: `generate(generation_config) -> impl Iterator<Item = [Vec2; 2]>` and `generate_3d(generation_config) -> impl Iterator<Item = [Vec3; 2]>`; exposes `svg_export` when the `svg` feature is enabled |
 
-Data flow (2D): `Config` → `OwnedExpandIter` → `Segments2D` → streaming `[Vec2; 2]` segments.
-Data flow (3D): `Config` → `OwnedExpandIter` → `Segments3D` → streaming `[Vec3; 2]` segments.
+Data flow (2D): `ConfigDocument` → `Config` → `GenerationConfig` → `OwnedExpandIter` → `Segments2D` → streaming `[Vec2; 2]` segments.
+Data flow (3D): `ConfigDocument` → `Config` → `GenerationConfig` → `OwnedExpandIter` → `Segments3D` → streaming `[Vec3; 2]` segments.
 
 ### `lsystem-renderer` — toolkit-independent wgpu renderer
 
@@ -118,6 +118,8 @@ Bundled TOML L-System definitions. New fractals are added here; they are embedde
 - **Iced/wgpu version coupling**: the workspace `wgpu` dependency is pinned to version 29 and Iced is pinned to a specific upstream git revision that uses the same wgpu major version. Do not independently bump `wgpu` or the Iced git revision; update them in lockstep and verify native + wasm builds.
 - **3D turtle uses quaternion orientation**: `Segments3D<I>` stores a `glam::Quat` orientation instead of a scalar heading angle. Heading = `orientation * Vec3::X`; left = `* Vec3::Y`; up = `* Vec3::Z`. Each rotation symbol applies `orientation *= Quat::from_rotation_*(angle)` in local space, so rotations compose correctly regardless of prior orientation.
 - **Whitespace in axiom/rules is stripped**: whitespace inside `axiom` and rule RHS strings is removed before validation and expansion, allowing multi-line formatting in TOML configs.
+- **Format-preserving config documents**: `ConfigDocument` owns a `toml_edit::DocumentMut`, so parsing and serializing an unchanged preset preserves comments, spacing, and string quoting byte-for-byte. New canonical TOML uses the nested schema only: `[metadata]`, `[l-system]`, explicit `[l-system.rules]`, `[turtle]`, `[colors]`, and `[colors.line]`.
+- **Hue-cycle config uses RGB input**: `LineColorConfig::HueCycle { initial }` stores the starting color as an RGB array. SVG export and the renderer derive HSV parameters from that RGB value at the output boundary.
 - **Fractal lives in an Iced shader widget**: `lsystem-app` renders the fractal through `iced::widget::shader`. Iced owns the window, surface, event loop, and render pass; the custom primitive owns only the fractal GPU pipeline state.
 - **Async scene generation**: `FractalApp` schedules geometry generation with `Task::perform` when presets, TOML, iterations, or angle change. Each request gets a monotonic generation token; stale results are ignored, so rapid slider changes do not block the UI with outdated work.
 - **Scene-revision uploads**: `FractalApp::schedule_scene_generation()` increments a monotonic generation token whenever geometry is requested. Completed scene builds store that token as `Scene::revision`; the Iced shader pipeline uploads vertices and color params only when the observed revision changes, while camera transforms are written during prepare.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2317,9 +2317,8 @@ name = "lsystem-core"
 version = "0.1.0"
 dependencies = [
  "glam 0.32.1",
- "serde",
  "thiserror 2.0.18",
- "toml",
+ "toml_edit",
 ]
 
 [[package]]
@@ -4140,12 +4139,10 @@ version = "1.1.2+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "81f3d15e84cbcd896376e6730314d59fb5a87f31e4b038454184435cd57defee"
 dependencies = [
- "indexmap",
  "serde_core",
  "serde_spanned",
  "toml_datetime",
  "toml_parser",
- "toml_writer",
  "winnow",
 ]
 
@@ -4167,6 +4164,7 @@ dependencies = [
  "indexmap",
  "toml_datetime",
  "toml_parser",
+ "toml_writer",
  "winnow",
 ]
 

--- a/README.md
+++ b/README.md
@@ -65,21 +65,30 @@ Any other character is a validation error.
 Each L-System is defined in a TOML file:
 
 ```toml
+[metadata]
 name = "Koch Snowflake"
-dimensions = 2          # 2 (default) or 3
+
+[l-system]
+dimensions = 2          # 2 or 3
 axiom = "F++F++F"
 iterations = 4          # number of times the rules are applied
+
+[l-system.rules]
+F = "F-F++F-F"          # each F is replaced by this string each iteration
+
+[turtle]
 angle = 60.0            # degrees; used by + - and |
 step = 1.0              # length of each F / f move
 initial_heading = 0.0   # starting direction in degrees (0 = east,
                         # counter-clockwise positive)
 
-background_color = [0.0, 0.0, 0.0]   # RGB 0–1; optional, default black
+[colors]
+background = [0.0, 0.0, 0.0]   # RGB 0-1
 
-[line_color]
-# mode = "solid"          # (default) single color; set with `color`
+[colors.line]
+# mode = "solid"          # single color; set with `color`
 # mode = "gradient"       # linear RGB from `start` to `end` across all segments
-# mode = "hue_cycle"      # full HSV hue rotation across all segments
+# mode = "hue_cycle"      # full hue rotation starting from `initial`
 mode = "solid"
 color = [0.0, 0.9, 0.5]  # used by solid mode
 
@@ -89,16 +98,21 @@ color = [0.0, 0.9, 0.5]  # used by solid mode
 # end   = [0.6, 0.0, 1.0]
 
 # hue_cycle example:
-# mode       = "hue_cycle"
-# start_hue  = 0.0    # degrees, default 0
-# saturation = 1.0    # default 1.0
-# value      = 0.9    # default 0.9
-
-[rules]
-F = "F-F++F-F"          # each F is replaced by this string each iteration
+# mode    = "hue_cycle"
+# initial = [0.9, 0.0, 0.0]
 ```
 
-Color fields are optional — omitting `background_color` or `[line_color]` keeps the defaults (black background, solid teal lines).
+Configuration uses the nested v2 schema only, with explicit `[metadata]`,
+`[l-system]`, `[l-system.rules]`, `[turtle]`, `[colors]`, and `[colors.line]`
+tables. Older flat TOML with top-level `name`, `axiom`, `[rules]`,
+`background_color`, or `[line_color]` is rejected. All colors are RGB arrays
+with finite components in the 0-1 range, including `hue_cycle`'s RGB
+`initial` color.
+
+Config parsing is format-preserving: parsing and serializing an unchanged TOML
+document keeps comments, spacing, and string quoting intact. Newly generated
+TOML writes axiom/rule text as literal strings when possible and keeps color
+arrays inline.
 
 Whitespace inside `axiom` and rule strings is stripped before processing, so
 you can break long rules across lines for readability.
@@ -218,7 +232,7 @@ mise.toml                   pins trunk version (read by CI and local dev)
 crates/
   lsystem-core/             pure Rust, no rendering deps
     src/
-      config.rs             TOML parsing + Config struct
+      config.rs             format-preserving TOML docs + Config/GenerationConfig structs
       alphabet.rs           reserved-symbol sets, validation
       grammar.rs            axiom + rule expansion (N iterations); OwnedExpandIter for lifetime-free streaming
       turtle/

--- a/crates/lsystem-app/src/ui/app_state.rs
+++ b/crates/lsystem-app/src/ui/app_state.rs
@@ -283,10 +283,13 @@ impl FractalApp {
                 } else {
                     lsystem_renderer::line_renderer::MAX_SEGMENTS
                 };
-                self.max_iterations =
-                    lsystem_core::max_safe_iterations(&config.axiom, &config.rules, max_seg) as u32;
-                self.iterations = config.iterations.min(self.max_iterations);
-                self.angle = config.angle;
+                self.max_iterations = lsystem_core::max_safe_iterations(
+                    &config.generation.axiom,
+                    &config.generation.rules,
+                    max_seg,
+                ) as u32;
+                self.iterations = config.generation.iterations.min(self.max_iterations);
+                self.angle = config.generation.angle;
                 self.base_config = Some(config);
                 self.error = None;
                 self.export_status = None;
@@ -303,8 +306,8 @@ impl FractalApp {
 
     fn effective_config(&self) -> Option<Config> {
         self.base_config.clone().map(|mut config| {
-            config.iterations = self.iterations;
-            config.angle = self.angle;
+            config.generation.iterations = self.iterations;
+            config.generation.angle = self.angle;
             config
         })
     }

--- a/crates/lsystem-app/src/ui/fractal_canvas.rs
+++ b/crates/lsystem-app/src/ui/fractal_canvas.rs
@@ -195,7 +195,7 @@ pub(super) async fn build_scene(
         let mut builder = VertexDataBuilder3D::new();
         let mut segments_seen = 0usize;
 
-        for segment in lsystem_core::generate_3d(&config) {
+        for segment in lsystem_core::generate_3d(&config.generation) {
             if segments_seen.is_multiple_of(CANCELLATION_CHECK_INTERVAL) {
                 if is_cancelled(generation, &current_generation) {
                     return SceneBuildResult::Cancelled;
@@ -221,7 +221,7 @@ pub(super) async fn build_scene(
         let mut builder = VertexDataBuilder::new();
         let mut segments_seen = 0usize;
 
-        for segment in lsystem_core::generate(&config) {
+        for segment in lsystem_core::generate(&config.generation) {
             if segments_seen.is_multiple_of(CANCELLATION_CHECK_INTERVAL) {
                 if is_cancelled(generation, &current_generation) {
                     return SceneBuildResult::Cancelled;

--- a/crates/lsystem-core/Cargo.toml
+++ b/crates/lsystem-core/Cargo.toml
@@ -9,6 +9,5 @@ svg = []
 
 [dependencies]
 glam = { workspace = true, features = ["bytemuck"] }
-serde = { version = "1", features = ["derive"] }
-toml = "1"
 thiserror = "2"
+toml_edit = "0.25.11"

--- a/crates/lsystem-core/src/color_util.rs
+++ b/crates/lsystem-core/src/color_util.rs
@@ -1,3 +1,5 @@
+/// Converts an RGB color with components in `0.0..=1.0` to
+/// `(hue_degrees, saturation, value)`.
 pub fn rgb_to_hsv([r, g, b]: [f32; 3]) -> (f32, f32, f32) {
     let max = r.max(g).max(b);
     let min = r.min(g).min(b);
@@ -43,5 +45,32 @@ mod tests {
         assert!(close(hue, 0.0));
         assert!(close(saturation, 0.0));
         assert!(close(value, 0.4));
+    }
+
+    #[test]
+    fn pure_blue_maps_to_blue_hue() {
+        let (hue, saturation, value) = rgb_to_hsv([0.0, 0.0, 1.0]);
+
+        assert!(close(hue, 240.0));
+        assert!(close(saturation, 1.0));
+        assert!(close(value, 1.0));
+    }
+
+    #[test]
+    fn black_has_zero_saturation_and_value() {
+        let (hue, saturation, value) = rgb_to_hsv([0.0, 0.0, 0.0]);
+
+        assert!(close(hue, 0.0));
+        assert!(close(saturation, 0.0));
+        assert!(close(value, 0.0));
+    }
+
+    #[test]
+    fn red_dominant_negative_hue_wraps() {
+        let (hue, saturation, value) = rgb_to_hsv([1.0, 0.0, 0.5]);
+
+        assert!(close(hue, 330.0));
+        assert!(close(saturation, 1.0));
+        assert!(close(value, 1.0));
     }
 }

--- a/crates/lsystem-core/src/color_util.rs
+++ b/crates/lsystem-core/src/color_util.rs
@@ -1,0 +1,47 @@
+pub fn rgb_to_hsv([r, g, b]: [f32; 3]) -> (f32, f32, f32) {
+    let max = r.max(g).max(b);
+    let min = r.min(g).min(b);
+    let delta = max - min;
+
+    let hue = if delta == 0.0 {
+        0.0
+    } else if max == r {
+        60.0 * ((g - b) / delta).rem_euclid(6.0)
+    } else if max == g {
+        60.0 * (((b - r) / delta) + 2.0)
+    } else {
+        60.0 * (((r - g) / delta) + 4.0)
+    };
+
+    let saturation = if max == 0.0 { 0.0 } else { delta / max };
+    (hue, saturation, max)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    const EPS: f32 = 1e-5;
+
+    fn close(a: f32, b: f32) -> bool {
+        (a - b).abs() < EPS
+    }
+
+    #[test]
+    fn converts_rgb_to_hsv() {
+        let (hue, saturation, value) = rgb_to_hsv([0.25, 0.5, 0.5]);
+
+        assert!(close(hue, 180.0));
+        assert!(close(saturation, 0.5));
+        assert!(close(value, 0.5));
+    }
+
+    #[test]
+    fn grayscale_has_zero_saturation_and_hue() {
+        let (hue, saturation, value) = rgb_to_hsv([0.4, 0.4, 0.4]);
+
+        assert!(close(hue, 0.0));
+        assert!(close(saturation, 0.0));
+        assert!(close(value, 0.4));
+    }
+}

--- a/crates/lsystem-core/src/config.rs
+++ b/crates/lsystem-core/src/config.rs
@@ -1,14 +1,26 @@
 use std::collections::HashMap;
 
-use serde::Deserialize;
 use thiserror::Error;
+use toml_edit::{DocumentMut, Item, Table, Value, value};
 
 use crate::alphabet::{validate_bracket_balance, validate_symbols};
 
 #[derive(Debug, Error)]
 pub enum ConfigError {
     #[error("TOML parse error: {0}")]
-    TomlParse(#[from] toml::de::Error),
+    TomlParse(#[from] toml_edit::TomlError),
+
+    #[error("missing required field `{0}`")]
+    MissingField(String),
+
+    #[error("invalid value for `{field}`: expected {expected}")]
+    InvalidField {
+        field: String,
+        expected: &'static str,
+    },
+
+    #[error("unknown field `{0}`")]
+    UnknownField(String),
 
     #[error("rule key {key:?} must be a single ASCII letter")]
     InvalidRuleKey { key: String },
@@ -37,21 +49,23 @@ pub enum ConfigError {
 
     #[error("initial_heading must be finite, got {0}")]
     InvalidInitialHeading(f32),
+
+    #[error(
+        "color component `{component}` in `{field}` must be finite and in 0.0..=1.0, got {value}"
+    )]
+    InvalidColorComponent {
+        field: String,
+        component: usize,
+        value: f32,
+    },
 }
 
 /// Color mode for the fractal lines.
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, PartialEq)]
 pub enum LineColorConfig {
     Solid([f32; 3]),
-    Gradient {
-        start: [f32; 3],
-        end: [f32; 3],
-    },
-    HueCycle {
-        start_hue: f32,
-        saturation: f32,
-        value: f32,
-    },
+    Gradient { start: [f32; 3], end: [f32; 3] },
+    HueCycle { initial: [f32; 3] },
 }
 
 impl Default for LineColorConfig {
@@ -61,7 +75,7 @@ impl Default for LineColorConfig {
 }
 
 /// Visual color settings for background and fractal lines.
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, PartialEq)]
 pub struct ColorConfig {
     pub background: [f32; 3],
     pub line: LineColorConfig,
@@ -77,11 +91,18 @@ impl Default for ColorConfig {
 }
 
 /// Parsed and validated L-System configuration.
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, PartialEq)]
 pub struct Config {
     pub name: String,
     /// Number of spatial dimensions: 2 or 3.
     pub dimensions: u8,
+    pub generation: GenerationConfig,
+    pub colors: ColorConfig,
+}
+
+/// Validated inputs needed to expand an L-system and run the turtle.
+#[derive(Debug, Clone, PartialEq)]
+pub struct GenerationConfig {
     pub axiom: String,
     pub iterations: u32,
     /// Turn angle in degrees.
@@ -93,143 +114,404 @@ pub struct Config {
     pub initial_heading: f32,
     /// Production rules: single ASCII letter → replacement string.
     pub rules: HashMap<char, String>,
-    pub colors: ColorConfig,
 }
 
 impl Config {
     pub fn parse(toml_str: &str) -> Result<Self, ConfigError> {
-        let raw: RawConfig = toml::from_str(toml_str)?;
+        ConfigDocument::parse(toml_str)?.to_config()
+    }
 
-        if raw.dimensions != 2 && raw.dimensions != 3 {
-            return Err(ConfigError::InvalidDimensions(raw.dimensions));
+    pub fn to_toml_string(&self) -> String {
+        ConfigDocument::from_config(self).to_toml_string()
+    }
+}
+
+/// Format-preserving TOML document for an L-system configuration.
+#[derive(Debug, Clone)]
+pub struct ConfigDocument {
+    document: DocumentMut,
+}
+
+impl ConfigDocument {
+    pub fn parse(toml_str: &str) -> Result<Self, ConfigError> {
+        Ok(Self {
+            document: toml_str.parse()?,
+        })
+    }
+
+    pub fn to_config(&self) -> Result<Config, ConfigError> {
+        validate_schema(&self.document)?;
+
+        let metadata = required_table(&self.document, "metadata")?;
+        let l_system = required_table(&self.document, "l-system")?;
+        let rules_table = required_table(l_system, "rules")?;
+        let turtle = required_table(&self.document, "turtle")?;
+        let colors_table = required_table(&self.document, "colors")?;
+        let line_table = required_table(colors_table, "line")?;
+
+        let dimensions = required_u8(l_system, "l-system.dimensions")?;
+
+        if dimensions != 2 && dimensions != 3 {
+            return Err(ConfigError::InvalidDimensions(dimensions));
         }
-        if !raw.step.is_finite() || raw.step <= 0.0 {
-            return Err(ConfigError::InvalidStep(raw.step));
+        let step = required_f32(turtle, "turtle.step")?;
+        let angle = required_f32(turtle, "turtle.angle")?;
+        let initial_heading = required_f32(turtle, "turtle.initial_heading")?;
+        if !step.is_finite() || step <= 0.0 {
+            return Err(ConfigError::InvalidStep(step));
         }
-        if !raw.angle.is_finite() {
-            return Err(ConfigError::InvalidAngle(raw.angle));
+        if !angle.is_finite() {
+            return Err(ConfigError::InvalidAngle(angle));
         }
-        if !raw.initial_heading.is_finite() {
-            return Err(ConfigError::InvalidInitialHeading(raw.initial_heading));
+        if !initial_heading.is_finite() {
+            return Err(ConfigError::InvalidInitialHeading(initial_heading));
         }
 
         // Strip whitespace from axiom and rule RHS, then validate symbols.
-        let axiom: String = raw.axiom.chars().filter(|c| !c.is_whitespace()).collect();
-        validate_symbols(&axiom, "axiom", raw.dimensions)?;
+        let axiom_raw = required_str(l_system, "l-system.axiom")?;
+        let axiom: String = axiom_raw.chars().filter(|c| !c.is_whitespace()).collect();
+        validate_symbols(&axiom, "axiom", dimensions)?;
         validate_bracket_balance(&axiom, "axiom")?;
 
-        let mut rules = HashMap::with_capacity(raw.rules.len());
-        for (key_str, rhs_raw) in raw.rules {
+        let mut rules = HashMap::with_capacity(rules_table.len());
+        for (key_str, item) in rules_table.iter() {
             let mut key_chars = key_str.chars();
             let key = key_chars
                 .next()
                 .filter(|c| c.is_ascii_alphabetic())
                 .ok_or_else(|| ConfigError::InvalidRuleKey {
-                    key: key_str.clone(),
+                    key: key_str.to_string(),
                 })?;
             if key_chars.next().is_some() {
-                return Err(ConfigError::InvalidRuleKey { key: key_str });
+                return Err(ConfigError::InvalidRuleKey {
+                    key: key_str.to_string(),
+                });
             }
 
+            let rhs_raw = item.as_str().ok_or_else(|| ConfigError::InvalidField {
+                field: format!("l-system.rules.{key}"),
+                expected: "string",
+            })?;
             let rhs: String = rhs_raw.chars().filter(|c| !c.is_whitespace()).collect();
-            validate_symbols(&rhs, &format!("rules.{key}"), raw.dimensions)?;
-            validate_bracket_balance(&rhs, &format!("rules.{key}"))?;
+            validate_symbols(&rhs, &format!("l-system.rules.{key}"), dimensions)?;
+            validate_bracket_balance(&rhs, &format!("l-system.rules.{key}"))?;
             rules.insert(key, rhs);
         }
 
-        let colors = ColorConfig {
-            background: raw.background_color.unwrap_or_default(),
-            line: match raw.line_color {
-                None => LineColorConfig::default(),
-                Some(RawLineColor::Solid { color }) => LineColorConfig::Solid(color),
-                Some(RawLineColor::Gradient { start, end }) => {
-                    LineColorConfig::Gradient { start, end }
-                }
-                Some(RawLineColor::HueCycle {
-                    start_hue,
-                    saturation,
-                    value,
-                }) => LineColorConfig::HueCycle {
-                    start_hue,
-                    saturation,
-                    value,
-                },
-            },
+        let background = required_color(colors_table, "colors.background")?;
+        validate_color(background, "colors.background")?;
+
+        let mode = required_str(line_table, "colors.line.mode")?;
+        let line = match mode {
+            "solid" => {
+                validate_keys(line_table, "colors.line", &["mode", "color"])?;
+                let color = required_color(line_table, "colors.line.color")?;
+                validate_color(color, "colors.line.color")?;
+                LineColorConfig::Solid(color)
+            }
+            "gradient" => {
+                validate_keys(line_table, "colors.line", &["mode", "start", "end"])?;
+                let start = required_color(line_table, "colors.line.start")?;
+                let end = required_color(line_table, "colors.line.end")?;
+                validate_color(start, "colors.line.start")?;
+                validate_color(end, "colors.line.end")?;
+                LineColorConfig::Gradient { start, end }
+            }
+            "hue_cycle" => {
+                validate_keys(line_table, "colors.line", &["mode", "initial"])?;
+                let initial = required_color(line_table, "colors.line.initial")?;
+                validate_color(initial, "colors.line.initial")?;
+                LineColorConfig::HueCycle { initial }
+            }
+            _ => {
+                return Err(ConfigError::InvalidField {
+                    field: "colors.line.mode".to_string(),
+                    expected: "\"solid\", \"gradient\", or \"hue_cycle\"",
+                });
+            }
         };
 
+        let colors = ColorConfig { background, line };
+
         Ok(Config {
-            name: raw.name,
-            dimensions: raw.dimensions,
-            axiom,
-            iterations: raw.iterations,
-            angle: raw.angle,
-            step: raw.step,
-            initial_heading: raw.initial_heading,
-            rules,
+            name: required_str(metadata, "metadata.name")?.to_string(),
+            dimensions,
+            generation: GenerationConfig {
+                axiom,
+                iterations: required_u32(l_system, "l-system.iterations")?,
+                angle,
+                step,
+                initial_heading,
+                rules,
+            },
             colors,
         })
     }
+
+    pub fn to_toml_string(&self) -> String {
+        self.document.to_string()
+    }
+
+    pub fn from_config(config: &Config) -> Self {
+        let mut document = DocumentMut::new();
+
+        document["metadata"] = Item::Table(Table::new());
+        document["metadata"]["name"] = value(config.name.clone());
+
+        document["l-system"] = Item::Table(Table::new());
+        document["l-system"]["dimensions"] = value(i64::from(config.dimensions));
+        document["l-system"]["axiom"] = literal_string_item(&config.generation.axiom);
+        document["l-system"]["iterations"] = value(i64::from(config.generation.iterations));
+
+        document["l-system"]["rules"] = Item::Table(Table::new());
+        let mut rules: Vec<_> = config.generation.rules.iter().collect();
+        rules.sort_by_key(|(key, _)| **key);
+        for (key, rhs) in rules {
+            document["l-system"]["rules"][&key.to_string()] = literal_string_item(rhs);
+        }
+
+        document["turtle"] = Item::Table(Table::new());
+        document["turtle"]["angle"] = value(f64::from(config.generation.angle));
+        document["turtle"]["step"] = value(f64::from(config.generation.step));
+        document["turtle"]["initial_heading"] = value(f64::from(config.generation.initial_heading));
+
+        document["colors"] = Item::Table(Table::new());
+        document["colors"]["background"] = color_item(config.colors.background);
+
+        document["colors"]["line"] = Item::Table(Table::new());
+        match &config.colors.line {
+            LineColorConfig::Solid(color) => {
+                document["colors"]["line"]["mode"] = value("solid");
+                document["colors"]["line"]["color"] = color_item(*color);
+            }
+            LineColorConfig::Gradient { start, end } => {
+                document["colors"]["line"]["mode"] = value("gradient");
+                document["colors"]["line"]["start"] = color_item(*start);
+                document["colors"]["line"]["end"] = color_item(*end);
+            }
+            LineColorConfig::HueCycle { initial } => {
+                document["colors"]["line"]["mode"] = value("hue_cycle");
+                document["colors"]["line"]["initial"] = color_item(*initial);
+            }
+        }
+
+        let result = Self { document };
+        result
+            .to_config()
+            .expect("generated config TOML must be valid");
+        result
+    }
 }
 
-#[derive(Deserialize)]
-struct RawConfig {
-    name: String,
-    #[serde(default = "default_dimensions")]
-    dimensions: u8,
-    axiom: String,
-    iterations: u32,
-    angle: f32,
-    #[serde(default = "default_step")]
-    step: f32,
-    #[serde(default)]
-    initial_heading: f32,
-    #[serde(default)]
-    rules: HashMap<String, String>,
-    #[serde(default)]
-    background_color: Option<[f32; 3]>,
-    #[serde(default)]
-    line_color: Option<RawLineColor>,
+impl std::fmt::Display for ConfigDocument {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.write_str(&self.to_toml_string())
+    }
 }
 
-#[derive(Deserialize)]
-#[serde(tag = "mode", rename_all = "snake_case")]
-enum RawLineColor {
-    Solid {
-        #[serde(default = "default_line_color")]
-        color: [f32; 3],
-    },
-    Gradient {
-        start: [f32; 3],
-        end: [f32; 3],
-    },
-    HueCycle {
-        #[serde(default)]
-        start_hue: f32,
-        #[serde(default = "default_saturation")]
-        saturation: f32,
-        #[serde(default = "default_value")]
-        value: f32,
-    },
+fn validate_schema(document: &DocumentMut) -> Result<(), ConfigError> {
+    validate_keys(document, "", &["metadata", "l-system", "turtle", "colors"])?;
+    validate_keys(required_table(document, "metadata")?, "metadata", &["name"])?;
+    validate_keys(
+        required_table(document, "l-system")?,
+        "l-system",
+        &["dimensions", "axiom", "iterations", "rules"],
+    )?;
+    validate_keys(
+        required_table(document, "turtle")?,
+        "turtle",
+        &["angle", "step", "initial_heading"],
+    )?;
+    validate_keys(
+        required_table(document, "colors")?,
+        "colors",
+        &["background", "line"],
+    )?;
+    Ok(())
 }
 
-fn default_dimensions() -> u8 {
-    2
+trait TableLike {
+    fn get_item(&self, key: &str) -> Option<&Item>;
+    fn keys<'a>(&'a self) -> Box<dyn Iterator<Item = &'a str> + 'a>;
 }
 
-fn default_step() -> f32 {
-    1.0
+impl TableLike for DocumentMut {
+    fn get_item(&self, key: &str) -> Option<&Item> {
+        self.get(key)
+    }
+
+    fn keys<'a>(&'a self) -> Box<dyn Iterator<Item = &'a str> + 'a> {
+        Box::new(self.iter().map(|(key, _)| key))
+    }
 }
 
-fn default_line_color() -> [f32; 3] {
-    [0.0, 0.9, 0.5]
+impl TableLike for Table {
+    fn get_item(&self, key: &str) -> Option<&Item> {
+        self.get(key)
+    }
+
+    fn keys<'a>(&'a self) -> Box<dyn Iterator<Item = &'a str> + 'a> {
+        Box::new(self.iter().map(|(key, _)| key))
+    }
 }
 
-fn default_saturation() -> f32 {
-    1.0
+fn validate_keys(table: &impl TableLike, path: &str, allowed: &[&str]) -> Result<(), ConfigError> {
+    for key in table.keys() {
+        if !allowed.contains(&key) {
+            let field = if path.is_empty() {
+                key.to_string()
+            } else {
+                format!("{path}.{key}")
+            };
+            return Err(ConfigError::UnknownField(field));
+        }
+    }
+    Ok(())
 }
 
-fn default_value() -> f32 {
-    0.9
+fn required_item<'a>(table: &'a impl TableLike, field: &str) -> Result<&'a Item, ConfigError> {
+    let key = field.rsplit('.').next().unwrap_or(field);
+    table
+        .get_item(key)
+        .ok_or_else(|| ConfigError::MissingField(field.to_string()))
+}
+
+fn required_table<'a>(table: &'a impl TableLike, field: &str) -> Result<&'a Table, ConfigError> {
+    let table =
+        required_item(table, field)?
+            .as_table()
+            .ok_or_else(|| ConfigError::InvalidField {
+                field: field.to_string(),
+                expected: "table",
+            })?;
+    if table.is_implicit() || table.is_dotted() {
+        return Err(ConfigError::InvalidField {
+            field: field.to_string(),
+            expected: "explicit table",
+        });
+    }
+    Ok(table)
+}
+
+fn required_str<'a>(table: &'a impl TableLike, field: &str) -> Result<&'a str, ConfigError> {
+    required_item(table, field)?
+        .as_str()
+        .ok_or_else(|| ConfigError::InvalidField {
+            field: field.to_string(),
+            expected: "string",
+        })
+}
+
+fn required_u8(table: &impl TableLike, field: &str) -> Result<u8, ConfigError> {
+    let value =
+        required_item(table, field)?
+            .as_integer()
+            .ok_or_else(|| ConfigError::InvalidField {
+                field: field.to_string(),
+                expected: "integer",
+            })?;
+    u8::try_from(value).map_err(|_| ConfigError::InvalidField {
+        field: field.to_string(),
+        expected: "integer in 0..=255",
+    })
+}
+
+fn required_u32(table: &impl TableLike, field: &str) -> Result<u32, ConfigError> {
+    let value =
+        required_item(table, field)?
+            .as_integer()
+            .ok_or_else(|| ConfigError::InvalidField {
+                field: field.to_string(),
+                expected: "integer",
+            })?;
+    u32::try_from(value).map_err(|_| ConfigError::InvalidField {
+        field: field.to_string(),
+        expected: "integer in 0..=4294967295",
+    })
+}
+
+fn required_f32(table: &impl TableLike, field: &str) -> Result<f32, ConfigError> {
+    let item = required_item(table, field)?;
+    let value = if let Some(value) = item.as_float() {
+        value
+    } else if let Some(value) = item.as_integer() {
+        value as f64
+    } else {
+        return Err(ConfigError::InvalidField {
+            field: field.to_string(),
+            expected: "number",
+        });
+    };
+    Ok(value as f32)
+}
+
+fn required_color(table: &impl TableLike, field: &str) -> Result<[f32; 3], ConfigError> {
+    let array =
+        required_item(table, field)?
+            .as_array()
+            .ok_or_else(|| ConfigError::InvalidField {
+                field: field.to_string(),
+                expected: "array of three numbers",
+            })?;
+
+    if array.len() != 3 {
+        return Err(ConfigError::InvalidField {
+            field: field.to_string(),
+            expected: "array of three numbers",
+        });
+    }
+
+    let mut out = [0.0; 3];
+    for (idx, value) in array.iter().enumerate() {
+        out[idx] = value_as_f32(value).ok_or_else(|| ConfigError::InvalidField {
+            field: format!("{field}[{idx}]"),
+            expected: "number",
+        })?;
+    }
+    Ok(out)
+}
+
+fn value_as_f32(value: &Value) -> Option<f32> {
+    value
+        .as_float()
+        .or_else(|| value.as_integer().map(|value| value as f64))
+        .map(|value| value as f32)
+}
+
+fn validate_color(color: [f32; 3], field: &str) -> Result<(), ConfigError> {
+    for (component, value) in color.into_iter().enumerate() {
+        if !value.is_finite() || !(0.0..=1.0).contains(&value) {
+            return Err(ConfigError::InvalidColorComponent {
+                field: field.to_string(),
+                component,
+                value,
+            });
+        }
+    }
+    Ok(())
+}
+
+fn literal_string_item(value: &str) -> Item {
+    if !value.contains('\'') && !value.contains('\n') && !value.contains('\r') {
+        return format!("'{value}'")
+            .parse::<Item>()
+            .expect("validated L-system literal string should parse");
+    }
+    Value::from(value).into()
+}
+
+fn color_item([r, g, b]: [f32; 3]) -> Item {
+    let item = format!("[{}, {}, {}]", toml_float(r), toml_float(g), toml_float(b));
+    item.parse()
+        .expect("validated inline color array should parse")
+}
+
+fn toml_float(value: f32) -> String {
+    if value.fract() == 0.0 {
+        format!("{value:.1}")
+    } else {
+        value.to_string()
+    }
 }
 
 #[cfg(test)]
@@ -249,26 +531,432 @@ step = 1.0
 F = "F-F++F-F"
 "#;
 
-    #[test]
-    fn parses_valid_config() {
-        let cfg = Config::parse(KOCH_TOML).unwrap();
-        assert_eq!(cfg.axiom, "F++F++F");
-        assert_eq!(cfg.angle, 60.0);
-        assert_eq!(cfg.step, 1.0);
-        assert_eq!(cfg.iterations, 4);
-        assert_eq!(cfg.rules[&'F'], "F-F++F-F");
+    const NESTED_KOCH_TOML: &str = r#"
+[metadata]
+name = "Koch Snowflake"
+
+[l-system]
+dimensions = 2
+axiom = "F++F++F"
+iterations = 4
+
+[l-system.rules]
+F = "F-F++F-F"
+
+[turtle]
+angle = 60.0
+step = 1.0
+initial_heading = 0.0
+
+[colors]
+background = [0.0, 0.0, 0.0]
+
+[colors.line]
+mode = "hue_cycle"
+initial = [0.25, 0.5, 0.5]
+"#;
+
+    fn test_toml(
+        dimensions: u8,
+        axiom: &str,
+        iterations: u32,
+        angle: &str,
+        step: &str,
+        initial_heading: &str,
+        rules: &str,
+    ) -> String {
+        let rules_table = format!("\n[l-system.rules]\n{rules}\n");
+        format!(
+            r#"[metadata]
+name = "test"
+
+[l-system]
+dimensions = {dimensions}
+axiom = "{axiom}"
+iterations = {iterations}
+{rules_table}
+[turtle]
+angle = {angle}
+step = {step}
+initial_heading = {initial_heading}
+
+[colors]
+background = [0.0, 0.0, 0.0]
+
+[colors.line]
+mode = "solid"
+color = [0.0, 0.9, 0.5]
+"#
+        )
     }
 
     #[test]
-    fn defaults_missing_step() {
+    fn config_document_preserves_unmodified_toml_byte_for_byte() {
+        let original = r#"# leading comment
+[metadata] # keep this comment
+name = "Styled"
+
+[l-system]
+dimensions = 3
+axiom = 'F\F'
+iterations = 2
+
+[l-system.rules]
+F = 'F\F'
+
+[turtle]
+angle = 22.5
+step = 1.0
+initial_heading = 45.0
+
+[colors]
+background = [ 0.0, 0.1, 0.2 ]
+
+[colors.line]
+mode = "gradient"
+start = [
+    0.1,
+    0.2,
+    0.3,
+]
+end = [ 0.7, 0.8, 0.9 ]
+"#;
+
+        let doc = ConfigDocument::parse(original).unwrap();
+
+        assert_eq!(doc.to_string(), original);
+        assert!(doc.to_config().is_ok());
+    }
+
+    #[test]
+    fn config_uses_generation_config_for_lsystem_and_turtle_fields() {
+        let cfg = Config::parse(NESTED_KOCH_TOML).unwrap();
+
+        assert_eq!(cfg.name, "Koch Snowflake");
+        assert_eq!(cfg.dimensions, 2);
+        assert_eq!(cfg.generation.axiom, "F++F++F");
+        assert_eq!(cfg.generation.angle, 60.0);
+        assert_eq!(cfg.generation.step, 1.0);
+        assert_eq!(cfg.generation.initial_heading, 0.0);
+        assert_eq!(cfg.generation.iterations, 4);
+        assert_eq!(cfg.generation.rules[&'F'], "F-F++F-F");
+    }
+
+    #[test]
+    fn config_document_from_config_writes_canonical_nested_toml() {
+        let mut cfg = Config::parse(NESTED_KOCH_TOML).unwrap();
+        cfg.dimensions = 3;
+        cfg.generation.axiom = "F\\F".to_string();
+        cfg.generation.rules.insert('F', "F\\F".to_string());
+        cfg.colors.line = LineColorConfig::Gradient {
+            start: [0.1, 0.2, 0.3],
+            end: [0.7, 0.8, 0.9],
+        };
+
+        let serialized = ConfigDocument::from_config(&cfg).to_string();
+
+        assert!(serialized.contains("[metadata]\n"));
+        assert!(serialized.contains("[l-system]\n"));
+        assert!(serialized.contains("[l-system.rules]\n"));
+        assert!(serialized.contains("[turtle]\n"));
+        assert!(serialized.contains("[colors]\n"));
+        assert!(serialized.contains("[colors.line]\n"));
+        assert!(serialized.contains("axiom = 'F\\F'"));
+        assert!(serialized.contains("F = 'F\\F'"));
+        assert!(!serialized.contains("F\\\\F"));
+        assert!(serialized.contains("start = [0.1, 0.2, 0.3]"));
+        assert!(serialized.contains("end = [0.7, 0.8, 0.9]"));
+        assert_eq!(
+            ConfigDocument::parse(&serialized)
+                .unwrap()
+                .to_config()
+                .unwrap(),
+            cfg
+        );
+    }
+
+    #[test]
+    fn parses_nested_v2_config() {
+        let cfg = Config::parse(NESTED_KOCH_TOML).unwrap();
+        assert_eq!(cfg.name, "Koch Snowflake");
+        assert_eq!(cfg.dimensions, 2);
+        assert_eq!(cfg.generation.axiom, "F++F++F");
+        assert_eq!(cfg.generation.angle, 60.0);
+        assert_eq!(cfg.generation.step, 1.0);
+        assert_eq!(cfg.generation.initial_heading, 0.0);
+        assert_eq!(cfg.generation.iterations, 4);
+        assert_eq!(cfg.generation.rules[&'F'], "F-F++F-F");
+        assert_eq!(cfg.colors.background, [0.0, 0.0, 0.0]);
+        match cfg.colors.line {
+            LineColorConfig::HueCycle { initial } => assert_eq!(initial, [0.25, 0.5, 0.5]),
+            other => panic!("expected hue cycle line color, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn rejects_flat_v1_schema() {
+        assert!(
+            Config::parse(KOCH_TOML).is_err(),
+            "flat v1 TOML must not parse as v2"
+        );
+    }
+
+    #[test]
+    fn config_document_preserves_unchanged_toml() {
+        let toml = r#"# preset comment
+[metadata]
+name = 'Formatted'
+
+[l-system] # keep this suffix
+dimensions = 3
+axiom = 'F\F'
+iterations = 2
+
+[l-system.rules]
+F = 'F\F'
+
+[turtle]
+angle = 45.0
+step = 1.0
+initial_heading = 0.0
+
+[colors]
+background = [0.0, 0.0, 0.0]
+
+[colors.line]
+mode = "solid"
+color = [0.1, 0.2, 0.3]
+"#;
+
+        let document = ConfigDocument::parse(toml).unwrap();
+
+        assert_eq!(document.to_toml_string(), toml);
+        let cfg = document.to_config().unwrap();
+        assert_eq!(cfg.generation.axiom, "F\\F");
+        assert_eq!(cfg.generation.rules[&'F'], "F\\F");
+    }
+
+    #[test]
+    fn serializes_canonical_nested_toml_and_round_trips() {
+        let cfg = Config::parse(NESTED_KOCH_TOML).unwrap();
+        let serialized = cfg.to_toml_string();
+
+        assert!(serialized.contains("[metadata]\n"));
+        assert!(serialized.contains("[l-system]\n"));
+        assert!(serialized.contains("[l-system.rules]\n"));
+        assert!(serialized.contains("[turtle]\n"));
+        assert!(serialized.contains("[colors]\n"));
+        assert!(serialized.contains("[colors.line]\n"));
+        assert!(!serialized.contains("background_color"));
+        assert!(!serialized.contains("[line_color]"));
+        assert!(!serialized.contains("[rules]"));
+
+        let round_tripped = Config::parse(&serialized).unwrap();
+        assert_eq!(round_tripped.name, cfg.name);
+        assert_eq!(round_tripped.dimensions, cfg.dimensions);
+        assert_eq!(round_tripped.generation.axiom, cfg.generation.axiom);
+        assert_eq!(
+            round_tripped.generation.iterations,
+            cfg.generation.iterations
+        );
+        assert_eq!(round_tripped.generation.angle, cfg.generation.angle);
+        assert_eq!(round_tripped.generation.step, cfg.generation.step);
+        assert_eq!(
+            round_tripped.generation.initial_heading,
+            cfg.generation.initial_heading
+        );
+        assert_eq!(round_tripped.generation.rules, cfg.generation.rules);
+        assert_eq!(round_tripped.to_toml_string(), serialized);
+    }
+
+    #[test]
+    fn serializes_axiom_and_rules_as_literal_strings() {
+        let cfg = Config::parse(
+            r#"[metadata]
+name = "Backslash"
+
+[l-system]
+dimensions = 3
+axiom = 'F\F'
+iterations = 1
+
+[l-system.rules]
+F = 'F\F'
+
+[turtle]
+angle = 90.0
+step = 1.0
+initial_heading = 0.0
+
+[colors]
+background = [0.0, 0.0, 0.0]
+
+[colors.line]
+mode = "solid"
+color = [0.0, 0.9, 0.5]
+"#,
+        )
+        .unwrap();
+
+        let serialized = cfg.to_toml_string();
+
+        assert!(serialized.contains("axiom = 'F\\F'"));
+        assert!(serialized.contains("F = 'F\\F'"));
+        assert!(!serialized.contains("F\\\\F"));
+        let round_tripped = Config::parse(&serialized).unwrap();
+        assert_eq!(round_tripped.generation.axiom, "F\\F");
+        assert_eq!(round_tripped.generation.rules[&'F'], "F\\F");
+    }
+
+    #[test]
+    fn serializes_solid_line_color_and_round_trips() {
+        let mut cfg = Config::parse(NESTED_KOCH_TOML).unwrap();
+        cfg.colors.line = LineColorConfig::Solid([0.1, 0.2, 0.3]);
+
+        let serialized = cfg.to_toml_string();
+
+        assert!(serialized.contains("mode = \"solid\""));
+        assert!(serialized.contains("color = [0.1, 0.2, 0.3]"));
+        let round_tripped = Config::parse(&serialized).unwrap();
+        match round_tripped.colors.line {
+            LineColorConfig::Solid(color) => assert_eq!(color, [0.1, 0.2, 0.3]),
+            other => panic!("expected solid line color, got {other:?}"),
+        }
+        assert_eq!(round_tripped.to_toml_string(), serialized);
+    }
+
+    #[test]
+    fn serializes_gradient_line_color_and_round_trips() {
+        let mut cfg = Config::parse(NESTED_KOCH_TOML).unwrap();
+        cfg.colors.line = LineColorConfig::Gradient {
+            start: [0.1, 0.2, 0.3],
+            end: [0.7, 0.8, 0.9],
+        };
+
+        let serialized = cfg.to_toml_string();
+
+        assert!(serialized.contains("mode = \"gradient\""));
+        assert!(serialized.contains("start = [0.1, 0.2, 0.3]"));
+        assert!(serialized.contains("end = [0.7, 0.8, 0.9]"));
+        let round_tripped = Config::parse(&serialized).unwrap();
+        match round_tripped.colors.line {
+            LineColorConfig::Gradient { start, end } => {
+                assert_eq!(start, [0.1, 0.2, 0.3]);
+                assert_eq!(end, [0.7, 0.8, 0.9]);
+            }
+            other => panic!("expected gradient line color, got {other:?}"),
+        }
+        assert_eq!(round_tripped.to_toml_string(), serialized);
+    }
+
+    #[test]
+    fn serializes_empty_rules_table_for_ruleless_configs() {
+        let cfg = Config::parse(&test_toml(2, "F", 0, "90.0", "1.0", "0.0", "")).unwrap();
+        let serialized = cfg.to_toml_string();
+
+        assert!(serialized.contains("[l-system.rules]\n"));
+        let round_tripped = Config::parse(&serialized).unwrap();
+        assert!(round_tripped.generation.rules.is_empty());
+        assert_eq!(round_tripped.to_toml_string(), serialized);
+    }
+
+    #[test]
+    fn parses_valid_config() {
+        let cfg = Config::parse(NESTED_KOCH_TOML).unwrap();
+        assert_eq!(cfg.generation.axiom, "F++F++F");
+        assert_eq!(cfg.generation.angle, 60.0);
+        assert_eq!(cfg.generation.step, 1.0);
+        assert_eq!(cfg.generation.iterations, 4);
+        assert_eq!(cfg.generation.rules[&'F'], "F-F++F-F");
+    }
+
+    #[test]
+    fn rejects_missing_step() {
         let toml = r#"
+[metadata]
 name = "test"
+
+[l-system]
+dimensions = 2
 axiom = "F"
 iterations = 1
+
+[turtle]
 angle = 90.0
+
+[colors]
+background = [0.0, 0.0, 0.0]
+
+[colors.line]
+mode = "solid"
+color = [0.0, 0.9, 0.5]
 "#;
-        let cfg = Config::parse(toml).unwrap();
-        assert_eq!(cfg.step, 1.0);
+        assert!(Config::parse(&toml).is_err());
+    }
+
+    #[test]
+    fn rejects_missing_rules_table() {
+        let toml = r#"
+[metadata]
+name = "test"
+
+[l-system]
+dimensions = 2
+axiom = "F"
+iterations = 1
+
+[turtle]
+angle = 90.0
+step = 1.0
+initial_heading = 0.0
+
+[colors]
+background = [0.0, 0.0, 0.0]
+
+[colors.line]
+mode = "solid"
+color = [0.0, 0.9, 0.5]
+"#;
+        assert!(Config::parse(toml).is_err());
+    }
+
+    #[test]
+    fn rejects_out_of_range_color_component() {
+        let toml = test_toml(2, "F", 1, "90.0", "1.0", "0.0", "");
+        let toml = toml.replace(
+            "background = [0.0, 0.0, 0.0]",
+            "background = [0.0, 1.2, 0.0]",
+        );
+        let err = Config::parse(&toml).unwrap_err();
+        assert!(
+            matches!(
+                err,
+                ConfigError::InvalidColorComponent {
+                    ref field,
+                    component: 1,
+                    value
+                } if field == "colors.background" && value == 1.2
+            ),
+            "unexpected error: {err}"
+        );
+    }
+
+    #[test]
+    fn rejects_non_finite_line_color_component() {
+        let toml = test_toml(2, "F", 1, "90.0", "1.0", "0.0", "");
+        let toml = toml.replace("color = [0.0, 0.9, 0.5]", "color = [0.0, nan, 0.5]");
+        let err = Config::parse(&toml).unwrap_err();
+        assert!(
+            matches!(
+                err,
+                ConfigError::InvalidColorComponent {
+                    ref field,
+                    component: 1,
+                    ..
+                } if field == "colors.line.color"
+            ),
+            "unexpected error: {err}"
+        );
     }
 
     #[test]
@@ -292,31 +980,16 @@ angle = 90.0
 
     #[test]
     fn strips_whitespace_from_axiom() {
-        let toml = r#"
-name = "test"
-axiom = "F + + F"
-iterations = 1
-angle = 90.0
-step = 1.0
-
-[rules]
-F = "F - F"
-"#;
-        let cfg = Config::parse(toml).unwrap();
-        assert_eq!(cfg.axiom, "F++F");
-        assert_eq!(cfg.rules[&'F'], "F-F");
+        let toml = test_toml(2, "F + + F", 1, "90.0", "1.0", "0.0", r#"F = "F - F""#);
+        let cfg = Config::parse(&toml).unwrap();
+        assert_eq!(cfg.generation.axiom, "F++F");
+        assert_eq!(cfg.generation.rules[&'F'], "F-F");
     }
 
     #[test]
     fn rejects_digit_in_axiom() {
-        let toml = r#"
-name = "bad"
-axiom = "F+1"
-iterations = 1
-angle = 90.0
-step = 1.0
-"#;
-        let err = Config::parse(toml).unwrap_err();
+        let toml = test_toml(2, "F+1", 1, "90.0", "1.0", "0.0", "");
+        let err = Config::parse(&toml).unwrap_err();
         assert!(
             matches!(err, ConfigError::InvalidSymbol { ch: '1', .. }),
             "unexpected error: {err}"
@@ -325,17 +998,8 @@ step = 1.0
 
     #[test]
     fn rejects_multi_char_rule_key() {
-        let toml = r#"
-name = "bad"
-axiom = "F"
-iterations = 1
-angle = 90.0
-step = 1.0
-
-[rules]
-FF = "FFF"
-"#;
-        let err = Config::parse(toml).unwrap_err();
+        let toml = test_toml(2, "F", 1, "90.0", "1.0", "0.0", r#"FF = "FFF""#);
+        let err = Config::parse(&toml).unwrap_err();
         assert!(
             matches!(err, ConfigError::InvalidRuleKey { .. }),
             "unexpected error: {err}"
@@ -345,9 +1009,7 @@ FF = "FFF"
     #[test]
     fn rejects_invalid_dimensions() {
         for bad_dim in [1u8, 4] {
-            let toml = format!(
-                "name=\"bad\"\ndimensions={bad_dim}\naxiom=\"F\"\niterations=1\nangle=90.0\nstep=1.0"
-            );
+            let toml = test_toml(bad_dim, "F", 1, "90.0", "1.0", "0.0", "");
             let err = Config::parse(&toml).unwrap_err();
             assert!(
                 matches!(err, ConfigError::InvalidDimensions(d) if d == bad_dim),
@@ -358,15 +1020,14 @@ FF = "FFF"
 
     #[test]
     fn accepts_dimensions_3_with_3d_symbols() {
-        let toml =
-            "name=\"t\"\ndimensions=3\naxiom=\"F&F^F/F\"\niterations=0\nangle=90.0\nstep=1.0";
-        Config::parse(toml).expect("3D config with 3D symbols should be valid");
+        let toml = test_toml(3, "F&F^F/F", 0, "90.0", "1.0", "0.0", "");
+        Config::parse(&toml).expect("3D config with 3D symbols should be valid");
     }
 
     #[test]
     fn rejects_3d_symbols_in_2d_config() {
-        let toml = "name=\"bad\"\naxiom=\"F&F\"\niterations=1\nangle=90.0\nstep=1.0";
-        let err = Config::parse(toml).unwrap_err();
+        let toml = test_toml(2, "F&F", 1, "90.0", "1.0", "0.0", "");
+        let err = Config::parse(&toml).unwrap_err();
         assert!(
             matches!(err, ConfigError::InvalidSymbol { ch: '&', .. }),
             "unexpected error: {err}"
@@ -375,8 +1036,8 @@ FF = "FFF"
 
     #[test]
     fn rejects_unmatched_close_bracket_in_axiom() {
-        let toml = "name=\"bad\"\naxiom=\"F]F\"\niterations=1\nangle=90.0\nstep=1.0";
-        let err = Config::parse(toml).unwrap_err();
+        let toml = test_toml(2, "F]F", 1, "90.0", "1.0", "0.0", "");
+        let err = Config::parse(&toml).unwrap_err();
         assert!(
             matches!(err, ConfigError::UnmatchedClose { position: 1, .. }),
             "unexpected error: {err}"
@@ -385,8 +1046,8 @@ FF = "FFF"
 
     #[test]
     fn rejects_unclosed_open_bracket_in_axiom() {
-        let toml = "name=\"bad\"\naxiom=\"F[F\"\niterations=1\nangle=90.0\nstep=1.0";
-        let err = Config::parse(toml).unwrap_err();
+        let toml = test_toml(2, "F[F", 1, "90.0", "1.0", "0.0", "");
+        let err = Config::parse(&toml).unwrap_err();
         assert!(
             matches!(err, ConfigError::UnmatchedOpen { position: 1, .. }),
             "unexpected error: {err}"
@@ -396,8 +1057,8 @@ FF = "FFF"
     #[test]
     fn reports_first_unclosed_bracket_not_last() {
         // "F[F[F": two unclosed brackets at positions 1 and 3; error must point to 1.
-        let toml = "name=\"bad\"\naxiom=\"F[F[F\"\niterations=1\nangle=90.0\nstep=1.0";
-        let err = Config::parse(toml).unwrap_err();
+        let toml = test_toml(2, "F[F[F", 1, "90.0", "1.0", "0.0", "");
+        let err = Config::parse(&toml).unwrap_err();
         assert!(
             matches!(err, ConfigError::UnmatchedOpen { position: 1, .. }),
             "unexpected error: {err}"
@@ -406,9 +1067,8 @@ FF = "FFF"
 
     #[test]
     fn rejects_unbalanced_brackets_in_rule() {
-        let toml =
-            "name=\"bad\"\naxiom=\"F\"\niterations=1\nangle=90.0\nstep=1.0\n[rules]\nF=\"F[+F\"";
-        let err = Config::parse(toml).unwrap_err();
+        let toml = test_toml(2, "F", 1, "90.0", "1.0", "0.0", r#"F = "F[+F""#);
+        let err = Config::parse(&toml).unwrap_err();
         assert!(
             matches!(err, ConfigError::UnmatchedOpen { .. }),
             "unexpected error: {err}"
@@ -418,8 +1078,7 @@ FF = "FFF"
     #[test]
     fn rejects_non_positive_step() {
         for bad_step in ["0.0", "-1.0"] {
-            let toml =
-                format!("name=\"bad\"\naxiom=\"F\"\niterations=1\nangle=90.0\nstep={bad_step}");
+            let toml = test_toml(2, "F", 1, "90.0", bad_step, "0.0", "");
             let err = Config::parse(&toml).unwrap_err();
             assert!(
                 matches!(err, ConfigError::InvalidStep(_)),
@@ -430,8 +1089,8 @@ FF = "FFF"
 
     #[test]
     fn rejects_non_finite_step() {
-        let toml = "name=\"bad\"\naxiom=\"F\"\niterations=1\nangle=90.0\nstep=inf";
-        let err = Config::parse(toml).unwrap_err();
+        let toml = test_toml(2, "F", 1, "90.0", "inf", "0.0", "");
+        let err = Config::parse(&toml).unwrap_err();
         assert!(
             matches!(err, ConfigError::InvalidStep(_)),
             "unexpected error: {err}"
@@ -440,8 +1099,8 @@ FF = "FFF"
 
     #[test]
     fn rejects_non_finite_angle() {
-        let toml = "name=\"bad\"\naxiom=\"F\"\niterations=1\nangle=nan\nstep=1.0";
-        let err = Config::parse(toml).unwrap_err();
+        let toml = test_toml(2, "F", 1, "nan", "1.0", "0.0", "");
+        let err = Config::parse(&toml).unwrap_err();
         assert!(
             matches!(err, ConfigError::InvalidAngle(_)),
             "unexpected error: {err}"

--- a/crates/lsystem-core/src/config.rs
+++ b/crates/lsystem-core/src/config.rs
@@ -1,4 +1,4 @@
-use std::collections::HashMap;
+use std::collections::BTreeMap;
 
 use thiserror::Error;
 use toml_edit::{DocumentMut, Item, Table, Value, value};
@@ -33,7 +33,7 @@ pub enum ConfigError {
     },
 
     #[error("unsupported dimensions value {0} (must be 2 or 3)")]
-    InvalidDimensions(u8),
+    InvalidDimensions(i64),
 
     #[error("unmatched `]` at position {position} in `{field}`")]
     UnmatchedClose { field: String, position: usize },
@@ -63,14 +63,16 @@ pub enum ConfigError {
 /// Color mode for the fractal lines.
 #[derive(Debug, Clone, PartialEq)]
 pub enum LineColorConfig {
-    Solid([f32; 3]),
+    Solid { color: [f32; 3] },
     Gradient { start: [f32; 3], end: [f32; 3] },
     HueCycle { initial: [f32; 3] },
 }
 
 impl Default for LineColorConfig {
     fn default() -> Self {
-        Self::Solid([0.0, 0.9, 0.5])
+        Self::Solid {
+            color: [0.0, 0.9, 0.5],
+        }
     }
 }
 
@@ -113,7 +115,7 @@ pub struct GenerationConfig {
     /// In 3D this is the initial yaw in the XY plane.
     pub initial_heading: f32,
     /// Production rules: single ASCII letter → replacement string.
-    pub rules: HashMap<char, String>,
+    pub rules: BTreeMap<char, String>,
 }
 
 impl Config {
@@ -149,11 +151,7 @@ impl ConfigDocument {
         let colors_table = required_table(&self.document, "colors")?;
         let line_table = required_table(colors_table, "line")?;
 
-        let dimensions = required_u8(l_system, "l-system.dimensions")?;
-
-        if dimensions != 2 && dimensions != 3 {
-            return Err(ConfigError::InvalidDimensions(dimensions));
-        }
+        let dimensions = required_dimensions(l_system, "l-system.dimensions")?;
         let step = required_f32(turtle, "turtle.step")?;
         let angle = required_f32(turtle, "turtle.angle")?;
         let initial_heading = required_f32(turtle, "turtle.initial_heading")?;
@@ -173,7 +171,7 @@ impl ConfigDocument {
         validate_symbols(&axiom, "axiom", dimensions)?;
         validate_bracket_balance(&axiom, "axiom")?;
 
-        let mut rules = HashMap::with_capacity(rules_table.len());
+        let mut rules = BTreeMap::new();
         for (key_str, item) in rules_table.iter() {
             let mut key_chars = key_str.chars();
             let key = key_chars
@@ -207,7 +205,7 @@ impl ConfigDocument {
                 validate_keys(line_table, "colors.line", &["mode", "color"])?;
                 let color = required_color(line_table, "colors.line.color")?;
                 validate_color(color, "colors.line.color")?;
-                LineColorConfig::Solid(color)
+                LineColorConfig::Solid { color }
             }
             "gradient" => {
                 validate_keys(line_table, "colors.line", &["mode", "start", "end"])?;
@@ -280,7 +278,7 @@ impl ConfigDocument {
 
         document["colors"]["line"] = Item::Table(Table::new());
         match &config.colors.line {
-            LineColorConfig::Solid(color) => {
+            LineColorConfig::Solid { color } => {
                 document["colors"]["line"]["mode"] = value("solid");
                 document["colors"]["line"]["color"] = color_item(*color);
             }
@@ -295,11 +293,7 @@ impl ConfigDocument {
             }
         }
 
-        let result = Self { document };
-        result
-            .to_config()
-            .expect("generated config TOML must be valid");
-        result
+        Self { document }
     }
 }
 
@@ -402,7 +396,7 @@ fn required_str<'a>(table: &'a impl TableLike, field: &str) -> Result<&'a str, C
         })
 }
 
-fn required_u8(table: &impl TableLike, field: &str) -> Result<u8, ConfigError> {
+fn required_dimensions(table: &impl TableLike, field: &str) -> Result<u8, ConfigError> {
     let value =
         required_item(table, field)?
             .as_integer()
@@ -410,10 +404,11 @@ fn required_u8(table: &impl TableLike, field: &str) -> Result<u8, ConfigError> {
                 field: field.to_string(),
                 expected: "integer",
             })?;
-    u8::try_from(value).map_err(|_| ConfigError::InvalidField {
-        field: field.to_string(),
-        expected: "integer in 0..=255",
-    })
+    match value {
+        2 => Ok(2),
+        3 => Ok(3),
+        other => Err(ConfigError::InvalidDimensions(other)),
+    }
 }
 
 fn required_u32(table: &impl TableLike, field: &str) -> Result<u32, ConfigError> {
@@ -557,7 +552,7 @@ initial = [0.25, 0.5, 0.5]
 "#;
 
     fn test_toml(
-        dimensions: u8,
+        dimensions: i64,
         axiom: &str,
         iterations: u32,
         angle: &str,
@@ -811,7 +806,9 @@ color = [0.0, 0.9, 0.5]
     #[test]
     fn serializes_solid_line_color_and_round_trips() {
         let mut cfg = Config::parse(NESTED_KOCH_TOML).unwrap();
-        cfg.colors.line = LineColorConfig::Solid([0.1, 0.2, 0.3]);
+        cfg.colors.line = LineColorConfig::Solid {
+            color: [0.1, 0.2, 0.3],
+        };
 
         let serialized = cfg.to_toml_string();
 
@@ -819,7 +816,7 @@ color = [0.0, 0.9, 0.5]
         assert!(serialized.contains("color = [0.1, 0.2, 0.3]"));
         let round_tripped = Config::parse(&serialized).unwrap();
         match round_tripped.colors.line {
-            LineColorConfig::Solid(color) => assert_eq!(color, [0.1, 0.2, 0.3]),
+            LineColorConfig::Solid { color } => assert_eq!(color, [0.1, 0.2, 0.3]),
             other => panic!("expected solid line color, got {other:?}"),
         }
         assert_eq!(round_tripped.to_toml_string(), serialized);
@@ -858,6 +855,16 @@ color = [0.0, 0.9, 0.5]
         let round_tripped = Config::parse(&serialized).unwrap();
         assert!(round_tripped.generation.rules.is_empty());
         assert_eq!(round_tripped.to_toml_string(), serialized);
+    }
+
+    #[test]
+    fn serializing_mutated_invalid_config_does_not_revalidate_and_panic() {
+        let mut cfg = Config::parse(NESTED_KOCH_TOML).unwrap();
+        cfg.generation.axiom = "F1".to_string();
+
+        let result = std::panic::catch_unwind(|| cfg.to_toml_string());
+
+        assert!(result.is_ok());
     }
 
     #[test]
@@ -960,6 +967,85 @@ color = [0.0, 0.9, 0.5]
     }
 
     #[test]
+    fn rejects_unknown_line_color_mode() {
+        let toml = test_toml(2, "F", 1, "90.0", "1.0", "0.0", "");
+        let toml = toml.replace("mode = \"solid\"", "mode = \"rainbow\"");
+        let err = Config::parse(&toml).unwrap_err();
+
+        assert!(
+            matches!(
+                err,
+                ConfigError::InvalidField { ref field, .. } if field == "colors.line.mode"
+            ),
+            "unexpected error: {err}"
+        );
+    }
+
+    #[test]
+    fn rejects_extra_keys_for_line_color_modes() {
+        let cases = [
+            (
+                "solid",
+                r#"mode = "solid"
+color = [0.0, 0.9, 0.5]
+start = [0.0, 0.0, 0.0]"#,
+                "colors.line.start",
+            ),
+            (
+                "gradient",
+                r#"mode = "gradient"
+start = [0.0, 0.0, 0.0]
+end = [1.0, 1.0, 1.0]
+color = [0.0, 0.9, 0.5]"#,
+                "colors.line.color",
+            ),
+            (
+                "hue_cycle",
+                r#"mode = "hue_cycle"
+initial = [0.0, 0.9, 0.5]
+end = [1.0, 1.0, 1.0]"#,
+                "colors.line.end",
+            ),
+        ];
+
+        for (mode, replacement, expected_field) in cases {
+            let toml = test_toml(2, "F", 1, "90.0", "1.0", "0.0", "");
+            let toml = toml.replace("mode = \"solid\"\ncolor = [0.0, 0.9, 0.5]", replacement);
+            let err = Config::parse(&toml).unwrap_err();
+
+            assert!(
+                matches!(
+                    err,
+                    ConfigError::UnknownField(ref field) if field == expected_field
+                ),
+                "mode={mode}: unexpected error: {err}"
+            );
+        }
+    }
+
+    #[test]
+    fn rejects_unknown_schema_fields() {
+        let toml = format!("{}\n[experimental]\nfoo = true\n", NESTED_KOCH_TOML);
+        let err = Config::parse(&toml).unwrap_err();
+
+        assert!(
+            matches!(err, ConfigError::UnknownField(ref field) if field == "experimental"),
+            "unexpected error: {err}"
+        );
+
+        let toml = NESTED_KOCH_TOML.replace(
+            "initial_heading = 0.0",
+            "initial_heading = 0.0\nfriction = 0.5",
+        );
+        let err = Config::parse(&toml).unwrap_err();
+
+        assert!(
+            matches!(err, ConfigError::UnknownField(ref field) if field == "turtle.friction"),
+            "unexpected error: {err}"
+        );
+    }
+
+    #[test]
     fn bundled_presets_are_parseable() {
         let presets_dir = Path::new(env!("CARGO_MANIFEST_DIR")).join("../../presets");
         let mut preset_paths: Vec<_> = std::fs::read_dir(&presets_dir)
@@ -1008,7 +1094,7 @@ color = [0.0, 0.9, 0.5]
 
     #[test]
     fn rejects_invalid_dimensions() {
-        for bad_dim in [1u8, 4] {
+        for bad_dim in [1, 4, 300] {
             let toml = test_toml(bad_dim, "F", 1, "90.0", "1.0", "0.0", "");
             let err = Config::parse(&toml).unwrap_err();
             assert!(
@@ -1016,6 +1102,17 @@ color = [0.0, 0.9, 0.5]
                 "dim={bad_dim}: unexpected error: {err}"
             );
         }
+    }
+
+    #[test]
+    fn rejects_non_finite_initial_heading() {
+        let toml = test_toml(2, "F", 1, "90.0", "1.0", "nan", "");
+        let err = Config::parse(&toml).unwrap_err();
+
+        assert!(
+            matches!(err, ConfigError::InvalidInitialHeading(_)),
+            "unexpected error: {err}"
+        );
     }
 
     #[test]

--- a/crates/lsystem-core/src/config.rs
+++ b/crates/lsystem-core/src/config.rs
@@ -262,9 +262,7 @@ impl ConfigDocument {
         document["l-system"]["iterations"] = value(i64::from(config.generation.iterations));
 
         document["l-system"]["rules"] = Item::Table(Table::new());
-        let mut rules: Vec<_> = config.generation.rules.iter().collect();
-        rules.sort_by_key(|(key, _)| **key);
-        for (key, rhs) in rules {
+        for (key, rhs) in &config.generation.rules {
             document["l-system"]["rules"][&key.to_string()] = literal_string_item(rhs);
         }
 

--- a/crates/lsystem-core/src/grammar.rs
+++ b/crates/lsystem-core/src/grammar.rs
@@ -1,8 +1,8 @@
-use std::collections::HashMap;
+use std::collections::BTreeMap;
 
 pub(crate) struct ExpandIter<'a> {
     stack: Vec<(std::str::Chars<'a>, u32)>,
-    rules: &'a HashMap<char, String>,
+    rules: &'a BTreeMap<char, String>,
 }
 
 impl<'a> Iterator for ExpandIter<'a> {
@@ -32,7 +32,7 @@ impl<'a> Iterator for ExpandIter<'a> {
 
 pub fn expand<'a>(
     axiom: &'a str,
-    rules: &'a HashMap<char, String>,
+    rules: &'a BTreeMap<char, String>,
     iterations: u32,
 ) -> impl Iterator<Item = char> + 'a {
     ExpandIter {
@@ -43,7 +43,7 @@ pub fn expand<'a>(
 
 pub(crate) struct OwnedExpandIter {
     stack: Vec<(std::vec::IntoIter<char>, u32)>,
-    rules: HashMap<char, Vec<char>>,
+    rules: BTreeMap<char, Vec<char>>,
 }
 
 impl Iterator for OwnedExpandIter {
@@ -73,10 +73,10 @@ impl Iterator for OwnedExpandIter {
 
 pub(crate) fn expand_owned(
     axiom: String,
-    rules: HashMap<char, String>,
+    rules: BTreeMap<char, String>,
     iterations: u32,
 ) -> OwnedExpandIter {
-    let char_rules: HashMap<char, Vec<char>> = rules
+    let char_rules: BTreeMap<char, Vec<char>> = rules
         .into_iter()
         .map(|(k, v)| (k, v.chars().collect()))
         .collect();
@@ -93,22 +93,22 @@ pub(crate) fn expand_owned(
 /// Uses symbolic growth tracking: iterates the per-character segment yield one step at
 /// a time without materialising any strings. Saturating arithmetic prevents overflow for
 /// fast-growing systems. Hard-capped at 30 so the loop always terminates.
-pub fn max_safe_iterations(axiom: &str, rules: &HashMap<char, String>, max_segments: u64) -> u32 {
+pub fn max_safe_iterations(axiom: &str, rules: &BTreeMap<char, String>, max_segments: u64) -> u32 {
     const HARD_MAX: u32 = 30;
 
-    let axiom_counts: HashMap<char, u64> = axiom.chars().fold(HashMap::new(), |mut m, c| {
+    let axiom_counts: BTreeMap<char, u64> = axiom.chars().fold(BTreeMap::new(), |mut m, c| {
         *m.entry(c).or_insert(0) += 1;
         m
     });
 
-    let total = |yields: &HashMap<char, u64>| -> u64 {
+    let total = |yields: &BTreeMap<char, u64>| -> u64 {
         axiom_counts
             .iter()
             .map(|(c, n)| n.saturating_mul(*yields.get(c).unwrap_or(&0)))
             .fold(0u64, |a, x| a.saturating_add(x))
     };
 
-    let mut yields: HashMap<char, u64> = [('F', 1u64)].into();
+    let mut yields: BTreeMap<char, u64> = [('F', 1u64)].into();
 
     for n in 0..=HARD_MAX {
         if total(&yields) > max_segments {
@@ -131,7 +131,7 @@ pub fn max_safe_iterations(axiom: &str, rules: &HashMap<char, String>, max_segme
 mod tests {
     use super::*;
 
-    fn koch_rules() -> HashMap<char, String> {
+    fn koch_rules() -> BTreeMap<char, String> {
         [('F', "F-F++F-F".to_string())].into()
     }
 
@@ -160,7 +160,7 @@ mod tests {
         }
     }
 
-    fn sierpinski_rules() -> HashMap<char, String> {
+    fn sierpinski_rules() -> BTreeMap<char, String> {
         [('F', "F-F+F+F-F".to_string())].into()
     }
 
@@ -183,7 +183,7 @@ mod tests {
     #[test]
     fn max_safe_no_drawing_symbols_returns_hard_max() {
         // Axiom "A" with no F → always 0 segments, should return HARD_MAX (30).
-        let rules: HashMap<char, String> = [('A', "AA".to_string())].into();
+        let rules: BTreeMap<char, String> = [('A', "AA".to_string())].into();
         assert_eq!(max_safe_iterations("A", &rules, 16_777_216), 30);
     }
 
@@ -192,7 +192,7 @@ mod tests {
         // X has no rule; F maps to FX.
         // iter 1: "F" → "FX"
         // iter 2: F→FX, X→X → "FXX"
-        let rules: HashMap<char, String> = [('F', "FX".to_string())].into();
+        let rules: BTreeMap<char, String> = [('F', "FX".to_string())].into();
         let result: String = expand("F", &rules, 2).collect();
         assert_eq!(result, "FXX");
     }
@@ -203,7 +203,7 @@ mod tests {
         // iter 0: "AB"
         // iter 1: A→aA, B→Bb  →  "aABb"
         // iter 2: a→a, A→aA, B→Bb, b→b  →  "aaABbb"
-        let rules: HashMap<char, String> =
+        let rules: BTreeMap<char, String> =
             [('A', "aA".to_string()), ('B', "Bb".to_string())].into();
         let result: String = expand("AB", &rules, 2).collect();
         assert_eq!(result, "aaABbb");

--- a/crates/lsystem-core/src/lib.rs
+++ b/crates/lsystem-core/src/lib.rs
@@ -2,18 +2,21 @@
 pub mod svg_export;
 
 pub(crate) mod alphabet;
+pub mod color_util;
 pub mod config;
 pub mod grammar;
 pub(crate) mod turtle;
 
-pub use config::{ColorConfig, Config, ConfigError, LineColorConfig};
+pub use config::{
+    ColorConfig, Config, ConfigDocument, ConfigError, GenerationConfig, LineColorConfig,
+};
 pub use grammar::max_safe_iterations;
 
 use glam::{Vec2, Vec3};
 
 /// Expand the grammar and run the 2D turtle, returning a lazy iterator of
 /// line segments. The iterator owns all its state and does not borrow from `config`.
-pub fn generate(config: &Config) -> impl Iterator<Item = [Vec2; 2]> {
+pub fn generate(config: &GenerationConfig) -> impl Iterator<Item = [Vec2; 2]> {
     let chars = grammar::expand_owned(
         config.axiom.clone(),
         config.rules.clone(),
@@ -23,7 +26,7 @@ pub fn generate(config: &Config) -> impl Iterator<Item = [Vec2; 2]> {
 }
 
 /// Like `generate` but runs the 3D turtle; the iterator owns all its state.
-pub fn generate_3d(config: &Config) -> impl Iterator<Item = [Vec3; 2]> {
+pub fn generate_3d(config: &GenerationConfig) -> impl Iterator<Item = [Vec3; 2]> {
     let chars = grammar::expand_owned(
         config.axiom.clone(),
         config.rules.clone(),

--- a/crates/lsystem-core/src/svg_export.rs
+++ b/crates/lsystem-core/src/svg_export.rs
@@ -75,7 +75,7 @@ pub fn export_svg(config: &Config) -> String {
 
 fn build_body(segments: &[[Vec2; 2]], line: &LineColorConfig) -> String {
     match line {
-        LineColorConfig::Solid(c) => {
+        LineColorConfig::Solid { color: c } => {
             let color = to_hex(*c);
             let mut d = String::new();
             for [a, b] in segments {

--- a/crates/lsystem-core/src/svg_export.rs
+++ b/crates/lsystem-core/src/svg_export.rs
@@ -1,13 +1,13 @@
 use glam::Vec2;
 
-use crate::{Config, LineColorConfig, generate};
+use crate::{Config, LineColorConfig, color_util::rgb_to_hsv, generate};
 
 /// Generate an SVG string for the given config.
 ///
 /// The SVG uses the natural turtle coordinate system, scaled to fit the fractal.
 /// Colors match the GPU render exactly.
 pub fn export_svg(config: &Config) -> String {
-    let segments: Vec<[Vec2; 2]> = generate(config).collect();
+    let segments: Vec<[Vec2; 2]> = generate(&config.generation).collect();
 
     if segments.is_empty() {
         let bg = to_hex(config.colors.background);
@@ -32,7 +32,7 @@ pub fn export_svg(config: &Config) -> String {
     }
 
     // Pad degenerate (zero-width or zero-height) bounding boxes.
-    let pad = config.step * 0.5;
+    let pad = config.generation.step * 0.5;
     if max_x == min_x {
         min_x -= pad;
         max_x += pad;
@@ -102,18 +102,15 @@ fn build_body(segments: &[[Vec2; 2]], line: &LineColorConfig) -> String {
             }
             out
         }
-        LineColorConfig::HueCycle {
-            start_hue,
-            saturation,
-            value,
-        } => {
+        LineColorConfig::HueCycle { initial } => {
+            let (start_hue, saturation, value) = rgb_to_hsv(*initial);
             let n = segments.len();
             let denom = (n.max(2) - 1) as f32;
             let mut out = String::new();
             for (i, [a, b]) in segments.iter().enumerate() {
                 let t = i as f32 / denom;
                 let hue = start_hue + t * 360.0;
-                let rgb = hsv_to_rgb(hue, *saturation, *value);
+                let rgb = hsv_to_rgb(hue, saturation, value);
                 let color = to_hex(rgb);
                 out.push_str(&format!(
                     "<line x1=\"{:.3}\" y1=\"{:.3}\" x2=\"{:.3}\" y2=\"{:.3}\" stroke=\"{color}\"/>\n",
@@ -156,19 +153,62 @@ mod tests {
 
     fn make_config(extra_toml: &str) -> Config {
         let toml = format!(
-            "name = \"Test\"\naxiom = \"F+F\"\niterations = 1\nangle = 90.0\nstep = 1.0\n{extra_toml}"
+            r#"[metadata]
+name = "Test"
+
+[l-system]
+dimensions = 2
+axiom = "F+F"
+iterations = 1
+
+[l-system.rules]
+
+[turtle]
+angle = 90.0
+step = 1.0
+initial_heading = 0.0
+
+[colors]
+background = [0.0, 0.0, 0.0]
+
+[colors.line]
+{extra_toml}
+"#
         );
         Config::parse(&toml).unwrap()
     }
 
     fn make_empty_config() -> Config {
-        Config::parse("name = \"Empty\"\naxiom = \"+\"\niterations = 1\nangle = 90.0\nstep = 1.0")
-            .unwrap()
+        Config::parse(
+            r#"[metadata]
+name = "Empty"
+
+[l-system]
+dimensions = 2
+axiom = "+"
+iterations = 1
+
+[l-system.rules]
+
+[turtle]
+angle = 90.0
+step = 1.0
+initial_heading = 0.0
+
+[colors]
+background = [0.0, 0.0, 0.0]
+
+[colors.line]
+mode = "solid"
+color = [0.0, 0.9, 0.5]
+"#,
+        )
+        .unwrap()
     }
 
     #[test]
     fn solid_contains_svg_and_color() {
-        let cfg = make_config("[line_color]\nmode = \"solid\"\ncolor = [1.0, 0.0, 0.0]");
+        let cfg = make_config("mode = \"solid\"\ncolor = [1.0, 0.0, 0.0]");
         let svg = export_svg(&cfg);
         assert!(svg.contains("<svg"), "missing <svg tag");
         assert!(
@@ -181,9 +221,8 @@ mod tests {
 
     #[test]
     fn gradient_first_and_last_segment_colors() {
-        let cfg = make_config(
-            "[line_color]\nmode = \"gradient\"\nstart = [1.0, 0.0, 0.0]\nend = [0.0, 0.0, 1.0]",
-        );
+        let cfg =
+            make_config("mode = \"gradient\"\nstart = [1.0, 0.0, 0.0]\nend = [0.0, 0.0, 1.0]");
         let svg = export_svg(&cfg);
         assert!(svg.contains("<svg"), "missing <svg tag");
         assert!(
@@ -197,10 +236,7 @@ mod tests {
 
     #[test]
     fn hue_cycle_start_color() {
-        // start_hue=0, s=1, v=1 → hue=0 → pure red for first segment
-        let cfg = make_config(
-            "[line_color]\nmode = \"hue_cycle\"\nstart_hue = 0.0\nsaturation = 1.0\nvalue = 1.0",
-        );
+        let cfg = make_config("mode = \"hue_cycle\"\ninitial = [1.0, 0.0, 0.0]");
         let svg = export_svg(&cfg);
         assert!(svg.contains("<svg"), "missing <svg tag");
         assert!(

--- a/crates/lsystem-core/src/turtle/turtle2d.rs
+++ b/crates/lsystem-core/src/turtle/turtle2d.rs
@@ -61,14 +61,38 @@ mod tests {
     use super::*;
     use crate::Config;
 
-    fn parse(toml: &str) -> Config {
-        Config::parse(toml).expect("valid test config")
+    fn parse(axiom: &str) -> Config {
+        let toml = format!(
+            r#"[metadata]
+name = "t"
+
+[l-system]
+dimensions = 2
+axiom = "{axiom}"
+iterations = 0
+
+[l-system.rules]
+
+[turtle]
+angle = 90.0
+step = 1.0
+initial_heading = 0.0
+
+[colors]
+background = [0.0, 0.0, 0.0]
+
+[colors.line]
+mode = "solid"
+color = [0.0, 0.9, 0.5]
+"#
+        );
+        Config::parse(&toml).expect("valid test config")
     }
 
     #[test]
     fn single_f_draws_one_segment() {
-        let cfg = parse("name=\"t\"\naxiom=\"F\"\niterations=0\nangle=90.0\nstep=1.0");
-        let segments: Vec<[Vec2; 2]> = crate::generate(&cfg).collect();
+        let cfg = parse("F");
+        let segments: Vec<[Vec2; 2]> = crate::generate(&cfg.generation).collect();
         assert_eq!(segments.len(), 1);
         let [a, b] = segments[0];
         assert!((a - Vec2::ZERO).length() < 1e-5);
@@ -77,8 +101,8 @@ mod tests {
 
     #[test]
     fn plus_turns_left() {
-        let cfg = parse("name=\"t\"\naxiom=\"F+F\"\niterations=0\nangle=90.0\nstep=1.0");
-        let segments: Vec<[Vec2; 2]> = crate::generate(&cfg).collect();
+        let cfg = parse("F+F");
+        let segments: Vec<[Vec2; 2]> = crate::generate(&cfg.generation).collect();
         assert_eq!(segments.len(), 2);
         let [a, b] = segments[1];
         assert!((a - Vec2::new(1.0, 0.0)).length() < 1e-5);
@@ -93,8 +117,8 @@ mod tests {
         //   +F  → turn north, draw (1,0)→(1,1)
         //   ]   → restore position=(1,0), heading=0
         //   -F  → turn south (-90°), draw (1,0)→(1,-1)
-        let cfg = parse("name=\"t\"\naxiom=\"F[+F]-F\"\niterations=0\nangle=90.0\nstep=1.0");
-        let segments: Vec<[Vec2; 2]> = crate::generate(&cfg).collect();
+        let cfg = parse("F[+F]-F");
+        let segments: Vec<[Vec2; 2]> = crate::generate(&cfg.generation).collect();
         assert_eq!(segments.len(), 3);
         let [a3, b3] = segments[2];
         assert!(
@@ -109,20 +133,34 @@ mod tests {
 
     #[test]
     fn koch_segment_count() {
-        let base = r#"
+        for (iters, expected) in [(0u32, 3usize), (1, 12), (2, 48), (3, 192), (4, 768)] {
+            let toml = format!(
+                r#"[metadata]
 name = "Koch Snowflake"
+
+[l-system]
 dimensions = 2
 axiom = "F++F++F"
+iterations = {iters}
+
+[l-system.rules]
+F = "F-F++F-F"
+
+[turtle]
 angle = 60.0
 step = 1.0
+initial_heading = 0.0
 
-[rules]
-F = "F-F++F-F"
-"#;
-        for (iters, expected) in [(0u32, 3usize), (1, 12), (2, 48), (3, 192), (4, 768)] {
-            let toml = format!("iterations = {iters}\n{base}");
-            let cfg = parse(&toml);
-            let segments: Vec<[Vec2; 2]> = crate::generate(&cfg).collect();
+[colors]
+background = [0.0, 0.0, 0.0]
+
+[colors.line]
+mode = "solid"
+color = [0.0, 0.9, 0.5]
+"#
+            );
+            let cfg = Config::parse(&toml).expect("valid test config");
+            let segments: Vec<[Vec2; 2]> = crate::generate(&cfg.generation).collect();
             assert_eq!(segments.len(), expected, "iter {iters}");
         }
     }

--- a/crates/lsystem-core/src/turtle/turtle3d.rs
+++ b/crates/lsystem-core/src/turtle/turtle3d.rs
@@ -111,18 +111,32 @@ mod tests {
     fn generate_3d_uses_config_initial_heading() {
         let cfg = Config::parse(
             r#"
+[metadata]
 name = "t"
+
+[l-system]
 dimensions = 3
 axiom = "F"
 iterations = 0
+
+[l-system.rules]
+
+[turtle]
 angle = 90.0
 step = 1.0
 initial_heading = 90.0
+
+[colors]
+background = [0.0, 0.0, 0.0]
+
+[colors.line]
+mode = "solid"
+color = [0.0, 0.9, 0.5]
 "#,
         )
         .expect("valid test config");
 
-        let segments: Vec<[Vec3; 2]> = crate::generate_3d(&cfg).collect();
+        let segments: Vec<[Vec3; 2]> = crate::generate_3d(&cfg.generation).collect();
         assert_eq!(segments.len(), 1);
         let [a, b] = segments[0];
         assert!(a.distance(Vec3::ZERO) < 1e-5);

--- a/crates/lsystem-renderer/src/lsystem_bridge.rs
+++ b/crates/lsystem-renderer/src/lsystem_bridge.rs
@@ -148,7 +148,7 @@ pub fn geometry_to_vertices_3d(segments: impl Iterator<Item = [Vec3; 2]>) -> Ver
 
 pub fn color_params_from_config(line: &LineColorConfig, total_segments: u32) -> ColorParams {
     match *line {
-        LineColorConfig::Solid(c) => ColorParams {
+        LineColorConfig::Solid { color: c } => ColorParams {
             mode: 0,
             total_segments,
             color_start: [c[0], c[1], c[2], 1.0],

--- a/crates/lsystem-renderer/src/lsystem_bridge.rs
+++ b/crates/lsystem-renderer/src/lsystem_bridge.rs
@@ -1,5 +1,5 @@
 use glam::{Vec2, Vec3};
-use lsystem_core::LineColorConfig;
+use lsystem_core::{LineColorConfig, color_util::rgb_to_hsv};
 
 use crate::line_renderer::{ColorParams, Transform, Vertex2D, Vertex3D};
 
@@ -161,18 +161,17 @@ pub fn color_params_from_config(line: &LineColorConfig, total_segments: u32) -> 
             color_end: [end[0], end[1], end[2], 1.0],
             ..Default::default()
         },
-        LineColorConfig::HueCycle {
-            start_hue,
-            saturation,
-            value,
-        } => ColorParams {
-            mode: 2,
-            total_segments,
-            hue_start: start_hue,
-            saturation,
-            value,
-            ..Default::default()
-        },
+        LineColorConfig::HueCycle { initial } => {
+            let (hue_start, saturation, value) = rgb_to_hsv(initial);
+            ColorParams {
+                mode: 2,
+                total_segments,
+                hue_start,
+                saturation,
+                value,
+                ..Default::default()
+            }
+        }
     }
 }
 
@@ -218,8 +217,48 @@ mod tests {
         (a - b).abs() < EPS
     }
 
-    fn cfg(toml: &str) -> Config {
-        Config::parse(toml).unwrap()
+    #[test]
+    fn hue_cycle_initial_rgb_maps_to_hsv_uniforms() {
+        let params = color_params_from_config(
+            &LineColorConfig::HueCycle {
+                initial: [0.25, 0.5, 0.5],
+            },
+            9,
+        );
+
+        assert_eq!(params.mode, 2);
+        assert_eq!(params.total_segments, 9);
+        assert!(close(params.hue_start, 180.0));
+        assert!(close(params.saturation, 0.5));
+        assert!(close(params.value, 0.5));
+    }
+
+    fn cfg(axiom: &str) -> Config {
+        let toml = format!(
+            r#"[metadata]
+name = "t"
+
+[l-system]
+dimensions = 2
+axiom = "{axiom}"
+iterations = 0
+
+[l-system.rules]
+
+[turtle]
+angle = 90.0
+step = 1.0
+initial_heading = 0.0
+
+[colors]
+background = [0.0, 0.0, 0.0]
+
+[colors.line]
+mode = "solid"
+color = [0.0, 0.9, 0.5]
+"#
+        );
+        Config::parse(&toml).unwrap()
     }
 
     #[test]
@@ -228,9 +267,7 @@ mod tests {
             vertices,
             bounds_min,
             bounds_max,
-        } = geometry_to_vertices(generate(&cfg(
-            "name=\"t\"\naxiom=\"A\"\niterations=0\nangle=90.0\nstep=1.0",
-        )));
+        } = geometry_to_vertices(generate(&cfg("A").generation));
         assert!(vertices.is_empty());
         assert!(close(bounds_min[0], -1.0) && close(bounds_min[1], -1.0));
         assert!(close(bounds_max[0], 1.0) && close(bounds_max[1], 1.0));
@@ -242,9 +279,7 @@ mod tests {
             vertices,
             bounds_min,
             bounds_max,
-        } = geometry_to_vertices(generate(&cfg(
-            "name=\"t\"\naxiom=\"F\"\niterations=0\nangle=90.0\nstep=1.0",
-        )));
+        } = geometry_to_vertices(generate(&cfg("F").generation));
         assert_eq!(vertices.len(), 2);
         assert!(close(vertices[0].position[0], 0.0) && close(vertices[0].position[1], 0.0));
         assert!(close(vertices[1].position[0], 1.0) && close(vertices[1].position[1], 0.0));
@@ -258,9 +293,7 @@ mod tests {
             vertices,
             bounds_min,
             bounds_max,
-        } = geometry_to_vertices(generate(&cfg(
-            "name=\"t\"\naxiom=\"F+F-F\"\niterations=0\nangle=90.0\nstep=1.0",
-        )));
+        } = geometry_to_vertices(generate(&cfg("F+F-F").generation));
         assert_eq!(vertices.len(), 6);
         assert!(close(bounds_min[0], 0.0) && close(bounds_min[1], 0.0));
         assert!(close(bounds_max[0], 2.0) && close(bounds_max[1], 1.0));

--- a/crates/lsystem-renderer/src/png_export.rs
+++ b/crates/lsystem-renderer/src/png_export.rs
@@ -100,7 +100,7 @@ pub async fn render_png(
     validate_width(width)?;
 
     if config.dimensions == 3 {
-        let data = geometry_to_vertices_3d(lsystem_core::generate_3d(config));
+        let data = geometry_to_vertices_3d(lsystem_core::generate_3d(&config.generation));
         let height = width; // square viewport for perspective
         let total_segments = (data.vertices.len() / 2) as u32;
         let color_params = color_params_from_config(&config.colors.line, total_segments);
@@ -122,7 +122,7 @@ pub async fn render_png(
         )
         .await
     } else {
-        let data = geometry_to_vertices(lsystem_core::generate(config));
+        let data = geometry_to_vertices(lsystem_core::generate(&config.generation));
         let height = derive_height(width, data.bounds_min, data.bounds_max)?;
         let total_segments = (data.vertices.len() / 2) as u32;
         let color_params = color_params_from_config(&config.colors.line, total_segments);

--- a/crates/lsystem-web-app/src/app.rs
+++ b/crates/lsystem-web-app/src/app.rs
@@ -29,10 +29,15 @@ pub(crate) fn App() -> impl IntoView {
     let (toml_text, set_toml_text) = signal(first_toml);
     let (base_config, set_base_config) = signal(Some(initial.config.clone()));
     let (error, set_error) = signal(None::<String>);
-    let (iterations, set_iterations) =
-        signal(initial.config.iterations.min(initial.max_iterations));
+    let (iterations, set_iterations) = signal(
+        initial
+            .config
+            .generation
+            .iterations
+            .min(initial.max_iterations),
+    );
     let (max_iterations, set_max_iterations) = signal(initial.max_iterations);
-    let (angle, set_angle) = signal(initial.config.angle);
+    let (angle, set_angle) = signal(initial.config.generation.angle);
     let (png_width, set_png_width) = signal(2048u32);
     let (gpu_error, set_gpu_error) = signal(None::<String>);
     let (auto_rotate, set_auto_rotate) = signal(false);
@@ -163,8 +168,8 @@ pub(crate) fn App() -> impl IntoView {
                 let max = applied.max_iterations;
                 let new_is_3d = applied.config.dimensions == 3;
                 set_max_iterations.set(max);
-                set_iterations.set(applied.config.iterations.min(max));
-                set_angle.set(applied.config.angle);
+                set_iterations.set(applied.config.generation.iterations.min(max));
+                set_angle.set(applied.config.generation.angle);
                 set_base_config.set(Some(applied.config));
                 set_error.set(None);
                 if !new_is_3d && auto_rotate.get_untracked() {

--- a/crates/lsystem-web-app/src/app.rs
+++ b/crates/lsystem-web-app/src/app.rs
@@ -222,15 +222,24 @@ pub(crate) fn App() -> impl IntoView {
                         window.clear_interval_with_handle(id);
                     }
                 });
-                if let Some(window) = web_sys::window()
-                    && let Ok(id) = window.set_interval_with_callback_and_timeout_and_arguments_0(
+                if let Some(window) = web_sys::window() {
+                    match window.set_interval_with_callback_and_timeout_and_arguments_0(
                         closure.as_ref().unchecked_ref(),
                         AUTO_ROTATE_DT_MS as i32,
-                    )
-                {
-                    interval_id_store.set(Some(id));
+                    ) {
+                        Ok(id) => {
+                            interval_id_store.set(Some(id));
+                            closure.forget();
+                        }
+                        Err(err) => {
+                            log::error!("Failed to start auto-rotate interval: {err:?}");
+                            set_auto_rotate.set(false);
+                        }
+                    }
+                } else {
+                    log::error!("Failed to start auto-rotate interval: window is unavailable");
+                    set_auto_rotate.set(false);
                 }
-                closure.forget();
             }
         }
     };
@@ -373,6 +382,7 @@ pub(crate) fn App() -> impl IntoView {
                                         iterations.get_untracked(),
                                         angle.get_untracked(),
                                         png_width.get_untracked(),
+                                        move |error| set_gpu_error.set(Some(error)),
                                     );
                                 }
                             }
@@ -612,10 +622,8 @@ fn install_resize_listener<H>(
             );
         }
     });
-    if window
-        .add_event_listener_with_callback("resize", closure.as_ref().unchecked_ref())
-        .is_ok()
-    {
-        closure.forget();
+    match window.add_event_listener_with_callback("resize", closure.as_ref().unchecked_ref()) {
+        Ok(()) => closure.forget(),
+        Err(err) => log::error!("Failed to install resize listener: {err:?}"),
     }
 }

--- a/crates/lsystem-web-app/src/export.rs
+++ b/crates/lsystem-web-app/src/export.rs
@@ -17,8 +17,9 @@ pub(crate) fn export_svg(config: Option<Config>, iterations: u32, angle: f32) {
     array.push(&wasm_bindgen::JsValue::from_str(&svg));
     let props = web_sys::BlobPropertyBag::new();
     props.set_type("image/svg+xml");
-    if let Ok(blob) = web_sys::Blob::new_with_str_sequence_and_options(&array, &props) {
-        download_blob(blob, filename);
+    match web_sys::Blob::new_with_str_sequence_and_options(&array, &props) {
+        Ok(blob) => download_blob(blob, filename),
+        Err(err) => log::error!("Failed to create SVG export blob: {err:?}"),
     }
 }
 
@@ -28,6 +29,7 @@ pub(crate) fn export_png(
     iterations: u32,
     angle: f32,
     width: u32,
+    on_error: impl Fn(String) + 'static,
 ) {
     let Some(config) = effective_config(config, iterations, angle) else {
         return;
@@ -49,13 +51,16 @@ pub(crate) fn export_png(
                 array.push(&bytes);
                 let props = web_sys::BlobPropertyBag::new();
                 props.set_type("image/png");
-                if let Ok(blob) =
-                    web_sys::Blob::new_with_u8_array_sequence_and_options(&array, &props)
-                {
-                    download_blob(blob, filename);
+                match web_sys::Blob::new_with_u8_array_sequence_and_options(&array, &props) {
+                    Ok(blob) => download_blob(blob, filename),
+                    Err(err) => log::error!("Failed to create PNG export blob: {err:?}"),
                 }
             }
-            Err(err) => log::error!("Failed to export PNG: {err}"),
+            Err(err) => {
+                let error = format!("Failed to export PNG: {err}");
+                log::error!("{error}");
+                on_error(error);
+            }
         }
     });
 }
@@ -76,19 +81,35 @@ fn sanitize_filename(name: &str, extension: &str) -> String {
 
 fn download_blob(blob: web_sys::Blob, suggested_name: String) {
     let Some(window) = web_sys::window() else {
+        log::error!("Cannot download export: window is unavailable");
         return;
     };
     let Some(document) = window.document() else {
+        log::error!("Cannot download export: document is unavailable");
         return;
     };
-    let Ok(url) = web_sys::Url::create_object_url_with_blob(&blob) else {
-        return;
+    let url = match web_sys::Url::create_object_url_with_blob(&blob) {
+        Ok(url) => url,
+        Err(err) => {
+            log::error!("Failed to create export object URL: {err:?}");
+            return;
+        }
     };
-    let Ok(el) = document.create_element("a") else {
-        return;
+    let el = match document.create_element("a") {
+        Ok(el) => el,
+        Err(err) => {
+            log::error!("Failed to create export download link: {err:?}");
+            let _ = web_sys::Url::revoke_object_url(&url);
+            return;
+        }
     };
-    let Ok(anchor) = el.dyn_into::<web_sys::HtmlAnchorElement>() else {
-        return;
+    let anchor = match el.dyn_into::<web_sys::HtmlAnchorElement>() {
+        Ok(anchor) => anchor,
+        Err(err) => {
+            log::error!("Export download link was not an anchor element: {err:?}");
+            let _ = web_sys::Url::revoke_object_url(&url);
+            return;
+        }
     };
     anchor.set_href(&url);
     anchor.set_download(&suggested_name);

--- a/crates/lsystem-web-app/src/presets.rs
+++ b/crates/lsystem-web-app/src/presets.rs
@@ -31,7 +31,11 @@ pub(crate) fn apply_toml(text: &str) -> Result<AppliedConfig, lsystem_core::Conf
     } else {
         lsystem_renderer::line_renderer::MAX_SEGMENTS
     };
-    let max_iterations = lsystem_core::max_safe_iterations(&config.axiom, &config.rules, max_seg);
+    let max_iterations = lsystem_core::max_safe_iterations(
+        &config.generation.axiom,
+        &config.generation.rules,
+        max_seg,
+    );
     Ok(AppliedConfig {
         config,
         max_iterations,
@@ -44,8 +48,8 @@ pub(crate) fn effective_config(
     angle: f32,
 ) -> Option<Config> {
     config.map(|mut config| {
-        config.iterations = iterations;
-        config.angle = angle;
+        config.generation.iterations = iterations;
+        config.generation.angle = angle;
         config
     })
 }

--- a/crates/lsystem-web-app/src/presets.rs
+++ b/crates/lsystem-web-app/src/presets.rs
@@ -18,7 +18,13 @@ pub(crate) fn load_presets() -> Vec<(String, &'static str)> {
         .into_iter()
         .filter_map(|f| {
             let content = f.contents_utf8()?;
-            let name = Config::parse(content).ok()?.name;
+            let name = match Config::parse(content) {
+                Ok(config) => config.name,
+                Err(err) => {
+                    log::error!("Bundled preset {:?} failed to parse: {err}", f.path());
+                    return None;
+                }
+            };
             Some((name, content))
         })
         .collect()

--- a/crates/lsystem-web-app/src/renderer.rs
+++ b/crates/lsystem-web-app/src/renderer.rs
@@ -75,7 +75,7 @@ impl CanvasRenderer {
                 vertices,
                 bounds_min,
                 bounds_max,
-            } = geometry_to_vertices_3d(lsystem_core::generate_3d(config));
+            } = geometry_to_vertices_3d(lsystem_core::generate_3d(&config.generation));
             total_segments = (vertices.len() / 2) as u32;
             self.scene = ActiveScene::ThreeD {
                 vertices,
@@ -87,7 +87,7 @@ impl CanvasRenderer {
                 vertices,
                 bounds_min,
                 bounds_max,
-            } = geometry_to_vertices(lsystem_core::generate(config));
+            } = geometry_to_vertices(lsystem_core::generate(&config.generation));
             total_segments = (vertices.len() / 2) as u32;
             self.scene = ActiveScene::TwoD {
                 vertices,

--- a/presets/dragon_curve.toml
+++ b/presets/dragon_curve.toml
@@ -1,12 +1,23 @@
+[metadata]
 name = "Harter-Heightway Dragon"
+
+[l-system]
 dimensions = 2
 axiom = "FX"
 iterations = 16
-angle = 90.0
 
-[line_color]
-mode = "hue_cycle"
-
-[rules]
+[l-system.rules]
 X = "X+YF+"
 Y = "-FX-Y"
+
+[turtle]
+angle = 90.0
+step = 1.0
+initial_heading = 0.0
+
+[colors]
+background = [0.0, 0.0, 0.0]
+
+[colors.line]
+mode = "hue_cycle"
+initial = [0.9, 0.0, 0.0]

--- a/presets/gosper_curve.toml
+++ b/presets/gosper_curve.toml
@@ -1,12 +1,23 @@
+[metadata]
 name = "Gosper Curve"
+
+[l-system]
 dimensions = 2
 axiom = "XF"
 iterations = 4
-angle = 60.0
 
-[line_color]
-mode = "hue_cycle"
-
-[rules]
+[l-system.rules]
 X = "X+YF++YF-FX--FXFX-YF+"
 Y = "-FX+YFYF++YF+FX--FX-Y"
+
+[turtle]
+angle = 60.0
+step = 1.0
+initial_heading = 0.0
+
+[colors]
+background = [0.0, 0.0, 0.0]
+
+[colors.line]
+mode = "hue_cycle"
+initial = [0.9, 0.0, 0.0]

--- a/presets/hilbert_curve.toml
+++ b/presets/hilbert_curve.toml
@@ -1,12 +1,23 @@
+[metadata]
 name = "Hilbert Curve"
+
+[l-system]
 dimensions = 2
 axiom = "A"
 iterations = 5
-angle = 90.0
 
-[line_color]
-mode = "hue_cycle"
-
-[rules]
+[l-system.rules]
 A = "-BF+AFA+FB-"
 B = "+AF-BFB-FA+"
+
+[turtle]
+angle = 90.0
+step = 1.0
+initial_heading = 0.0
+
+[colors]
+background = [0.0, 0.0, 0.0]
+
+[colors.line]
+mode = "hue_cycle"
+initial = [0.9, 0.0, 0.0]

--- a/presets/hilbert_curve_3d.toml
+++ b/presets/hilbert_curve_3d.toml
@@ -1,11 +1,22 @@
+[metadata]
 name = "3D Hilbert Curve"
+
+[l-system]
 dimensions = 3
 axiom = "X"
 iterations = 3
-angle = 90.0
 
-[line_color]
-mode = "hue_cycle"
-
-[rules]
+[l-system.rules]
 X = '^\XF^\XFX-F^//XFX&F+//XFX-F/X-/'
+
+[turtle]
+angle = 90.0
+step = 1.0
+initial_heading = 0.0
+
+[colors]
+background = [0.0, 0.0, 0.0]
+
+[colors.line]
+mode = "hue_cycle"
+initial = [0.9, 0.0, 0.0]

--- a/presets/koch_snowflake.toml
+++ b/presets/koch_snowflake.toml
@@ -1,11 +1,22 @@
+[metadata]
 name = "Koch Snowflake"
+
+[l-system]
 dimensions = 2
 axiom = "F++F++F"
 iterations = 6
-angle = 60.0
 
-[line_color]
-mode = "hue_cycle"
-
-[rules]
+[l-system.rules]
 F = "F-F++F-F"
+
+[turtle]
+angle = 60.0
+step = 1.0
+initial_heading = 0.0
+
+[colors]
+background = [0.0, 0.0, 0.0]
+
+[colors.line]
+mode = "hue_cycle"
+initial = [0.9, 0.0, 0.0]

--- a/presets/peano_curve.toml
+++ b/presets/peano_curve.toml
@@ -1,12 +1,23 @@
+[metadata]
 name = "Peano Curve"
+
+[l-system]
 dimensions = 2
 axiom = "L"
 iterations = 4
-angle = 90.0
 
-[line_color]
-mode = "hue_cycle"
-
-[rules]
+[l-system.rules]
 L = "LFRFL-F-RFLFR+F+LFRFL"
 R = "RFLFR+F+LFRFL-F-RFLFR"
+
+[turtle]
+angle = 90.0
+step = 1.0
+initial_heading = 0.0
+
+[colors]
+background = [0.0, 0.0, 0.0]
+
+[colors.line]
+mode = "hue_cycle"
+initial = [0.9, 0.0, 0.0]

--- a/presets/plant_3d.toml
+++ b/presets/plant_3d.toml
@@ -1,15 +1,24 @@
+[metadata]
 name = "3D Plant"
+
+[l-system]
 dimensions = 3
 axiom = "X"
 iterations = 6
-angle = 30
+
+[l-system.rules]
+X = "F[+X][-X][&X][^X]"
+F = "FF"
+
+[turtle]
+angle = 30.0
+step = 1.0
 initial_heading = 90.0
 
-[line_color]
+[colors]
+background = [0.0, 0.0, 0.0]
+
+[colors.line]
 mode = "gradient"
 start = [0.35, 0.35, 0.05]
 end = [0.2, 0.85, 0.25]
-
-[rules]
-X = "F[+X][-X][&X][^X]"
-F = "FF"

--- a/presets/plant_a.toml
+++ b/presets/plant_a.toml
@@ -1,15 +1,24 @@
+[metadata]
 name = "Plant A"
+
+[l-system]
 dimensions = 2
 axiom = "X"
 iterations = 7
+
+[l-system.rules]
+X = "F+[[X]-X]-F[-FX]+X"
+F = "FF"
+
+[turtle]
 angle = 25.0
+step = 1.0
 initial_heading = 90.0
 
-[line_color]
+[colors]
+background = [0.0, 0.0, 0.0]
+
+[colors.line]
 mode = "gradient"
 start = [0.05, 0.35, 0.05]
 end = [0.6, 0.9, 0.1]
-
-[rules]
-X = "F+[[X]-X]-F[-FX]+X"
-F = "FF"

--- a/presets/sierpinski_curve.toml
+++ b/presets/sierpinski_curve.toml
@@ -1,11 +1,22 @@
+[metadata]
 name = "Sierpinski Curve"
+
+[l-system]
 dimensions = 2
 axiom = "F+XF+F+XF"
 iterations = 5
-angle = 90.0
 
-[line_color]
-mode = "hue_cycle"
-
-[rules]
+[l-system.rules]
 X = "XF-F+F-XF+F+XF-F+F-X"
+
+[turtle]
+angle = 90.0
+step = 1.0
+initial_heading = 0.0
+
+[colors]
+background = [0.0, 0.0, 0.0]
+
+[colors.line]
+mode = "hue_cycle"
+initial = [0.9, 0.0, 0.0]

--- a/presets/sierpinski_triangle.toml
+++ b/presets/sierpinski_triangle.toml
@@ -1,12 +1,23 @@
+[metadata]
 name = "Sierpinski Triangle"
+
+[l-system]
 dimensions = 2
 axiom = "FXF-FF-FF"
 iterations = 9
-angle = 120.0
 
-[line_color]
-mode = "hue_cycle"
-
-[rules]
+[l-system.rules]
 F = "FF"
 X = "-FXF+FXF+FXF-"
+
+[turtle]
+angle = 120.0
+step = 1.0
+initial_heading = 0.0
+
+[colors]
+background = [0.0, 0.0, 0.0]
+
+[colors.line]
+mode = "hue_cycle"
+initial = [0.9, 0.0, 0.0]

--- a/presets/snowflake.toml
+++ b/presets/snowflake.toml
@@ -1,8 +1,22 @@
+[metadata]
 name = "Snowflake"
+
+[l-system]
 dimensions = 2
 axiom = "[F]+[F]+[F]+[F]+[F]+[F]"
 iterations = 4
-angle = 60.0
 
-[rules]
+[l-system.rules]
 F = "F[+FF][-FF]FF[+F][-F]FF"
+
+[turtle]
+angle = 60.0
+step = 1.0
+initial_heading = 0.0
+
+[colors]
+background = [0.0, 0.0, 0.0]
+
+[colors.line]
+mode = "solid"
+color = [0.0, 0.9, 0.5]

--- a/presets/ternary_tree_3d.toml
+++ b/presets/ternary_tree_3d.toml
@@ -1,15 +1,24 @@
+[metadata]
 name = "3D Ternary Tree"
+
+[l-system]
 dimensions = 3
 axiom = "FA"
 iterations = 8
+
+[l-system.rules]
+A = '[&FA]///[&FA]///[&FA]'
+F = 'FF'
+
+[turtle]
 angle = 40.0
+step = 1.0
 initial_heading = 90.0
 
-[line_color]
+[colors]
+background = [0.0, 0.0, 0.0]
+
+[colors.line]
 mode = "gradient"
 start = [0.55, 0.25, 0.05]
 end = [0.10, 0.95, 0.45]
-
-[rules]
-A = '[&FA]///[&FA]///[&FA]'
-F = 'FF'

--- a/presets/tree_3d.toml
+++ b/presets/tree_3d.toml
@@ -1,13 +1,23 @@
+[metadata]
 name = "3D Tree"
+
+[l-system]
 dimensions = 3
 axiom = "A"
 iterations = 7
-angle = 40.0
-initial_heading = 90.0
 
-[line_color]
-mode = "hue_cycle"
-
-[rules]
+[l-system.rules]
 A = 'F[+/A]/[-/A]F[&/A]/[^/A]'
 F = 'FF'
+
+[turtle]
+angle = 40.0
+step = 1.0
+initial_heading = 90.0
+
+[colors]
+background = [0.0, 0.0, 0.0]
+
+[colors.line]
+mode = "hue_cycle"
+initial = [0.9, 0.0, 0.0]


### PR DESCRIPTION
## Summary
- Replace serde/RawConfig parsing in lsystem-core with a format-preserving ConfigDocument backed by toml_edit::DocumentMut.
- Keep the nested TOML schema explicit, including [metadata], [l-system], [l-system.rules], [turtle], [colors], and [colors.line].
- Restructure Config around metadata, dimensions, GenerationConfig, and colors, with generate/generate_3d now consuming GenerationConfig directly.
- Preserve unchanged TOML byte-for-byte while generating canonical TOML with literal L-system strings and inline color arrays.
- Store hue-cycle colors as RGB, share RGB-to-HSV conversion between renderer and SVG export, and keep strict per-component RGB validation.
- Update native/web call sites, tests, README, and AGENTS docs for the new config model.