### PR TITLE
Tighten and dedupe CI checks

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,6 +9,10 @@ on:
 permissions:
   contents: read
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}
+
 env:
   CARGO_TERM_COLOR: always
 
@@ -19,8 +23,6 @@ jobs:
     steps:
       - uses: actions/checkout@v6
       - uses: dtolnay/rust-toolchain@stable
-        with:
-          components: rustfmt
       - run: cargo fmt --check --all
 
   clippy:
@@ -29,11 +31,11 @@ jobs:
     steps:
       - uses: actions/checkout@v6
       - uses: dtolnay/rust-toolchain@stable
-        with:
-          components: clippy
       - uses: Swatinem/rust-cache@v2
-      - run: cargo clippy --workspace -- -D warnings
-      - run: cargo clippy --workspace --all-features -- -D warnings
+      - run: cargo clippy --workspace --all-targets -- -D warnings
+      - run: cargo clippy --workspace --all-features --all-targets -- -D warnings
+      - run: cargo clippy --target wasm32-unknown-unknown --workspace -- -D warnings
+      - run: cargo clippy --target wasm32-unknown-unknown --workspace --all-features -- -D warnings
 
   test:
     name: Test
@@ -44,20 +46,16 @@ jobs:
       - uses: Swatinem/rust-cache@v2
       - run: cargo test --workspace --all-features --all-targets
 
-  wasm-check:
-    name: WASM Check
+  docs:
+    name: Docs
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
       - uses: dtolnay/rust-toolchain@stable
-        with:
-          targets: wasm32-unknown-unknown
-          components: clippy
       - uses: Swatinem/rust-cache@v2
-      - run: cargo check --target wasm32-unknown-unknown --workspace
-      - run: cargo check --target wasm32-unknown-unknown --workspace --all-features
-      - run: cargo clippy --target wasm32-unknown-unknown --workspace -- -D warnings
-      - run: cargo clippy --target wasm32-unknown-unknown --workspace --all-features -- -D warnings
+      - env:
+          RUSTDOCFLAGS: -D warnings
+        run: cargo doc --no-deps --workspace --all-features
 
   trunk-build:
     name: Trunk Build
@@ -65,8 +63,6 @@ jobs:
     steps:
       - uses: actions/checkout@v6
       - uses: dtolnay/rust-toolchain@stable
-        with:
-          targets: wasm32-unknown-unknown
       - uses: Swatinem/rust-cache@v2
       - uses: jdx/mise-action@v4
       - run: trunk build --release --config crates/lsystem-app/Trunk.toml

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -17,11 +17,10 @@ trunk serve --config crates/lsystem-app/Trunk.toml    # Iced web app at localhos
 
 # Verification (all run in CI)
 cargo fmt --check --all
-cargo clippy --workspace -- -D warnings
-cargo clippy --workspace --all-features -- -D warnings
+cargo clippy --workspace --all-targets -- -D warnings
+cargo clippy --workspace --all-features --all-targets -- -D warnings
 cargo test --workspace --all-features --all-targets
-cargo check --target wasm32-unknown-unknown --workspace
-cargo check --target wasm32-unknown-unknown --workspace --all-features
+RUSTDOCFLAGS="-D warnings" cargo doc --no-deps --workspace --all-features
 cargo clippy --target wasm32-unknown-unknown --workspace -- -D warnings
 cargo clippy --target wasm32-unknown-unknown --workspace --all-features -- -D warnings
 trunk build --release --config crates/lsystem-app/Trunk.toml
@@ -130,4 +129,4 @@ Bundled TOML L-System definitions. New fractals are added here; they are embedde
 - **DOM browser UI with GPU canvas**: `lsystem-web-app` owns browser UI state in Leptos signals and renders the fractal into a dedicated `<canvas>`. It creates a wgpu surface from `web_sys::HtmlCanvasElement`, reuses `LinePipeline`, and drives rendering from explicit DOM events instead of a continuous repaint loop. On browser wasm targets, `wgpu_util` creates the instance with a web display handle and WebGPU detection so wgpu can use WebGPU when available and fall back to WebGL2 otherwise.
 - **Surface acquisition recovery**: `GpuContext::begin_frame` retries `CurrentSurfaceTexture::Outdated` once after reconfiguring the surface. Timeout and occlusion are quiet skip reasons, validation/repeated-outdated are explicit skip reasons, and true surface loss is reported to callers. The Leptos web renderer rebuilds `GpuContext` and `LinePipeline` after surface loss while preserving CPU-side scene/camera/color state and marking geometry for reupload.
 - **SVG export is 2D-only**: SVG export is a `lsystem-core` Cargo feature (`svg`). `export_svg(config) -> String` collects 2D segments, computes a padded bounding box, and builds SVG XML. The Y-axis flip is handled by a `<g transform="matrix(1 0 0 -1 0 0)">` group. Both apps hide the SVG export button when `config.dimensions == 3`.
-- **Strict CI**: `clippy -D warnings` and `cargo fmt --check` must pass. CI tests the workspace with all features/all targets, checks and lints native default/all-features builds, checks and lints `wasm32-unknown-unknown` default/all-features builds, and builds both Trunk web apps. GitHub Pages deploys the Leptos browser app.
+- **Strict CI**: `clippy -D warnings` and `cargo fmt --check` must pass. A single Clippy job lints native default/all-features builds (with `--all-targets`) and `wasm32-unknown-unknown` default/all-features builds. CI also tests the workspace with all features/all targets, builds rustdoc with `RUSTDOCFLAGS=-D warnings`, and builds both Trunk web apps. Toolchain channel/components/targets come from `rust-toolchain.toml`; rustup auto-installs them on first cargo invocation. GitHub Pages deploys the Leptos browser app.

--- a/crates/lsystem-core/src/config.rs
+++ b/crates/lsystem-core/src/config.rs
@@ -790,7 +790,7 @@ background = [0.0, 0.0, 0.0]
 mode = "solid"
 color = [0.0, 0.9, 0.5]
 "#;
-        assert!(parse_config(&toml).is_err());
+        assert!(parse_config(toml).is_err());
     }
 
     #[test]


### PR DESCRIPTION
## Summary

- Merge wasm clippy into the unified `Clippy` job. After removing the redundant `cargo check` steps, the former `wasm-check` job was just running clippy on `wasm32-unknown-unknown`; folding it in eliminates the duplicate toolchain setup and cache.
- Add `--all-targets` to native clippy so test, example, and benchmark code is linted (caught a real `needless_borrow` in `lsystem-core` tests, fixed here).
- Drop the wasm `cargo check` steps — strictly subsumed by `cargo clippy` on the same target.
- Stop passing `components:` / `targets:` to `dtolnay/rust-toolchain`. Those are already declared in `rust-toolchain.toml`, so rustup auto-installs them on first cargo invocation and the two sources cannot drift.
- Add a `Docs` job that runs `cargo doc --no-deps --workspace --all-features` with `RUSTDOCFLAGS=-D warnings`, catching broken intra-doc links and rustdoc lints that nothing was checking.
- Add a `concurrency` group keyed on workflow + ref so superseded PR runs are cancelled while runs on `main` complete (deploy depends on the latter).

## AGENTS.md

Updated the verification command list and the "Strict CI" paragraph to match the new job structure.