### PR TITLE
Expose mutable config entries

### DIFF
--- a/crates/lsystem-app/src/ui/app_state.rs
+++ b/crates/lsystem-app/src/ui/app_state.rs
@@ -134,24 +134,26 @@ impl FractalApp {
             },
             Message::TomlEdited(action) => {
                 self.toml.perform(action);
-                if let Err(error) = self
-                    .config_workspace
-                    .set_draft_text(self.selected_config_index, self.toml.text())
-                {
-                    self.error = Some(error.to_string());
-                }
+                let Some(entry) = self.config_workspace.entry_mut(self.selected_config_index)
+                else {
+                    self.error =
+                        Some("Internal error: selected config is unavailable.".to_string());
+                    return Task::none();
+                };
+                entry.set_draft_text(self.toml.text());
                 self.export_status = None;
                 Task::none()
             }
             Message::ApplyConfig => self.apply_config(),
             Message::RevertConfig => {
-                match self.config_workspace.revert(self.selected_config_index) {
-                    Ok(_) => self.refresh_from_workspace(),
-                    Err(error) => {
-                        self.error = Some(error.to_string());
-                        Task::none()
-                    }
-                }
+                let Some(entry) = self.config_workspace.entry_mut(self.selected_config_index)
+                else {
+                    self.error =
+                        Some("Internal error: selected config is unavailable.".to_string());
+                    return Task::none();
+                };
+                entry.revert();
+                self.refresh_from_workspace()
             }
             Message::ResetConfig => {
                 if self
@@ -336,13 +338,11 @@ impl FractalApp {
     }
 
     fn apply_config(&mut self) -> Task<Message> {
-        if let Err(error) = self
-            .config_workspace
-            .set_draft_text(self.selected_config_index, self.toml.text())
-        {
-            self.error = Some(error.to_string());
+        let Some(entry) = self.config_workspace.entry_mut(self.selected_config_index) else {
+            self.error = Some("Internal error: selected config is unavailable.".to_string());
             return Task::none();
-        }
+        };
+        entry.set_draft_text(self.toml.text());
         match self.config_workspace.apply(self.selected_config_index) {
             Ok(config) => {
                 self.base_config = Some(config);

--- a/crates/lsystem-app/src/ui/app_state.rs
+++ b/crates/lsystem-app/src/ui/app_state.rs
@@ -136,6 +136,10 @@ impl FractalApp {
                 self.toml.perform(action);
                 let Some(entry) = self.config_workspace.entry_mut(self.selected_config_index)
                 else {
+                    log::error!(
+                        "TomlEdited: entry_mut returned None for index {}",
+                        self.selected_config_index
+                    );
                     self.error =
                         Some("Internal error: selected config is unavailable.".to_string());
                     return Task::none();
@@ -148,6 +152,10 @@ impl FractalApp {
             Message::RevertConfig => {
                 let Some(entry) = self.config_workspace.entry_mut(self.selected_config_index)
                 else {
+                    log::error!(
+                        "RevertConfig: entry_mut returned None for index {}",
+                        self.selected_config_index
+                    );
                     self.error =
                         Some("Internal error: selected config is unavailable.".to_string());
                     return Task::none();
@@ -339,6 +347,10 @@ impl FractalApp {
 
     fn apply_config(&mut self) -> Task<Message> {
         let Some(entry) = self.config_workspace.entry_mut(self.selected_config_index) else {
+            log::error!(
+                "apply_config: entry_mut returned None for index {}",
+                self.selected_config_index
+            );
             self.error = Some("Internal error: selected config is unavailable.".to_string());
             return Task::none();
         };

--- a/crates/lsystem-core/src/config_workspace.rs
+++ b/crates/lsystem-core/src/config_workspace.rs
@@ -78,6 +78,10 @@ impl ConfigWorkspace {
         self.entries.get(index)
     }
 
+    pub fn entry_mut(&mut self, index: usize) -> Option<&mut ConfigEntry> {
+        self.entries.get_mut(index)
+    }
+
     pub fn names(&self) -> impl Iterator<Item = &str> {
         self.entries.iter().map(ConfigEntry::name)
     }
@@ -94,15 +98,6 @@ impl ConfigWorkspace {
             return false;
         };
         entry.has_default_changes() && !self.name_exists_except(name, index)
-    }
-
-    pub fn set_draft_text(
-        &mut self,
-        index: usize,
-        text: String,
-    ) -> Result<(), ConfigWorkspaceError> {
-        self.entry_or_error_mut(index)?.set_draft_text(text);
-        Ok(())
     }
 
     pub fn copy(&mut self, index: usize) -> Result<(usize, ConfigEntry), ConfigWorkspaceError> {
@@ -128,12 +123,6 @@ impl ConfigWorkspace {
         Ok(config)
     }
 
-    pub fn revert(&mut self, index: usize) -> Result<ConfigEntry, ConfigWorkspaceError> {
-        let entry = self.entry_or_error_mut(index)?;
-        entry.revert();
-        Ok(entry.clone())
-    }
-
     /// Restores the entry at `index` to its bundled default document.
     /// Returns `Ok(None)` only when the entry has no bundled default (e.g. custom copies).
     /// Callers should gate user-visible resets on [`ConfigWorkspace::can_reset`] to avoid
@@ -153,15 +142,6 @@ impl ConfigWorkspace {
     fn entry_or_error(&self, index: usize) -> Result<&ConfigEntry, ConfigWorkspaceError> {
         self.entries
             .get(index)
-            .ok_or(ConfigWorkspaceError::InvalidIndex(index))
-    }
-
-    fn entry_or_error_mut(
-        &mut self,
-        index: usize,
-    ) -> Result<&mut ConfigEntry, ConfigWorkspaceError> {
-        self.entries
-            .get_mut(index)
             .ok_or(ConfigWorkspaceError::InvalidIndex(index))
     }
 
@@ -214,7 +194,7 @@ impl ConfigEntry {
         self.draft.is_some()
     }
 
-    fn set_draft_text(&mut self, text: String) {
+    pub fn set_draft_text(&mut self, text: String) {
         let applied_text = self.applied_text();
         self.draft = (text != applied_text).then_some(text);
     }
@@ -254,7 +234,7 @@ impl ConfigEntry {
         self.draft = None;
     }
 
-    fn revert(&mut self) {
+    pub fn revert(&mut self) {
         self.draft = None;
     }
 
@@ -324,11 +304,13 @@ color = [0.0, 0.9, 0.5]
             ConfigWorkspace::from_presets(vec![("First", first), ("Second", second)]).unwrap();
 
         workspace
-            .set_draft_text(0, "edited first".to_string())
-            .unwrap();
+            .entry_mut(0)
+            .unwrap()
+            .set_draft_text("edited first".to_string());
         workspace
-            .set_draft_text(1, "edited second".to_string())
-            .unwrap();
+            .entry_mut(1)
+            .unwrap()
+            .set_draft_text("edited second".to_string());
 
         assert_eq!(workspace.entry(0).unwrap().draft_text(), "edited first");
         assert!(ConfigSource::parse(workspace.entry(0).unwrap().draft_text().as_ref()).is_err());
@@ -343,8 +325,9 @@ color = [0.0, 0.9, 0.5]
         let previous_config = workspace.entry(0).unwrap().applied_config();
 
         workspace
-            .set_draft_text(0, "not valid toml".to_string())
-            .unwrap();
+            .entry_mut(0)
+            .unwrap()
+            .set_draft_text("not valid toml".to_string());
         let error = workspace.apply(0).unwrap_err();
         assert!(matches!(
             error,
@@ -364,8 +347,9 @@ color = [0.0, 0.9, 0.5]
         let mut workspace = ConfigWorkspace::from_presets(vec![("First", first.clone())]).unwrap();
 
         workspace
-            .set_draft_text(0, first.replace("axiom = \"F\"", "axiom = \"[\""))
-            .unwrap();
+            .entry_mut(0)
+            .unwrap()
+            .set_draft_text(first.replace("axiom = \"F\"", "axiom = \"[\""));
         let error = workspace.apply(0).unwrap_err();
 
         assert!(matches!(
@@ -393,8 +377,9 @@ color = [0.0, 0.9, 0.5]
                 .unwrap();
 
         workspace
-            .set_draft_text(0, config_text_renamed(&first, "Renamed"))
-            .unwrap();
+            .entry_mut(0)
+            .unwrap()
+            .set_draft_text(config_text_renamed(&first, "Renamed"));
         let config = workspace.apply(0).unwrap();
 
         assert_eq!(config.name, "Renamed");
@@ -412,8 +397,9 @@ color = [0.0, 0.9, 0.5]
                 .unwrap();
 
         workspace
-            .set_draft_text(0, config_text_renamed(&first, "Second"))
-            .unwrap();
+            .entry_mut(0)
+            .unwrap()
+            .set_draft_text(config_text_renamed(&first, "Second"));
         let error = workspace.apply(0).unwrap_err();
 
         assert!(matches!(
@@ -431,15 +417,18 @@ color = [0.0, 0.9, 0.5]
         let mut workspace = ConfigWorkspace::from_presets(vec![("First", first.clone())]).unwrap();
 
         workspace
-            .set_draft_text(0, first.replace("angle = 60", "angle = 45"))
-            .unwrap();
+            .entry_mut(0)
+            .unwrap()
+            .set_draft_text(first.replace("angle = 60", "angle = 45"));
         workspace.apply(0).unwrap();
         let applied = workspace.entry(0).unwrap().draft_text().to_string();
         workspace
-            .set_draft_text(0, "temporary invalid text".to_string())
-            .unwrap();
+            .entry_mut(0)
+            .unwrap()
+            .set_draft_text("temporary invalid text".to_string());
 
-        let reverted = workspace.revert(0).unwrap();
+        workspace.entry_mut(0).unwrap().revert();
+        let reverted = workspace.entry(0).unwrap();
 
         assert!(!reverted.is_dirty());
         assert_eq!(reverted.draft_text(), applied.as_str());
@@ -460,8 +449,9 @@ color = [0.0, 0.9, 0.5]
         assert!(!workspace.can_reset(0));
 
         workspace
-            .set_draft_text(0, first.replace("angle = 60", "angle = 45"))
-            .unwrap();
+            .entry_mut(0)
+            .unwrap()
+            .set_draft_text(first.replace("angle = 60", "angle = 45"));
         workspace.apply(0).unwrap();
         assert_eq!(
             workspace
@@ -500,7 +490,7 @@ color = [0.0, 0.9, 0.5]
             .unwrap()
             .draft_text()
             .replace("angle = 60", "angle = 45");
-        workspace.set_draft_text(index, draft).unwrap();
+        workspace.entry_mut(index).unwrap().set_draft_text(draft);
         workspace.apply(index).unwrap();
 
         assert!(workspace.reset(index).unwrap().is_none());
@@ -526,12 +516,14 @@ color = [0.0, 0.9, 0.5]
         .unwrap();
 
         workspace
-            .set_draft_text(0, config_text_renamed(&first, "Third"))
-            .unwrap();
+            .entry_mut(0)
+            .unwrap()
+            .set_draft_text(config_text_renamed(&first, "Third"));
         workspace.apply(0).unwrap();
         workspace
-            .set_draft_text(1, config_text_renamed(&second, "First"))
-            .unwrap();
+            .entry_mut(1)
+            .unwrap()
+            .set_draft_text(config_text_renamed(&second, "First"));
         workspace.apply(1).unwrap();
 
         let error = workspace.reset(0).unwrap_err();
@@ -552,7 +544,10 @@ color = [0.0, 0.9, 0.5]
         let mut workspace =
             ConfigWorkspace::from_presets(vec![("Plant", first.clone()), ("Plant copy", second)])
                 .unwrap();
-        workspace.set_draft_text(0, draft.clone()).unwrap();
+        workspace
+            .entry_mut(0)
+            .unwrap()
+            .set_draft_text(draft.clone());
 
         let (index, entry) = workspace.copy(0).unwrap();
         let expected_text = config_text_renamed(&draft, "Plant copy 2");
@@ -591,7 +586,10 @@ color = [0.0, 0.9, 0.5]
         let first = config_text("Plant", "F", 60.0);
         let draft = first.replace("axiom = \"F\"", "axiom = \"[\"");
         let mut workspace = ConfigWorkspace::from_presets(vec![("Plant", first.clone())]).unwrap();
-        workspace.set_draft_text(0, draft.clone()).unwrap();
+        workspace
+            .entry_mut(0)
+            .unwrap()
+            .set_draft_text(draft.clone());
 
         let (index, entry) = workspace.copy(0).unwrap();
         let expected_draft = config_text_renamed(&draft, "Plant copy");
@@ -637,8 +635,9 @@ color = [0.0, 0.9, 0.5]
         let first = config_text("Plant", "F", 60.0);
         let mut workspace = ConfigWorkspace::from_presets(vec![("Plant", first.clone())]).unwrap();
         workspace
-            .set_draft_text(0, "not valid toml".to_string())
-            .unwrap();
+            .entry_mut(0)
+            .unwrap()
+            .set_draft_text("not valid toml".to_string());
 
         let (index, entry) = workspace.copy(0).unwrap();
         let expected_applied = config_text_renamed(&first, "Plant copy");
@@ -740,11 +739,12 @@ color = [0.0, 0.9, 0.5]
         let mut workspace = ConfigWorkspace::from_presets(vec![("First", first.clone())]).unwrap();
 
         workspace
-            .set_draft_text(0, "temporary edit".to_string())
-            .unwrap();
+            .entry_mut(0)
+            .unwrap()
+            .set_draft_text("temporary edit".to_string());
         assert!(workspace.entry(0).unwrap().is_dirty());
 
-        workspace.set_draft_text(0, first).unwrap();
+        workspace.entry_mut(0).unwrap().set_draft_text(first);
 
         assert!(!workspace.entry(0).unwrap().is_dirty());
     }
@@ -763,15 +763,11 @@ color = [0.0, 0.9, 0.5]
     }
 
     #[test]
-    fn indexed_mutation_returns_error_for_out_of_bounds() {
+    fn indexed_mutation_returns_none_for_out_of_bounds() {
         let first = config_text("First", "F", 60.0);
         let mut workspace = ConfigWorkspace::from_presets(vec![("First", first)]).unwrap();
 
-        let error = workspace
-            .set_draft_text(1, "edited".to_string())
-            .unwrap_err();
-
-        assert!(matches!(error, ConfigWorkspaceError::InvalidIndex(1)));
+        assert!(workspace.entry_mut(1).is_none());
     }
 
     #[test]

--- a/crates/lsystem-web-app/src/app.rs
+++ b/crates/lsystem-web-app/src/app.rs
@@ -3,7 +3,7 @@ use std::rc::Rc;
 
 use leptos::html::Canvas;
 use leptos::prelude::*;
-use lsystem_core::{Config, ConfigWorkspace, Dimensions};
+use lsystem_core::{Config, ConfigWorkspace, ConfigWorkspaceError, Dimensions};
 use lsystem_renderer::line_renderer::FrameSkipReason;
 use wasm_bindgen::JsCast;
 use wasm_bindgen::closure::Closure;
@@ -181,25 +181,14 @@ pub(crate) fn App() -> impl IntoView {
         let interval_id = Rc::clone(&interval_id);
         let install_config = Rc::clone(&install_config);
         move || {
-            let draft_updated = set_config_workspace.try_update(|workspace| {
-                let Some(entry) = workspace.entry_mut(selected_config_index.get_untracked()) else {
-                    set_error.set(Some(
-                        "Internal error: selected config is unavailable.".to_string(),
-                    ));
-                    return false;
+            let applied = set_config_workspace.try_update(|workspace| {
+                let index = selected_config_index.get_untracked();
+                let Some(entry) = workspace.entry_mut(index) else {
+                    return Err(ConfigWorkspaceError::InvalidIndex(index));
                 };
                 entry.set_draft_text(toml_text.get_untracked());
-                true
+                workspace.apply(index)
             });
-            if !matches!(draft_updated, Some(true)) {
-                if draft_updated.is_none() {
-                    log::error!("apply: config_workspace signal was unavailable");
-                    set_error.set(Some("Internal error: could not apply config.".to_string()));
-                }
-                return;
-            }
-            let applied = set_config_workspace
-                .try_update(|workspace| workspace.apply(selected_config_index.get_untracked()));
             match applied {
                 Some(Ok(config)) => {
                     let new_is_3d = matches!(config.generation.dimensions, Dimensions::ThreeD);
@@ -215,7 +204,14 @@ pub(crate) fn App() -> impl IntoView {
                     render_current();
                 }
                 Some(Err(err)) => {
-                    set_error.set(Some(err.to_string()));
+                    if let ConfigWorkspaceError::InvalidIndex(index) = err {
+                        log::error!("apply: entry_mut returned None for index {index}");
+                        set_error.set(Some(
+                            "Internal error: selected config is unavailable.".to_string(),
+                        ));
+                    } else {
+                        set_error.set(Some(err.to_string()));
+                    }
                 }
                 None => {
                     log::error!("apply: config_workspace signal was unavailable");
@@ -390,7 +386,9 @@ pub(crate) fn App() -> impl IntoView {
                         let text = textarea_value(ev);
                         set_toml_text.set(text.clone());
                         set_config_workspace.update(|workspace| {
-                            let Some(entry) = workspace.entry_mut(selected_config_index.get_untracked()) else {
+                            let index = selected_config_index.get_untracked();
+                            let Some(entry) = workspace.entry_mut(index) else {
+                                log::error!("on_input: entry_mut returned None for index {index}");
                                 set_error.set(Some(
                                     "Internal error: selected config is unavailable.".to_string(),
                                 ));

--- a/crates/lsystem-web-app/src/app.rs
+++ b/crates/lsystem-web-app/src/app.rs
@@ -181,14 +181,23 @@ pub(crate) fn App() -> impl IntoView {
         let interval_id = Rc::clone(&interval_id);
         let install_config = Rc::clone(&install_config);
         move || {
-            set_config_workspace.update(|workspace| {
-                if let Err(err) = workspace.set_draft_text(
-                    selected_config_index.get_untracked(),
-                    toml_text.get_untracked(),
-                ) {
-                    set_error.set(Some(err.to_string()));
-                }
+            let draft_updated = set_config_workspace.try_update(|workspace| {
+                let Some(entry) = workspace.entry_mut(selected_config_index.get_untracked()) else {
+                    set_error.set(Some(
+                        "Internal error: selected config is unavailable.".to_string(),
+                    ));
+                    return false;
+                };
+                entry.set_draft_text(toml_text.get_untracked());
+                true
             });
+            if !matches!(draft_updated, Some(true)) {
+                if draft_updated.is_none() {
+                    log::error!("apply: config_workspace signal was unavailable");
+                    set_error.set(Some("Internal error: could not apply config.".to_string()));
+                }
+                return;
+            }
             let applied = set_config_workspace
                 .try_update(|workspace| workspace.apply(selected_config_index.get_untracked()));
             match applied {
@@ -381,12 +390,13 @@ pub(crate) fn App() -> impl IntoView {
                         let text = textarea_value(ev);
                         set_toml_text.set(text.clone());
                         set_config_workspace.update(|workspace| {
-                            if let Err(err) = workspace.set_draft_text(
-                                selected_config_index.get_untracked(),
-                                text,
-                            ) {
-                                set_error.set(Some(err.to_string()));
-                            }
+                            let Some(entry) = workspace.entry_mut(selected_config_index.get_untracked()) else {
+                                set_error.set(Some(
+                                    "Internal error: selected config is unavailable.".to_string(),
+                                ));
+                                return;
+                            };
+                            entry.set_draft_text(text);
                         });
                     }
                 />
@@ -408,17 +418,26 @@ pub(crate) fn App() -> impl IntoView {
                             let render_current = Rc::clone(&render_current);
                             let install_config = Rc::clone(&install_config);
                             move |_| {
-                                let text = set_config_workspace.try_update(|workspace| {
-                                    workspace.revert(selected_config_index.get_untracked())
+                                let reverted = set_config_workspace.try_update(|workspace| {
+                                    let entry =
+                                        workspace.entry_mut(selected_config_index.get_untracked())?;
+                                    entry.revert();
+                                    Some((
+                                        entry.draft_text().into_owned(),
+                                        entry.applied_config(),
+                                    ))
                                 });
-                                match text {
-                                    Some(Ok(entry)) => {
-                                        set_toml_text.set(entry.draft_text().into_owned());
-                                        install_config(entry.applied_config());
+                                match reverted {
+                                    Some(Some((text, config))) => {
+                                        set_toml_text.set(text);
+                                        install_config(config);
                                         render_current();
                                     }
-                                    Some(Err(err)) => {
-                                        set_error.set(Some(err.to_string()));
+                                    Some(None) => {
+                                        set_error.set(Some(
+                                            "Internal error: selected config is unavailable."
+                                                .to_string(),
+                                        ));
                                     }
                                     None => {
                                         log::error!(


### PR DESCRIPTION
## Summary
- Add mutable indexed access to config workspace entries through ConfigWorkspace::entry_mut.
- Move draft text edits and revert behavior onto ConfigEntry as safe public entry-local mutations.
- Update both UIs to use entry_mut while keeping collection-level operations on ConfigWorkspace.