### PR TITLE
Narrow Config params to more specific types

### DIFF
--- a/crates/lsystem-app/src/export.rs
+++ b/crates/lsystem-app/src/export.rs
@@ -80,7 +80,7 @@ pub(crate) async fn handle_export(request: ExportRequest) -> ExportOutcome {
         } => save_png(config, width, path, camera).await,
         #[cfg(target_arch = "wasm32")]
         ExportRequest::Svg(config) => {
-            let filename = suggested_filename(&config, ExportKind::Svg);
+            let filename = suggested_filename(&config.name, ExportKind::Svg);
             let svg = lsystem_core::svg_export::export_svg(&config);
             save_svg(svg, filename)
         }
@@ -90,22 +90,22 @@ pub(crate) async fn handle_export(request: ExportRequest) -> ExportOutcome {
             width,
             camera,
         } => {
-            let filename = suggested_filename(&config, ExportKind::Png);
+            let filename = suggested_filename(&config.name, ExportKind::Png);
             save_png(config, width, camera, filename).await
         }
     }
 }
 
 #[cfg(not(target_arch = "wasm32"))]
-pub(crate) fn choose_export_path(config: &Config, kind: ExportKind) -> Option<PathBuf> {
+pub(crate) fn choose_export_path(name: &str, kind: ExportKind) -> Option<PathBuf> {
     rfd::FileDialog::new()
-        .set_file_name(suggested_filename(config, kind))
+        .set_file_name(suggested_filename(name, kind))
         .add_filter(kind.filter_name(), &[kind.extension()])
         .save_file()
 }
 
-fn suggested_filename(config: &Config, kind: ExportKind) -> String {
-    sanitize_filename(&config.name, kind.extension())
+fn suggested_filename(name: &str, kind: ExportKind) -> String {
+    sanitize_filename(name, kind.extension())
 }
 
 fn sanitize_filename(name: &str, extension: &str) -> String {

--- a/crates/lsystem-app/src/ui/app_state.rs
+++ b/crates/lsystem-app/src/ui/app_state.rs
@@ -387,7 +387,7 @@ impl FractalApp {
 
         #[cfg(not(target_arch = "wasm32"))]
         let request = {
-            let Some(path) = choose_export_path(&config, kind) else {
+            let Some(path) = choose_export_path(&config.name, kind) else {
                 return Task::done(Message::ExportFinished(ExportOutcome::Cancelled));
             };
 

--- a/crates/lsystem-app/src/ui/fractal_canvas.rs
+++ b/crates/lsystem-app/src/ui/fractal_canvas.rs
@@ -1,7 +1,7 @@
 use iced::mouse;
 use iced::widget::{container, shader};
 use iced::{Background, Color, Element, Event, Length, Point, Rectangle, Size, Theme};
-use lsystem_core::Config;
+use lsystem_core::{ColorConfig, Config};
 use lsystem_renderer::camera::Camera;
 use lsystem_renderer::line_renderer::{
     ColorParams, LinePipeline2D, LinePipeline3D, Vertex2D, Vertex3D,
@@ -44,7 +44,7 @@ pub(super) struct Scene {
 
 impl Scene {
     fn from_vertex_data_2d(
-        config: &Config,
+        colors: &ColorConfig,
         data: VertexData,
         camera: Camera,
         revision: u64,
@@ -56,15 +56,15 @@ impl Scene {
                 bounds_min: data.bounds_min,
                 bounds_max: data.bounds_max,
             },
-            color_params: color_params_from_config(&config.colors.line, total_segments),
-            background: config.colors.background,
+            color_params: color_params_from_config(&colors.line, total_segments),
+            background: colors.background,
             camera,
             revision,
         }
     }
 
     fn from_vertex_data_3d(
-        config: &Config,
+        colors: &ColorConfig,
         data: VertexData3D,
         camera: Camera,
         revision: u64,
@@ -76,8 +76,8 @@ impl Scene {
                 bounds_min: data.bounds_min,
                 bounds_max: data.bounds_max,
             },
-            color_params: color_params_from_config(&config.colors.line, total_segments),
-            background: config.colors.background,
+            color_params: color_params_from_config(&colors.line, total_segments),
+            background: colors.background,
             camera,
             revision,
         }
@@ -215,7 +215,7 @@ pub(super) async fn build_scene(
 
         SceneBuildResult::Ready {
             generation,
-            scene: Scene::from_vertex_data_3d(&config, builder.finish(), camera, generation),
+            scene: Scene::from_vertex_data_3d(&config.colors, builder.finish(), camera, generation),
         }
     } else {
         let mut builder = VertexDataBuilder::new();
@@ -241,7 +241,7 @@ pub(super) async fn build_scene(
 
         SceneBuildResult::Ready {
             generation,
-            scene: Scene::from_vertex_data_2d(&config, builder.finish(), camera, generation),
+            scene: Scene::from_vertex_data_2d(&config.colors, builder.finish(), camera, generation),
         }
     }
 }

--- a/crates/lsystem-web-app/src/app.rs
+++ b/crates/lsystem-web-app/src/app.rs
@@ -27,7 +27,8 @@ pub(crate) fn App() -> impl IntoView {
     .expect("bundled presets should parse");
     let first_toml = initial_workspace.selected_draft_text().to_string();
     let initial_config = initial_workspace.selected_applied_config().clone();
-    let initial_max_iterations = max_iterations_for_config(&initial_config);
+    let initial_max_iterations =
+        max_iterations_for_config(initial_config.dimensions, &initial_config.generation);
 
     let (preset_idx, set_preset_idx) = signal(0usize);
     let (config_workspace, set_config_workspace) = signal(initial_workspace);
@@ -166,7 +167,7 @@ pub(crate) fn App() -> impl IntoView {
     );
 
     let install_config = Rc::new(move |config: Config| {
-        let max = max_iterations_for_config(&config);
+        let max = max_iterations_for_config(config.dimensions, &config.generation);
         set_max_iterations.set(max);
         set_iterations.set(config.generation.iterations.min(max));
         set_angle.set(config.generation.angle);

--- a/crates/lsystem-web-app/src/presets.rs
+++ b/crates/lsystem-web-app/src/presets.rs
@@ -1,5 +1,5 @@
 use include_dir::{Dir, include_dir};
-use lsystem_core::Config;
+use lsystem_core::{Config, GenerationConfig};
 
 static PRESETS_DIR: Dir<'_> = include_dir!("$CARGO_MANIFEST_DIR/../../presets");
 
@@ -25,13 +25,13 @@ pub(crate) fn load_presets() -> Vec<(String, &'static str)> {
         .collect()
 }
 
-pub(crate) fn max_iterations_for_config(config: &Config) -> u32 {
-    let max_seg = if config.dimensions == 3 {
+pub(crate) fn max_iterations_for_config(dimensions: u8, generation: &GenerationConfig) -> u32 {
+    let max_seg = if dimensions == 3 {
         lsystem_renderer::line_renderer::MAX_SEGMENTS_3D
     } else {
         lsystem_renderer::line_renderer::MAX_SEGMENTS
     };
-    lsystem_core::max_safe_iterations(&config.generation.axiom, &config.generation.rules, max_seg)
+    lsystem_core::max_safe_iterations(&generation.axiom, &generation.rules, max_seg)
 }
 
 pub(crate) fn effective_config(


### PR DESCRIPTION
## What changed

Three functions accepted `&Config` but only accessed a subset of its fields. Each parameter now reflects exactly what the function needs:

- **`Scene::from_vertex_data_2d/3d`** (`fractal_canvas.rs`): parameter narrows from `&Config` to `&ColorConfig` — only `colors.line` and `colors.background` were read.
- **`choose_export_path` / `suggested_filename`** (`export.rs`): parameter narrows from `&Config` to `&str` — only `name` was used to construct a filename.
- **`max_iterations_for_config`** (`presets.rs`): parameter narrows from `&Config` to `(dimensions: u8, generation: &GenerationConfig)` — only those two fields were read.

## Why

Narrower parameter types make each function's actual dependencies explicit at the call site, and prevent callers from needing to construct or hold a full `Config` just to satisfy the signature.