### PR TITLE
Model dimensions as Dimensions enum in GenerationConfig

### DIFF
--- a/crates/lsystem-app/src/ui/app_state.rs
+++ b/crates/lsystem-app/src/ui/app_state.rs
@@ -324,11 +324,8 @@ impl FractalApp {
         let Some(config) = &self.base_config else {
             return;
         };
-        let max_seg = if config.dimensions == 3 {
-            lsystem_renderer::line_renderer::MAX_SEGMENTS_3D
-        } else {
-            lsystem_renderer::line_renderer::MAX_SEGMENTS
-        };
+        let max_seg =
+            lsystem_renderer::line_renderer::max_segments_for(config.generation.dimensions);
         self.max_iterations = lsystem_core::max_safe_iterations(
             &config.generation.axiom,
             &config.generation.rules,

--- a/crates/lsystem-app/src/ui/fractal_canvas.rs
+++ b/crates/lsystem-app/src/ui/fractal_canvas.rs
@@ -1,7 +1,7 @@
 use iced::mouse;
 use iced::widget::{container, shader};
 use iced::{Background, Color, Element, Event, Length, Point, Rectangle, Size, Theme};
-use lsystem_core::{ColorConfig, Config};
+use lsystem_core::{ColorConfig, Config, Dimensions};
 use lsystem_renderer::camera::Camera;
 use lsystem_renderer::line_renderer::{
     ColorParams, LinePipeline2D, LinePipeline3D, Vertex2D, Vertex3D,
@@ -191,57 +191,70 @@ pub(super) async fn build_scene(
     let mut camera = prev_camera;
     camera.reset_position();
 
-    if config.dimensions == 3 {
-        let mut builder = VertexDataBuilder3D::new();
-        let mut segments_seen = 0usize;
+    match config.generation.dimensions {
+        Dimensions::ThreeD => {
+            let mut builder = VertexDataBuilder3D::new();
+            let mut segments_seen = 0usize;
 
-        for segment in lsystem_core::generate_3d(&config.generation) {
-            if segments_seen.is_multiple_of(CANCELLATION_CHECK_INTERVAL) {
-                if is_cancelled(generation, &current_generation) {
-                    return SceneBuildResult::Cancelled;
+            for segment in lsystem_core::generate_3d(&config.generation) {
+                if segments_seen.is_multiple_of(CANCELLATION_CHECK_INTERVAL) {
+                    if is_cancelled(generation, &current_generation) {
+                        return SceneBuildResult::Cancelled;
+                    }
+                    yield_generation().await;
+                    if is_cancelled(generation, &current_generation) {
+                        return SceneBuildResult::Cancelled;
+                    }
                 }
-                yield_generation().await;
-                if is_cancelled(generation, &current_generation) {
-                    return SceneBuildResult::Cancelled;
-                }
+                builder.push_segment(segment);
+                segments_seen = segments_seen.wrapping_add(1);
             }
-            builder.push_segment(segment);
-            segments_seen = segments_seen.wrapping_add(1);
-        }
 
-        if is_cancelled(generation, &current_generation) {
-            return SceneBuildResult::Cancelled;
-        }
-
-        SceneBuildResult::Ready {
-            generation,
-            scene: Scene::from_vertex_data_3d(&config.colors, builder.finish(), camera, generation),
-        }
-    } else {
-        let mut builder = VertexDataBuilder::new();
-        let mut segments_seen = 0usize;
-
-        for segment in lsystem_core::generate(&config.generation) {
-            if segments_seen.is_multiple_of(CANCELLATION_CHECK_INTERVAL) {
-                if is_cancelled(generation, &current_generation) {
-                    return SceneBuildResult::Cancelled;
-                }
-                yield_generation().await;
-                if is_cancelled(generation, &current_generation) {
-                    return SceneBuildResult::Cancelled;
-                }
+            if is_cancelled(generation, &current_generation) {
+                return SceneBuildResult::Cancelled;
             }
-            builder.push_segment(segment);
-            segments_seen = segments_seen.wrapping_add(1);
-        }
 
-        if is_cancelled(generation, &current_generation) {
-            return SceneBuildResult::Cancelled;
+            SceneBuildResult::Ready {
+                generation,
+                scene: Scene::from_vertex_data_3d(
+                    &config.colors,
+                    builder.finish(),
+                    camera,
+                    generation,
+                ),
+            }
         }
+        Dimensions::TwoD => {
+            let mut builder = VertexDataBuilder::new();
+            let mut segments_seen = 0usize;
 
-        SceneBuildResult::Ready {
-            generation,
-            scene: Scene::from_vertex_data_2d(&config.colors, builder.finish(), camera, generation),
+            for segment in lsystem_core::generate(&config.generation) {
+                if segments_seen.is_multiple_of(CANCELLATION_CHECK_INTERVAL) {
+                    if is_cancelled(generation, &current_generation) {
+                        return SceneBuildResult::Cancelled;
+                    }
+                    yield_generation().await;
+                    if is_cancelled(generation, &current_generation) {
+                        return SceneBuildResult::Cancelled;
+                    }
+                }
+                builder.push_segment(segment);
+                segments_seen = segments_seen.wrapping_add(1);
+            }
+
+            if is_cancelled(generation, &current_generation) {
+                return SceneBuildResult::Cancelled;
+            }
+
+            SceneBuildResult::Ready {
+                generation,
+                scene: Scene::from_vertex_data_2d(
+                    &config.colors,
+                    builder.finish(),
+                    camera,
+                    generation,
+                ),
+            }
         }
     }
 }

--- a/crates/lsystem-core/src/alphabet.rs
+++ b/crates/lsystem-core/src/alphabet.rs
@@ -1,9 +1,13 @@
-use crate::config::ConfigError;
+use crate::config::{ConfigError, Dimensions};
 
 const TERMINALS_UNIVERSAL: &str = "Ff+-|[]";
 const TERMINALS_3D: &str = "&^/\\";
 
-pub fn validate_symbols(chars: &str, field: &str, dimensions: u8) -> Result<(), ConfigError> {
+pub fn validate_symbols(
+    chars: &str,
+    field: &str,
+    dimensions: Dimensions,
+) -> Result<(), ConfigError> {
     for (position, ch) in chars.chars().enumerate() {
         if ch.is_ascii_alphabetic() {
             continue;
@@ -11,7 +15,7 @@ pub fn validate_symbols(chars: &str, field: &str, dimensions: u8) -> Result<(), 
         if TERMINALS_UNIVERSAL.contains(ch) {
             continue;
         }
-        if dimensions == 3 && TERMINALS_3D.contains(ch) {
+        if dimensions == Dimensions::ThreeD && TERMINALS_3D.contains(ch) {
             continue;
         }
         return Err(ConfigError::InvalidSymbol {

--- a/crates/lsystem-core/src/config.rs
+++ b/crates/lsystem-core/src/config.rs
@@ -60,6 +60,13 @@ pub enum ConfigError {
     },
 }
 
+/// Spatial dimensions of an L-system: 2D or 3D.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub enum Dimensions {
+    TwoD,
+    ThreeD,
+}
+
 /// Color mode for the fractal lines.
 #[derive(Debug, Clone, PartialEq)]
 pub enum LineColorConfig {
@@ -96,8 +103,6 @@ impl Default for ColorConfig {
 #[derive(Debug, Clone, PartialEq)]
 pub struct Config {
     pub name: String,
-    /// Number of spatial dimensions: 2 or 3.
-    pub dimensions: u8,
     pub generation: GenerationConfig,
     pub colors: ColorConfig,
 }
@@ -105,6 +110,7 @@ pub struct Config {
 /// Validated inputs needed to expand an L-system and run the turtle.
 #[derive(Debug, Clone, PartialEq)]
 pub struct GenerationConfig {
+    pub dimensions: Dimensions,
     pub axiom: String,
     pub iterations: u32,
     /// Turn angle in degrees.
@@ -233,8 +239,8 @@ impl ConfigDocument {
 
         Ok(Config {
             name: required_str(metadata, "metadata.name")?.to_string(),
-            dimensions,
             generation: GenerationConfig {
+                dimensions,
                 axiom,
                 iterations: required_u32(l_system, "l-system.iterations")?,
                 angle,
@@ -257,7 +263,10 @@ impl ConfigDocument {
         document["metadata"]["name"] = value(config.name.clone());
 
         document["l-system"] = Item::Table(Table::new());
-        document["l-system"]["dimensions"] = value(i64::from(config.dimensions));
+        document["l-system"]["dimensions"] = value(match config.generation.dimensions {
+            Dimensions::TwoD => 2i64,
+            Dimensions::ThreeD => 3i64,
+        });
         document["l-system"]["axiom"] = literal_string_item(&config.generation.axiom);
         document["l-system"]["iterations"] = value(i64::from(config.generation.iterations));
 
@@ -394,7 +403,7 @@ fn required_str<'a>(table: &'a impl TableLike, field: &str) -> Result<&'a str, C
         })
 }
 
-fn required_dimensions(table: &impl TableLike, field: &str) -> Result<u8, ConfigError> {
+fn required_dimensions(table: &impl TableLike, field: &str) -> Result<Dimensions, ConfigError> {
     let value =
         required_item(table, field)?
             .as_integer()
@@ -403,8 +412,8 @@ fn required_dimensions(table: &impl TableLike, field: &str) -> Result<u8, Config
                 expected: "integer",
             })?;
     match value {
-        2 => Ok(2),
-        3 => Ok(3),
+        2 => Ok(Dimensions::TwoD),
+        3 => Ok(Dimensions::ThreeD),
         other => Err(ConfigError::InvalidDimensions(other)),
     }
 }
@@ -626,7 +635,7 @@ end = [ 0.7, 0.8, 0.9 ]
         let cfg = Config::parse(NESTED_KOCH_TOML).unwrap();
 
         assert_eq!(cfg.name, "Koch Snowflake");
-        assert_eq!(cfg.dimensions, 2);
+        assert_eq!(cfg.generation.dimensions, Dimensions::TwoD);
         assert_eq!(cfg.generation.axiom, "F++F++F");
         assert_eq!(cfg.generation.angle, 60.0);
         assert_eq!(cfg.generation.step, 1.0);
@@ -638,7 +647,7 @@ end = [ 0.7, 0.8, 0.9 ]
     #[test]
     fn config_document_from_config_writes_canonical_nested_toml() {
         let mut cfg = Config::parse(NESTED_KOCH_TOML).unwrap();
-        cfg.dimensions = 3;
+        cfg.generation.dimensions = Dimensions::ThreeD;
         cfg.generation.axiom = "F\\F".to_string();
         cfg.generation.rules.insert('F', "F\\F".to_string());
         cfg.colors.line = LineColorConfig::Gradient {
@@ -672,7 +681,7 @@ end = [ 0.7, 0.8, 0.9 ]
     fn parses_nested_v2_config() {
         let cfg = Config::parse(NESTED_KOCH_TOML).unwrap();
         assert_eq!(cfg.name, "Koch Snowflake");
-        assert_eq!(cfg.dimensions, 2);
+        assert_eq!(cfg.generation.dimensions, Dimensions::TwoD);
         assert_eq!(cfg.generation.axiom, "F++F++F");
         assert_eq!(cfg.generation.angle, 60.0);
         assert_eq!(cfg.generation.step, 1.0);
@@ -746,7 +755,10 @@ color = [0.1, 0.2, 0.3]
 
         let round_tripped = Config::parse(&serialized).unwrap();
         assert_eq!(round_tripped.name, cfg.name);
-        assert_eq!(round_tripped.dimensions, cfg.dimensions);
+        assert_eq!(
+            round_tripped.generation.dimensions,
+            cfg.generation.dimensions
+        );
         assert_eq!(round_tripped.generation.axiom, cfg.generation.axiom);
         assert_eq!(
             round_tripped.generation.iterations,

--- a/crates/lsystem-core/src/lib.rs
+++ b/crates/lsystem-core/src/lib.rs
@@ -9,7 +9,7 @@ pub mod grammar;
 pub(crate) mod turtle;
 
 pub use config::{
-    ColorConfig, Config, ConfigDocument, ConfigError, GenerationConfig, LineColorConfig,
+    ColorConfig, Config, ConfigDocument, ConfigError, Dimensions, GenerationConfig, LineColorConfig,
 };
 pub use config_workspace::{ConfigWorkspace, ConfigWorkspaceEntry, ConfigWorkspaceError};
 pub use grammar::max_safe_iterations;

--- a/crates/lsystem-renderer/src/line_renderer.rs
+++ b/crates/lsystem-renderer/src/line_renderer.rs
@@ -3,6 +3,7 @@ use std::fmt::{Display, Formatter};
 use std::sync::Arc;
 
 use bytemuck::{Pod, Zeroable};
+use lsystem_core::Dimensions;
 use wgpu::util::DeviceExt;
 
 use crate::wgpu_util;
@@ -48,11 +49,19 @@ impl Default for Mvp {
 
 /// Maximum number of line segments that fit in a 256 MiB vertex buffer (wgpu's guaranteed limit).
 /// Each 2D segment occupies 2 vertices × `size_of::<Vertex2D>()` bytes.
-pub const MAX_SEGMENTS: u64 = 268_435_456 / (2 * std::mem::size_of::<Vertex2D>() as u64);
+const MAX_SEGMENTS_2D: u64 = 268_435_456 / (2 * std::mem::size_of::<Vertex2D>() as u64);
 
 /// Maximum number of 3D line segments that fit in a 256 MiB vertex buffer.
 /// Each 3D segment occupies 2 vertices × `size_of::<Vertex3D>()` bytes.
-pub const MAX_SEGMENTS_3D: u64 = 268_435_456 / (2 * std::mem::size_of::<Vertex3D>() as u64);
+const MAX_SEGMENTS_3D: u64 = 268_435_456 / (2 * std::mem::size_of::<Vertex3D>() as u64);
+
+/// Returns the segment cap appropriate for the given dimensions.
+pub fn max_segments_for(dimensions: Dimensions) -> u64 {
+    match dimensions {
+        Dimensions::ThreeD => MAX_SEGMENTS_3D,
+        Dimensions::TwoD => MAX_SEGMENTS_2D,
+    }
+}
 
 /// Per-frame color parameters written to the GPU as a uniform.
 /// Layout mirrors `ColorParams` in `shader.wgsl`; padding keeps vec4 alignment.

--- a/crates/lsystem-renderer/src/png_export.rs
+++ b/crates/lsystem-renderer/src/png_export.rs
@@ -2,7 +2,7 @@ use std::error::Error;
 use std::fmt::{Display, Formatter};
 
 use futures_channel::oneshot;
-use lsystem_core::Config;
+use lsystem_core::{Config, Dimensions};
 
 use crate::camera::Camera;
 use crate::line_renderer::{LinePipeline2D, LinePipeline3D};
@@ -99,57 +99,60 @@ pub async fn render_png(
 ) -> Result<PngExport, PngExportError> {
     validate_width(width)?;
 
-    if config.dimensions == 3 {
-        let data = geometry_to_vertices_3d(lsystem_core::generate_3d(&config.generation));
-        let height = width; // square viewport for perspective
-        let total_segments = (data.vertices.len() / 2) as u32;
-        let color_params = color_params_from_config(&config.colors.line, total_segments);
-        let mut pipeline = LinePipeline3D::new(device, FORMAT);
-        pipeline.upload(device, queue, &data.vertices, color_params);
-        pipeline.write_mvp(
-            queue,
-            camera.compute_mvp_3d(data.bounds_min, data.bounds_max, width, height),
-        );
-        finish_render(
-            device,
-            queue,
-            width,
-            height,
-            config.colors.background,
-            |pass| {
-                pipeline.draw(pass);
-            },
-        )
-        .await
-    } else {
-        let data = geometry_to_vertices(lsystem_core::generate(&config.generation));
-        let height = derive_height(width, data.bounds_min, data.bounds_max)?;
-        let total_segments = (data.vertices.len() / 2) as u32;
-        let color_params = color_params_from_config(&config.colors.line, total_segments);
-        let mut pipeline = LinePipeline2D::new(device, FORMAT);
-        pipeline.upload(device, queue, &data.vertices, color_params);
-        pipeline.write_transform(
-            queue,
-            viewport_transform(
-                data.bounds_min,
-                data.bounds_max,
+    match config.generation.dimensions {
+        Dimensions::ThreeD => {
+            let data = geometry_to_vertices_3d(lsystem_core::generate_3d(&config.generation));
+            let height = width; // square viewport for perspective
+            let total_segments = (data.vertices.len() / 2) as u32;
+            let color_params = color_params_from_config(&config.colors.line, total_segments);
+            let mut pipeline = LinePipeline3D::new(device, FORMAT);
+            pipeline.upload(device, queue, &data.vertices, color_params);
+            pipeline.write_mvp(
+                queue,
+                camera.compute_mvp_3d(data.bounds_min, data.bounds_max, width, height),
+            );
+            finish_render(
+                device,
+                queue,
                 width,
                 height,
-                [0.0, 0.0],
-                1.0,
-            ),
-        );
-        finish_render(
-            device,
-            queue,
-            width,
-            height,
-            config.colors.background,
-            |pass| {
-                pipeline.draw(pass);
-            },
-        )
-        .await
+                config.colors.background,
+                |pass| {
+                    pipeline.draw(pass);
+                },
+            )
+            .await
+        }
+        Dimensions::TwoD => {
+            let data = geometry_to_vertices(lsystem_core::generate(&config.generation));
+            let height = derive_height(width, data.bounds_min, data.bounds_max)?;
+            let total_segments = (data.vertices.len() / 2) as u32;
+            let color_params = color_params_from_config(&config.colors.line, total_segments);
+            let mut pipeline = LinePipeline2D::new(device, FORMAT);
+            pipeline.upload(device, queue, &data.vertices, color_params);
+            pipeline.write_transform(
+                queue,
+                viewport_transform(
+                    data.bounds_min,
+                    data.bounds_max,
+                    width,
+                    height,
+                    [0.0, 0.0],
+                    1.0,
+                ),
+            );
+            finish_render(
+                device,
+                queue,
+                width,
+                height,
+                config.colors.background,
+                |pass| {
+                    pipeline.draw(pass);
+                },
+            )
+            .await
+        }
     }
 }
 

--- a/crates/lsystem-web-app/src/app.rs
+++ b/crates/lsystem-web-app/src/app.rs
@@ -4,7 +4,7 @@ use std::sync::Arc;
 
 use leptos::html::Canvas;
 use leptos::prelude::*;
-use lsystem_core::{Config, ConfigWorkspace};
+use lsystem_core::{Config, ConfigWorkspace, Dimensions};
 use lsystem_renderer::line_renderer::FrameSkipReason;
 use wasm_bindgen::JsCast;
 use wasm_bindgen::closure::Closure;
@@ -27,8 +27,7 @@ pub(crate) fn App() -> impl IntoView {
     .expect("bundled presets should parse");
     let first_toml = initial_workspace.selected_draft_text().to_string();
     let initial_config = initial_workspace.selected_applied_config().clone();
-    let initial_max_iterations =
-        max_iterations_for_config(initial_config.dimensions, &initial_config.generation);
+    let initial_max_iterations = max_iterations_for_config(&initial_config.generation);
 
     let (preset_idx, set_preset_idx) = signal(0usize);
     let (config_workspace, set_config_workspace) = signal(initial_workspace);
@@ -51,13 +50,13 @@ pub(crate) fn App() -> impl IntoView {
     let is_3d = move || {
         base_config
             .get()
-            .map(|c| c.dimensions == 3)
+            .map(|c| matches!(c.generation.dimensions, Dimensions::ThreeD))
             .unwrap_or(false)
     };
     let is_3d_untracked = move || {
         base_config
             .get_untracked()
-            .map(|c| c.dimensions == 3)
+            .map(|c| matches!(c.generation.dimensions, Dimensions::ThreeD))
             .unwrap_or(false)
     };
     let is_dirty = move || config_workspace.with(|workspace| workspace.selected_is_dirty());
@@ -167,7 +166,7 @@ pub(crate) fn App() -> impl IntoView {
     );
 
     let install_config = Rc::new(move |config: Config| {
-        let max = max_iterations_for_config(config.dimensions, &config.generation);
+        let max = max_iterations_for_config(&config.generation);
         set_max_iterations.set(max);
         set_iterations.set(config.generation.iterations.min(max));
         set_angle.set(config.generation.angle);
@@ -187,7 +186,7 @@ pub(crate) fn App() -> impl IntoView {
                 set_config_workspace.try_update(|workspace| workspace.apply_selected().cloned());
             match applied {
                 Some(Ok(config)) => {
-                    let new_is_3d = config.dimensions == 3;
+                    let new_is_3d = matches!(config.generation.dimensions, Dimensions::ThreeD);
                     install_config(config);
                     if !new_is_3d && auto_rotate.get_untracked() {
                         if let Some(id) = interval_id.take()

--- a/crates/lsystem-web-app/src/presets.rs
+++ b/crates/lsystem-web-app/src/presets.rs
@@ -25,12 +25,8 @@ pub(crate) fn load_presets() -> Vec<(String, &'static str)> {
         .collect()
 }
 
-pub(crate) fn max_iterations_for_config(dimensions: u8, generation: &GenerationConfig) -> u32 {
-    let max_seg = if dimensions == 3 {
-        lsystem_renderer::line_renderer::MAX_SEGMENTS_3D
-    } else {
-        lsystem_renderer::line_renderer::MAX_SEGMENTS
-    };
+pub(crate) fn max_iterations_for_config(generation: &GenerationConfig) -> u32 {
+    let max_seg = lsystem_renderer::line_renderer::max_segments_for(generation.dimensions);
     lsystem_core::max_safe_iterations(&generation.axiom, &generation.rules, max_seg)
 }
 

--- a/crates/lsystem-web-app/src/renderer.rs
+++ b/crates/lsystem-web-app/src/renderer.rs
@@ -1,6 +1,6 @@
 use std::sync::Arc;
 
-use lsystem_core::Config;
+use lsystem_core::{Config, Dimensions};
 use lsystem_renderer::camera::Camera;
 use lsystem_renderer::line_renderer::{
     ColorParams, FrameOutcome, FrameSkipReason, GpuContext, GpuInitError, LinePipeline2D,
@@ -70,30 +70,33 @@ impl CanvasRenderer {
         config: &Config,
     ) -> RenderStatus {
         let total_segments;
-        if config.dimensions == 3 {
-            let VertexData3D {
-                vertices,
-                bounds_min,
-                bounds_max,
-            } = geometry_to_vertices_3d(lsystem_core::generate_3d(&config.generation));
-            total_segments = (vertices.len() / 2) as u32;
-            self.scene = ActiveScene::ThreeD {
-                vertices,
-                bounds_min,
-                bounds_max,
-            };
-        } else {
-            let VertexData {
-                vertices,
-                bounds_min,
-                bounds_max,
-            } = geometry_to_vertices(lsystem_core::generate(&config.generation));
-            total_segments = (vertices.len() / 2) as u32;
-            self.scene = ActiveScene::TwoD {
-                vertices,
-                bounds_min,
-                bounds_max,
-            };
+        match config.generation.dimensions {
+            Dimensions::ThreeD => {
+                let VertexData3D {
+                    vertices,
+                    bounds_min,
+                    bounds_max,
+                } = geometry_to_vertices_3d(lsystem_core::generate_3d(&config.generation));
+                total_segments = (vertices.len() / 2) as u32;
+                self.scene = ActiveScene::ThreeD {
+                    vertices,
+                    bounds_min,
+                    bounds_max,
+                };
+            }
+            Dimensions::TwoD => {
+                let VertexData {
+                    vertices,
+                    bounds_min,
+                    bounds_max,
+                } = geometry_to_vertices(lsystem_core::generate(&config.generation));
+                total_segments = (vertices.len() / 2) as u32;
+                self.scene = ActiveScene::TwoD {
+                    vertices,
+                    bounds_min,
+                    bounds_max,
+                };
+            }
         }
 
         self.color_params = color_params_from_config(&config.colors.line, total_segments);


### PR DESCRIPTION
Fixes #53.

## What changed

- Added `Dimensions { TwoD, ThreeD }` enum (`Debug, Clone, Copy, PartialEq, Eq, Hash`) to `lsystem-core`.
- Moved `dimensions` from `Config` into `GenerationConfig`, where it belongs: the `[l-system]` TOML section maps to generation fields, and `dimensions` controls both symbol validation during parsing and turtle selection at runtime.
- Replaced all `config.dimensions == 3` / `== 2` comparisons with exhaustive `match` or `matches!()` across every affected crate. The compiler now enforces completeness when a variant is added.

## Implementation details

- `required_dimensions()` still validates the TOML integer and produces `ConfigError::InvalidDimensions` for values other than 2 or 3.
- Serialisation matches on `Dimensions::TwoD => 2i64` / `Dimensions::ThreeD => 3i64`, keeping the TOML representation unchanged.
- The 2D/3D segment-cap lookup is centralised in a new `line_renderer::max_segments_for(dimensions)` function; `MAX_SEGMENTS_2D` and `MAX_SEGMENTS_3D` are now private to that module.
- `max_iterations_for_config` in `lsystem-web-app` drops its separate `dimensions: u8` parameter since the value is now on `GenerationConfig`.