### PR TITLE
Strengthen Git/GitHub rule placement in AGENTS.md

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -2,6 +2,8 @@
 
 This file provides guidance to AI coding agents when working with code in this repository.
 
+> **REQUIRED before any interaction with Git or GitHub** — including `git` commands, the `gh` CLI, GitHub MCP tools, or any other mechanism that reads or writes repository or pull-request state: read `.agents/rules/git-and-github.md`.
+
 ## Project Overview
 
 **Grow Your Own Fractal** — an interactive L-System (Lindenmayer system) visualizer in Rust. The browser-first app (`lsystem-web-app`) uses Leptos/DOM controls with a wgpu canvas that uses WebGPU with a WebGL2 fallback on browser wasm targets, backed by the toolkit-independent `lsystem-renderer` crate. The `lsystem-app` crate uses Iced for native desktop and retained wasm builds; its fractal viewport is an `iced::widget::shader` custom primitive backed by the shared wgpu line pipeline.
@@ -36,8 +38,6 @@ cargo test -p lsystem-core --features svg svg_export
 `trunk` is managed by mise; run `mise install` to get the pinned version from `mise.toml`. `trunk` may fail to launch when `NO_COLOR=1` is present in the environment; use `NO_COLOR=true` or `NO_COLOR=false` as a workaround.
 
 ## Supplemental Rules
-
-Before running Git or GitHub CLI commands, read `.agents/rules/git-and-github.md`.
 
 When making code changes, check whether `README.md` and/or `AGENTS.md` need updates for the changed behavior, commands, architecture, or workflow. Update them in the same change when applicable.
 


### PR DESCRIPTION
## What changed

- Moved the "read `.agents/rules/git-and-github.md`" instruction from the middle of the Supplemental Rules section to the very top of the file, formatted as a blockquote.
- Broadened the coverage from "`git` or GitHub CLI commands" to any interaction with Git or GitHub — including the `gh` CLI, GitHub MCP tools, and any other mechanism that reads or writes repository or pull-request state.
- Removed the weaker duplicate sentence from Supplemental Rules.

## Why

The instruction was being skipped because it was buried mid-file and agents following an external workflow skill would execute that skill's steps without scanning for preconditions further down. A top-of-file blockquote is seen before any other content regardless of entry point.