### PR TITLE
Replace ColorParams.mode u32 with ColorMode enum

### DIFF
--- a/crates/lsystem-renderer/src/line_renderer.rs
+++ b/crates/lsystem-renderer/src/line_renderer.rs
@@ -2,7 +2,7 @@ use std::error::Error;
 use std::fmt::{Display, Formatter};
 use std::sync::Arc;
 
-use bytemuck::{Pod, Zeroable};
+use bytemuck::{NoUninit, Pod, Zeroable};
 use lsystem_core::{Dimensions, LineColorConfig};
 use wgpu::util::DeviceExt;
 
@@ -102,13 +102,24 @@ pub fn max_segments_for_line_color(dimensions: Dimensions, line: &LineColorConfi
     }
 }
 
+/// Discriminant values are matched by literal in `shader.wgsl` and `shader3d.wgsl`;
+/// keep them in sync when adding or renumbering variants.
+#[repr(u32)]
+#[derive(Copy, Clone, Debug, Default, PartialEq, Eq, NoUninit, Zeroable)]
+pub enum ColorMode {
+    #[default]
+    Solid = 0,
+    Gradient = 1,
+    HueCycle = 2,
+    DepthGradient = 3,
+}
+
 /// Per-frame color parameters written to the GPU as a uniform.
 /// Layout mirrors `ColorParams` in `shader.wgsl`; padding keeps vec4 alignment.
 #[repr(C)]
-#[derive(Copy, Clone, Default, Pod, Zeroable)]
+#[derive(Copy, Clone, Default, NoUninit, Zeroable)]
 pub struct ColorParams {
-    /// 0 = solid, 1 = gradient, 2 = hue_cycle, 3 = depth_gradient
-    pub mode: u32,
+    pub mode: ColorMode,
     pub total_segments: u32,
     pub max_topological_depth: u32,
     pub _pad: u32,

--- a/crates/lsystem-renderer/src/lsystem_bridge.rs
+++ b/crates/lsystem-renderer/src/lsystem_bridge.rs
@@ -5,8 +5,8 @@ use lsystem_core::{
 };
 
 use crate::line_renderer::{
-    ColorParams, Segment2D, Segment3D, TopologicalDepthSegment2D, TopologicalDepthSegment3D,
-    Transform,
+    ColorMode, ColorParams, Segment2D, Segment3D, TopologicalDepthSegment2D,
+    TopologicalDepthSegment3D, Transform,
 };
 
 pub struct SegmentData {
@@ -312,14 +312,14 @@ pub fn color_params_from_config(
 ) -> ColorParams {
     match *line {
         LineColorConfig::Solid { color: c } => ColorParams {
-            mode: 0,
+            mode: ColorMode::Solid,
             total_segments,
             max_topological_depth: 0,
             color_start: [c[0], c[1], c[2], 1.0],
             ..Default::default()
         },
         LineColorConfig::Gradient { start, end } => ColorParams {
-            mode: 1,
+            mode: ColorMode::Gradient,
             total_segments,
             max_topological_depth: 0,
             color_start: [start[0], start[1], start[2], 1.0],
@@ -329,7 +329,7 @@ pub fn color_params_from_config(
         LineColorConfig::HueCycle { initial } => {
             let (hue_start, saturation, value) = rgb_to_hsv(initial);
             ColorParams {
-                mode: 2,
+                mode: ColorMode::HueCycle,
                 total_segments,
                 max_topological_depth: 0,
                 hue_start,
@@ -339,7 +339,7 @@ pub fn color_params_from_config(
             }
         }
         LineColorConfig::DepthGradient { start, end } => ColorParams {
-            mode: 3,
+            mode: ColorMode::DepthGradient,
             total_segments,
             max_topological_depth,
             color_start: [start[0], start[1], start[2], 1.0],
@@ -393,6 +393,40 @@ mod tests {
     }
 
     #[test]
+    fn solid_maps_to_mode_solid_with_color() {
+        let params = color_params_from_config(
+            &LineColorConfig::Solid {
+                color: [0.2, 0.4, 0.6],
+            },
+            10,
+            0,
+        );
+
+        assert_eq!(params.mode, ColorMode::Solid);
+        assert_eq!(params.total_segments, 10);
+        assert_eq!(params.color_start, [0.2, 0.4, 0.6, 1.0]);
+        assert_eq!(params.max_topological_depth, 0);
+    }
+
+    #[test]
+    fn gradient_maps_to_mode_gradient_with_start_and_end_colors() {
+        let params = color_params_from_config(
+            &LineColorConfig::Gradient {
+                start: [0.1, 0.2, 0.3],
+                end: [0.7, 0.8, 0.9],
+            },
+            7,
+            0,
+        );
+
+        assert_eq!(params.mode, ColorMode::Gradient);
+        assert_eq!(params.total_segments, 7);
+        assert_eq!(params.color_start, [0.1, 0.2, 0.3, 1.0]);
+        assert_eq!(params.color_end, [0.7, 0.8, 0.9, 1.0]);
+        assert_eq!(params.max_topological_depth, 0);
+    }
+
+    #[test]
     fn hue_cycle_initial_rgb_maps_to_hsv_uniforms() {
         let params = color_params_from_config(
             &LineColorConfig::HueCycle {
@@ -402,7 +436,7 @@ mod tests {
             0,
         );
 
-        assert_eq!(params.mode, 2);
+        assert_eq!(params.mode, ColorMode::HueCycle);
         assert_eq!(params.total_segments, 9);
         assert!(close(params.hue_start, 180.0));
         assert!(close(params.saturation, 0.5));
@@ -420,7 +454,7 @@ mod tests {
             3,
         );
 
-        assert_eq!(params.mode, 3);
+        assert_eq!(params.mode, ColorMode::DepthGradient);
         assert_eq!(params.total_segments, 5);
         assert_eq!(params.max_topological_depth, 3);
         assert_eq!(params.color_start, [0.1, 0.2, 0.3, 1.0]);
@@ -438,7 +472,7 @@ mod tests {
             0,
         );
 
-        assert_eq!(params.mode, 3);
+        assert_eq!(params.mode, ColorMode::DepthGradient);
         assert_eq!(params.max_topological_depth, 0);
     }
 


### PR DESCRIPTION
## What changed

- Added `ColorMode` — a `#[repr(u32)]` enum with variants `Solid=0`, `Gradient=1`, `HueCycle=2`, `DepthGradient=3` — replacing the `pub mode: u32` field on `ColorParams`
- `ColorParams` now derives `NoUninit + Zeroable` instead of `Pod`: it is only ever written to the GPU as bytes, never reconstructed from arbitrary bytes, so `Pod` (which additionally requires `AnyBitPattern`) was broader than needed
- `ColorMode` derives `NoUninit` and `Zeroable` directly; `bytemuck_derive` verifies the preconditions mechanically, removing the need for `unsafe impl` blocks
- A doc comment on `ColorMode` notes that the discriminant integers are hardcoded as `case Nu` literals in `shader.wgsl` and `shader3d.wgsl` and must stay in sync
- Tests added for the previously uncovered `Solid` and `Gradient` arms of `color_params_from_config`; all four arms are now covered

## Why

Invalid mode values (any `u32` outside 0–3) were previously representable in safe Rust and would have silently fallen through to the shader's `default` branch. The enum makes that a compile error.