### PR TITLE
Eliminate unnecessary clones in lsystem-core

### DIFF
--- a/crates/lsystem-core/src/config_workspace.rs
+++ b/crates/lsystem-core/src/config_workspace.rs
@@ -56,7 +56,9 @@ impl ConfigWorkspace {
                 }
             };
             if !names.insert(entry.name().to_string()) {
-                return Err(ConfigWorkspaceError::DuplicateName(entry.name().to_string()));
+                return Err(ConfigWorkspaceError::DuplicateName(
+                    entry.name().to_string(),
+                ));
             }
             entries_out.push(entry);
         }

--- a/crates/lsystem-core/src/config_workspace.rs
+++ b/crates/lsystem-core/src/config_workspace.rs
@@ -55,9 +55,8 @@ impl ConfigWorkspace {
                     continue;
                 }
             };
-            let name = entry.name().to_string();
-            if !names.insert(name.clone()) {
-                return Err(ConfigWorkspaceError::DuplicateName(name));
+            if !names.insert(entry.name().to_string()) {
+                return Err(ConfigWorkspaceError::DuplicateName(entry.name().to_string()));
             }
             entries_out.push(entry);
         }

--- a/crates/lsystem-core/src/grammar.rs
+++ b/crates/lsystem-core/src/grammar.rs
@@ -5,7 +5,7 @@ pub(crate) struct ExpandIter<'a> {
     rules: &'a BTreeMap<char, String>,
 }
 
-impl<'a> Iterator for ExpandIter<'a> {
+impl Iterator for ExpandIter<'_> {
     type Item = char;
 
     fn next(&mut self) -> Option<char> {
@@ -30,60 +30,14 @@ impl<'a> Iterator for ExpandIter<'a> {
     }
 }
 
-pub fn expand<'a>(
+pub(crate) fn expand<'a>(
     axiom: &'a str,
     rules: &'a BTreeMap<char, String>,
     iterations: u32,
-) -> impl Iterator<Item = char> + 'a {
+) -> ExpandIter<'a> {
     ExpandIter {
         stack: vec![(axiom.chars(), iterations)],
         rules,
-    }
-}
-
-pub(crate) struct OwnedExpandIter {
-    stack: Vec<(std::vec::IntoIter<char>, u32)>,
-    rules: BTreeMap<char, Vec<char>>,
-}
-
-impl Iterator for OwnedExpandIter {
-    type Item = char;
-
-    fn next(&mut self) -> Option<char> {
-        loop {
-            let top = self.stack.last_mut()?;
-            let depth = top.1;
-            match top.0.next() {
-                None => {
-                    self.stack.pop();
-                }
-                Some(ch) => {
-                    if depth > 0
-                        && let Some(rhs) = self.rules.get(&ch)
-                    {
-                        self.stack.push((rhs.clone().into_iter(), depth - 1));
-                        continue;
-                    }
-                    return Some(ch);
-                }
-            }
-        }
-    }
-}
-
-pub(crate) fn expand_owned(
-    axiom: String,
-    rules: BTreeMap<char, String>,
-    iterations: u32,
-) -> OwnedExpandIter {
-    let char_rules: BTreeMap<char, Vec<char>> = rules
-        .into_iter()
-        .map(|(k, v)| (k, v.chars().collect()))
-        .collect();
-    let axiom_chars: Vec<char> = axiom.chars().collect();
-    OwnedExpandIter {
-        stack: vec![(axiom_chars.into_iter(), iterations)],
-        rules: char_rules,
     }
 }
 

--- a/crates/lsystem-core/src/lib.rs
+++ b/crates/lsystem-core/src/lib.rs
@@ -17,23 +17,14 @@ pub use grammar::max_safe_iterations;
 
 use glam::{Vec2, Vec3};
 
-/// Expand the grammar and run the 2D turtle, returning a lazy iterator of
-/// line segments. The iterator owns all its state and does not borrow from `config`.
-pub fn generate(config: &GenerationConfig) -> impl Iterator<Item = [Vec2; 2]> {
-    let chars = grammar::expand_owned(
-        config.axiom.clone(),
-        config.rules.clone(),
-        config.iterations,
-    );
+/// Expand the grammar and run the 2D turtle, returning a lazy iterator of line segments.
+pub fn generate(config: &GenerationConfig) -> impl Iterator<Item = [Vec2; 2]> + '_ {
+    let chars = grammar::expand(&config.axiom, &config.rules, config.iterations);
     turtle::turtle2d::Segments2D::new(chars, config.angle, config.step, config.initial_heading)
 }
 
-/// Like `generate` but runs the 3D turtle; the iterator owns all its state.
-pub fn generate_3d(config: &GenerationConfig) -> impl Iterator<Item = [Vec3; 2]> {
-    let chars = grammar::expand_owned(
-        config.axiom.clone(),
-        config.rules.clone(),
-        config.iterations,
-    );
+/// Like `generate` but runs the 3D turtle.
+pub fn generate_3d(config: &GenerationConfig) -> impl Iterator<Item = [Vec3; 2]> + '_ {
+    let chars = grammar::expand(&config.axiom, &config.rules, config.iterations);
     turtle::turtle3d::Segments3D::new(chars, config.angle, config.step, config.initial_heading)
 }


### PR DESCRIPTION
## What changed

- **Removed `OwnedExpandIter` and `expand_owned`** — these existed so `generate` and `generate_3d` could return a `'static` iterator, requiring the caller to clone `axiom` and `rules` upfront to manufacture owned data. Now that `expand` takes `&str` / `&BTreeMap<char, String>`, no upfront allocation is needed.
- **`generate` / `generate_3d` return `impl Iterator + '_`** — the iterator borrows directly from `&GenerationConfig`. This also eliminates the per-expansion `Vec<char>` clone that `OwnedExpandIter` performed on every rule application; `ExpandIter` uses `str::Chars` (a slice iterator with no allocation).
- **Removed intermediate `name` variable in `from_presets`** — the variable was introduced solely to support a clone-before-insert pattern. Calling `entry.name().to_string()` at each use site avoids the allocation on the common (non-duplicate) path.

## Why

Auditing `.clone()` calls revealed that several were load-bearing workarounds for an ownership constraint that didn't actually need to exist. `OwnedExpandIter` was created to let the returned iterators be `'static`, but all callers hold `GenerationConfig` for at least as long as they consume the iterator — including the async `build_scene` in `lsystem-app`, where the owned `Config` lives in the same async state machine as the iterator.