### PR TITLE
Redesign web app layout with disclosures

### DIFF
--- a/crates/lsystem-core/src/config.rs
+++ b/crates/lsystem-core/src/config.rs
@@ -337,6 +337,35 @@ impl ConfigSource {
         );
     }
 
+    pub(crate) fn set_initial_heading(&mut self, initial_heading: f32) {
+        set_value_preserving_decor(
+            &mut self.document["turtle"]["initial_heading"],
+            Value::from(f64::from(initial_heading)),
+        );
+    }
+
+    pub(crate) fn set_dimensions(&mut self, dimensions: Dimensions) {
+        set_value_preserving_decor(
+            &mut self.document["l-system"]["dimensions"],
+            Value::from(match dimensions {
+                Dimensions::TwoD => 2i64,
+                Dimensions::ThreeD => 3i64,
+            }),
+        );
+    }
+
+    pub(crate) fn set_grammar(&mut self, axiom: &str, rules: &[(char, String)]) {
+        set_value_preserving_decor(&mut self.document["l-system"]["axiom"], Value::from(axiom));
+        // The rules table is replaced wholesale rather than patched in place.
+        // This intentionally discards per-rule TOML comments and whitespace —
+        // the grammar editor constructs a new set of rules, not incremental edits.
+        let mut rules_table = Table::new();
+        for (symbol, rhs) in rules {
+            rules_table[&symbol.to_string()] = value(rhs.as_str());
+        }
+        self.document["l-system"]["rules"] = Item::Table(rules_table);
+    }
+
     pub(crate) fn set_background(&mut self, background: Option<[f32; 3]>) {
         match background {
             Some(background) => {

--- a/crates/lsystem-core/src/config_workspace.rs
+++ b/crates/lsystem-core/src/config_workspace.rs
@@ -3,7 +3,7 @@ use std::collections::BTreeSet;
 
 use thiserror::Error;
 
-use crate::{Config, ConfigDocument, ConfigError, ConfigSource, LineColorConfig};
+use crate::{Config, ConfigDocument, ConfigError, ConfigSource, Dimensions, LineColorConfig};
 
 #[derive(Debug, Error)]
 pub enum ConfigWorkspaceError {
@@ -144,6 +144,17 @@ impl ConfigWorkspace {
         self.entries.push(new_entry);
         self.selected = self.entries.len() - 1;
         Ok(&self.entries[self.selected])
+    }
+
+    pub fn rename(&mut self, index: usize, new_name: &str) -> Result<(), ConfigWorkspaceError> {
+        if index >= self.entries.len() {
+            return Err(ConfigWorkspaceError::InvalidIndex(index));
+        }
+        if self.name_exists_except(new_name, index) {
+            return Err(ConfigWorkspaceError::DuplicateName(new_name.to_string()));
+        }
+        self.entries[index].rename_in_place(new_name)?;
+        Ok(())
     }
 
     /// Validates the selected entry's draft text and commits it as the new applied
@@ -304,6 +315,22 @@ impl ConfigEntry {
         Ok(())
     }
 
+    fn rename_in_place(&mut self, new_name: &str) -> Result<(), ConfigError> {
+        let mut source = self.last_applied.source().clone();
+        source.set_name(new_name);
+        self.last_applied = ConfigDocument::try_from(source)?;
+        // Update the draft name too so applying the draft later does not silently
+        // revert the rename. If the draft is unparseable TOML, leave it verbatim —
+        // the apply path will surface the parse error to the user.
+        if let Some(draft_text) = &self.draft
+            && let Ok(mut draft_source) = ConfigSource::parse(draft_text)
+        {
+            draft_source.set_name(new_name);
+            self.draft = Some(draft_source.to_toml_string());
+        }
+        Ok(())
+    }
+
     fn default_name(&self) -> Option<&str> {
         self.default.as_ref().map(ConfigDocument::name)
     }
@@ -324,6 +351,25 @@ impl CleanMut<'_> {
     pub fn set_angle(&mut self, angle: f32) -> Result<(), ConfigError> {
         self.0
             .update_last_applied_source(|source| source.set_angle(angle))
+    }
+
+    pub fn set_initial_heading(&mut self, initial_heading: f32) -> Result<(), ConfigError> {
+        self.0
+            .update_last_applied_source(|source| source.set_initial_heading(initial_heading))
+    }
+
+    pub fn set_dimensions(&mut self, dimensions: Dimensions) -> Result<(), ConfigError> {
+        self.0
+            .update_last_applied_source(|source| source.set_dimensions(dimensions))
+    }
+
+    pub fn set_grammar(
+        &mut self,
+        axiom: &str,
+        rules: &[(char, String)],
+    ) -> Result<(), ConfigError> {
+        self.0
+            .update_last_applied_source(|source| source.set_grammar(axiom, rules))
     }
 
     pub fn set_background(&mut self, background: Option<[f32; 3]>) -> Result<(), ConfigError> {
@@ -837,6 +883,60 @@ color = [0.0, 0.9, 0.5]
     }
 
     #[test]
+    fn clean_entry_set_initial_heading_updates_toml_and_applied_config() {
+        let first = config_text("First", "F", 60.0);
+        let mut workspace = ConfigWorkspace::from_presets(vec![("First", first)]).unwrap();
+
+        clean_mut(&mut workspace).set_initial_heading(45.0).unwrap();
+
+        let entry = workspace.selected();
+        assert!(entry.draft_text().contains("initial_heading = 45"));
+        assert_eq!(entry.applied_config().generation.initial_heading, 45.0);
+        assert!(!entry.is_dirty());
+    }
+
+    #[test]
+    fn clean_entry_set_dimensions_updates_toml_and_applied_config() {
+        let first = config_text("First", "F", 60.0);
+        let mut workspace = ConfigWorkspace::from_presets(vec![("First", first)]).unwrap();
+        assert_eq!(
+            workspace.selected().applied_config().generation.dimensions,
+            Dimensions::TwoD
+        );
+        clean_mut(&mut workspace)
+            .set_dimensions(Dimensions::ThreeD)
+            .unwrap();
+        assert_eq!(
+            workspace.selected().applied_config().generation.dimensions,
+            Dimensions::ThreeD
+        );
+        assert!(workspace.selected().draft_text().contains("dimensions = 3"));
+    }
+
+    #[test]
+    fn clean_entry_set_grammar_updates_axiom_and_rules() {
+        let first = config_text("First", "F", 60.0);
+        let mut workspace = ConfigWorkspace::from_presets(vec![("First", first)]).unwrap();
+        let rules = vec![('F', "FF".to_string()), ('X', "F+X".to_string())];
+        clean_mut(&mut workspace).set_grammar("XF", &rules).unwrap();
+        let generation = &workspace.selected().applied_config().generation;
+        assert_eq!(generation.axiom, "XF");
+        assert_eq!(generation.rules[&'F'], "FF");
+        assert_eq!(generation.rules[&'X'], "F+X");
+    }
+
+    #[test]
+    fn clean_entry_set_grammar_rejects_invalid_axiom() {
+        let first = config_text("First", "F", 60.0);
+        let mut workspace = ConfigWorkspace::from_presets(vec![("First", first)]).unwrap();
+        // '@' is not a valid symbol
+        let result = clean_mut(&mut workspace).set_grammar("F@", &[]);
+        assert!(result.is_err());
+        // Entry left unchanged
+        assert_eq!(workspace.selected().applied_config().generation.axiom, "F");
+    }
+
+    #[test]
     fn clean_entry_set_background_some_updates_toml_and_applied_config() {
         let first = config_text("First", "F", 60.0);
         let mut workspace = ConfigWorkspace::from_presets(vec![("First", first)]).unwrap();
@@ -1322,5 +1422,47 @@ end = [ 1.0, 1.0, 1.0 ]
 
         assert_eq!(workspace.index_by_name("Missing"), None);
         assert_eq!(workspace.index_by_name("First"), Some(0));
+    }
+
+    #[test]
+    fn rename_updates_entry_name() {
+        let first = config_text("Plant", "F", 60.0);
+        let mut workspace = ConfigWorkspace::from_presets(vec![("Plant", first)]).unwrap();
+        workspace.rename(0, "My Plant").unwrap();
+        assert_eq!(workspace.selected().name(), "My Plant");
+        assert!(workspace.selected().draft_text().contains("\"My Plant\""));
+    }
+
+    #[test]
+    fn rename_rejects_duplicate_name() {
+        let first = config_text("First", "F", 60.0);
+        let second = config_text("Second", "F+F", 90.0);
+        let mut workspace =
+            ConfigWorkspace::from_presets(vec![("First", first), ("Second", second)]).unwrap();
+        let err = workspace.rename(0, "Second").unwrap_err();
+        assert!(matches!(err, ConfigWorkspaceError::DuplicateName(ref n) if n == "Second"));
+        assert_eq!(workspace.selected().name(), "First");
+    }
+
+    #[test]
+    fn rename_rejects_invalid_index() {
+        let first = config_text("First", "F", 60.0);
+        let mut workspace = ConfigWorkspace::from_presets(vec![("First", first)]).unwrap();
+        assert!(matches!(
+            workspace.rename(1, "Y").unwrap_err(),
+            ConfigWorkspaceError::InvalidIndex(1)
+        ));
+    }
+
+    #[test]
+    fn rename_works_while_entry_is_dirty() {
+        let first = config_text("Plant", "F", 60.0);
+        let mut workspace = ConfigWorkspace::from_presets(vec![("Plant", first)]).unwrap();
+        workspace
+            .selected_mut()
+            .set_draft_text("dirty draft".to_string());
+        workspace.rename(0, "Renamed Plant").unwrap();
+        assert_eq!(workspace.selected().name(), "Renamed Plant");
+        assert!(workspace.selected().is_dirty()); // draft preserved
     }
 }

--- a/crates/lsystem-web-app/src/app.rs
+++ b/crates/lsystem-web-app/src/app.rs
@@ -261,49 +261,29 @@ pub(crate) fn App() -> impl IntoView {
         )
     };
     let is_dirty = move || config_workspace.with(|workspace| workspace.selected().is_dirty());
+    let dirty_tooltip = move || {
+        if is_dirty() {
+            "Apply or Revert TOML changes first"
+        } else {
+            ""
+        }
+    };
 
     let rename_mode = RwSignal::new(false);
     let rename_draft = RwSignal::new(String::new());
-    let reset_prompt = RwSignal::new(false);
-
     let grammar_axiom = RwSignal::new(base_config.get_untracked().generation.axiom.clone());
-    let grammar_rules: RwSignal<Vec<(String, String)>> = RwSignal::new(
-        base_config
-            .get_untracked()
-            .generation
-            .rules
-            .iter()
-            .map(|(k, v)| (k.to_string(), v.clone()))
-            .collect(),
-    );
-    let grammar_prompt = RwSignal::new(false);
-    let grammar_3d_prompt = RwSignal::new(false);
+    let grammar_rules: RwSignal<Vec<(String, String)>> = RwSignal::new(rules_to_editor_rows(
+        &base_config.get_untracked().generation.rules,
+    ));
 
     let dims_3d_error: RwSignal<Option<String>> = RwSignal::new(None);
-    let params_pending: StoredValue<Option<Box<dyn Fn()>>, LocalStorage> =
-        StoredValue::new_local(None);
-    let params_prompt = RwSignal::new(false);
-
-    let colors_pending: StoredValue<Option<Box<dyn Fn()>>, LocalStorage> =
-        StoredValue::new_local(None);
-    let colors_prompt = RwSignal::new(false);
-
-    let hue_prompt = RwSignal::new(false);
-    let hue_pending_dir: StoredValue<Option<HsvMovementDirection>, LocalStorage> =
-        StoredValue::new_local(None);
 
     let save_format = RwSignal::new("png"); // "svg" | "png"
 
     let sync_grammar_editor = move || {
         let generation = base_config.get_untracked().generation.clone();
         grammar_axiom.set(generation.axiom);
-        grammar_rules.set(
-            generation
-                .rules
-                .iter()
-                .map(|(k, v)| (k.to_string(), v.clone()))
-                .collect(),
-        );
+        grammar_rules.set(rules_to_editor_rows(&generation.rules));
     };
 
     let canvas_ref = NodeRef::<Canvas>::new();
@@ -527,14 +507,26 @@ pub(crate) fn App() -> impl IntoView {
         sync_grammar_editor();
     };
 
-    // Silently reverts any in-flight dirty draft; used by confirm callbacks that
-    // need a clean entry before applying a new operation.
-    let revert_dirty = move || {
-        let _ = config_workspace.try_update(|ws| {
-            if let EntryViewMut::Dirty(dirty) = ws.selected_mut().view_mut() {
-                dirty.revert();
+    let do_revert = move || {
+        let result =
+            config_workspace.try_update(|workspace| match workspace.selected_mut().view_mut() {
+                EntryViewMut::Dirty(dirty) => {
+                    dirty.revert();
+                    true
+                }
+                EntryViewMut::Clean(_) => {
+                    log::error!("revert fired while entry is clean; UI guards bypassed");
+                    false
+                }
+            });
+        match result {
+            Some(true) => select_current_config(),
+            Some(false) => {}
+            None => {
+                log::error!("revert: config_workspace signal was unavailable");
+                error.set(Some("Internal error: could not revert config.".to_string()));
             }
-        });
+        }
     };
 
     let commit_rename = move || {
@@ -557,14 +549,7 @@ pub(crate) fn App() -> impl IntoView {
                 .map_err(|e| e.to_string())
         });
         match result {
-            Some(Ok(true)) => {
-                error.set(None);
-                stop_auto_rotate_if_2d();
-                refresh_color_memory();
-                render_current();
-                resume_hsv_movement_if_active();
-                sync_grammar_editor();
-            }
+            Some(Ok(true)) => select_current_config(),
             Some(Ok(false)) => {
                 log::warn!(
                     "do_reset: no-op for entry without a bundled default; button guard may have been bypassed"
@@ -575,20 +560,25 @@ pub(crate) fn App() -> impl IntoView {
         }
     };
 
-    let try_reset = move || {
-        if config_workspace.with_untracked(|ws| ws.selected().is_dirty()) {
-            reset_prompt.set(true);
-        } else {
-            do_reset();
-        }
-    };
-
     let grammar_has_3d_symbols = move || {
-        contains_3d_symbols(&grammar_axiom.get_untracked())
+        contains_3d_symbols(&grammar_axiom.get())
             || grammar_rules
-                .get_untracked()
+                .get()
                 .iter()
                 .any(|(_, rhs)| contains_3d_symbols(rhs))
+    };
+
+    let grammar_is_dirty = move || {
+        let generation = base_config.get().generation;
+        let applied_rules = rules_to_editor_rows(&generation.rules);
+        grammar_axiom.get() != generation.axiom || grammar_rules.get() != applied_rules
+    };
+    let grammar_dirty_tooltip = move || {
+        if grammar_is_dirty() {
+            "Apply or Revert grammar changes first"
+        } else {
+            ""
+        }
     };
 
     let do_apply_grammar = move || {
@@ -612,48 +602,29 @@ pub(crate) fn App() -> impl IntoView {
             }
             rules.push((c, v));
         }
-        update_clean_config(
+        if update_clean_config(
             config_workspace,
             error,
             render_current,
             "grammar apply",
             move |clean| clean.set_grammar(&axiom, &rules),
-        );
+        ) {
+            sync_grammar_editor();
+        }
     };
 
+    // Grammar Apply is enabled only when grammar has changes, the entry is clean, and
+    // no 3D-only symbols are present in 2D mode.
+    let grammar_can_apply =
+        move || grammar_is_dirty() && (is_3d() || !grammar_has_3d_symbols()) && !is_dirty();
+
     let try_apply_grammar = move || {
-        if config_workspace.with_untracked(|ws| ws.selected().is_dirty()) {
-            grammar_prompt.set(true);
-            return;
-        }
-        if grammar_has_3d_symbols()
-            && !matches!(
-                base_config.get_untracked().generation.dimensions,
-                Dimensions::ThreeD
-            )
-        {
-            grammar_3d_prompt.set(true);
+        // The Apply button is disabled when grammar has 3D symbols in 2D mode;
+        // this guard is a defensive fallback.
+        if grammar_has_3d_symbols() && !is_3d_untracked() {
             return;
         }
         do_apply_grammar();
-    };
-
-    let try_clean_param = move |action: Box<dyn Fn()>| {
-        if config_workspace.with_untracked(|ws| ws.selected().is_dirty()) {
-            params_pending.set_value(Some(action));
-            params_prompt.set(true);
-        } else {
-            action();
-        }
-    };
-
-    let try_clean_color = move |action: Box<dyn Fn()>| {
-        if config_workspace.with_untracked(|ws| ws.selected().is_dirty()) {
-            colors_pending.set_value(Some(action));
-            colors_prompt.set(true);
-        } else {
-            action();
-        }
     };
 
     let try_set_dimensions = move |key: &'static str| {
@@ -678,18 +649,16 @@ pub(crate) fn App() -> impl IntoView {
             }
         }
         dims_3d_error.set(None);
-        try_clean_param(Box::new(move || {
-            update_clean_config(
-                config_workspace,
-                error,
-                render_current,
-                "set dimensions",
-                move |clean| clean.set_dimensions(next),
-            );
-            if next == Dimensions::TwoD && auto_rotate.get_untracked() {
-                auto_rotate.set(false);
-            }
-        }));
+        update_clean_config(
+            config_workspace,
+            error,
+            render_current,
+            "set dimensions",
+            move |clean| clean.set_dimensions(next),
+        );
+        if next == Dimensions::TwoD && auto_rotate.get_untracked() {
+            auto_rotate.set(false);
+        }
     };
 
     let apply_hue_movement = move |dir: Option<HsvMovementDirection>| match dir {
@@ -707,14 +676,18 @@ pub(crate) fn App() -> impl IntoView {
             "backward" => Some(HsvMovementDirection::Reverse),
             _ => None,
         };
+        // Forward/Backward buttons are disabled when not in Hue-cycle mode;
+        // this guard is a defensive fallback in case disabled_keys is miscalculated.
         if dir.is_some()
             && !matches!(
                 base_config.with_untracked(line_color_of),
                 LineColorConfig::HueCycle { .. }
             )
         {
-            hue_pending_dir.set_value(dir);
-            hue_prompt.set(true);
+            log::error!(
+                "try_set_hue_movement: direction set while not in HueCycle mode; \
+                 disabled_keys guard may have been bypassed"
+            );
             return;
         }
         apply_hue_movement(dir);
@@ -873,31 +846,21 @@ pub(crate) fn App() -> impl IntoView {
                                 <button
                                     type="button"
                                     disabled=move || config_workspace.with(|ws| !ws.can_reset())
-                                    on:click=move |_| try_reset()
+                                    on:click=move |_| do_reset()
                                 >"Reset"</button>
                             </div>
                         }.into_any()
                     }}
                 </div>
 
-                <Show when=move || reset_prompt.get()>
-                    <crate::ui::WarningPrompt
-                        message="You have unapplied TOML changes. Discard them and reset?"
-                        confirm_label="Discard & reset"
-                        on_confirm=move || {
-                            reset_prompt.set(false);
-                            revert_dirty();
-                            do_reset();
-                        }
-                        on_cancel=move || reset_prompt.set(false)
-                    />
-                </Show>
-
-                <crate::ui::Disclosure title="Edit TOML" open=false>
+                <crate::ui::Disclosure title="Edit TOML" open=false
+                    badge=Signal::derive(is_dirty)>
+                    <div title=grammar_dirty_tooltip>
                     <textarea
                         id="config"
                         spellcheck="false"
                         prop:value=move || toml_text.get()
+                        disabled=grammar_is_dirty
                         on:input:target=move |ev| {
                             let text = ev.target().value();
                             let updated = config_workspace.try_update(|workspace| {
@@ -911,49 +874,29 @@ pub(crate) fn App() -> impl IntoView {
                             }
                         }
                     />
+                    </div>
+                    <div title=grammar_dirty_tooltip>
                     <div class="btn-row">
                         <button
                             type="button"
-                            disabled=move || !is_dirty()
+                            disabled=move || !is_dirty() || grammar_is_dirty()
                             on:click=move |_| apply_current()
                         >
                             "Apply"
                         </button>
                         <button
                             type="button"
-                            disabled=move || !is_dirty()
-                            on:click=move |_| {
-                                let ok = config_workspace.try_update(|workspace| {
-                                    match workspace.selected_mut().view_mut() {
-                                        EntryViewMut::Dirty(dirty) => dirty.revert(),
-                                        EntryViewMut::Clean(_) => {
-                                            log::error!(
-                                                "revert fired while entry is clean; UI guards bypassed"
-                                            );
-                                        }
-                                    }
-                                });
-                                if ok.is_some() {
-                                    error.set(None);
-                                    stop_auto_rotate_if_2d();
-                                    refresh_color_memory();
-                                    render_current();
-                                    resume_hsv_movement_if_active();
-                                    sync_grammar_editor();
-                                } else {
-                                    log::error!("revert: config_workspace signal was unavailable");
-                                    error.set(Some(
-                                        "Internal error: could not revert config.".to_string(),
-                                    ));
-                                }
-                            }
+                            disabled=move || !is_dirty() || grammar_is_dirty()
+                            on:click=move |_| do_revert()
                         >
                             "Revert"
                         </button>
                     </div>
+                    </div>
                 </crate::ui::Disclosure>
 
-                <crate::ui::Disclosure title="Grammar">
+                <crate::ui::Disclosure title="Grammar" badge=Signal::derive(grammar_is_dirty)>
+                    <div title=dirty_tooltip>
                     <table class="grammar-table">
                         <tbody>
                             <tr>
@@ -965,6 +908,7 @@ pub(crate) fn App() -> impl IntoView {
                                         type="text"
                                         class="grammar-rhs"
                                         prop:value=move || grammar_axiom.get()
+                                        disabled=is_dirty
                                         on:input:target=move |ev| grammar_axiom.set(ev.target().value())
                                     />
                                 </td>
@@ -991,6 +935,7 @@ pub(crate) fn App() -> impl IntoView {
                                                     list=list_id.clone()
                                                     maxlength="1"
                                                     prop:value=sym.clone()
+                                                    disabled=is_dirty
                                                     on:input:target=move |ev| {
                                                         grammar_rules.update(|rules| {
                                                             if let Some(r) = rules.get_mut(idx) {
@@ -1011,6 +956,7 @@ pub(crate) fn App() -> impl IntoView {
                                                     type="text"
                                                     class="grammar-rhs"
                                                     prop:value=rhs.clone()
+                                                    disabled=is_dirty
                                                     on:input:target=move |ev| {
                                                         grammar_rules.update(|rules| {
                                                             if let Some(r) = rules.get_mut(idx) {
@@ -1024,6 +970,7 @@ pub(crate) fn App() -> impl IntoView {
                                                 <button
                                                     type="button"
                                                     class="grammar-delete-btn"
+                                                    disabled=is_dirty
                                                     on:click=move |_| {
                                                         grammar_rules.update(|rules| { rules.remove(idx); });
                                                     }
@@ -1035,60 +982,45 @@ pub(crate) fn App() -> impl IntoView {
                             }}
                         </tbody>
                     </table>
+                    </div>
 
                     <div class="btn-row">
+                        <div title=dirty_tooltip>
+                            <button
+                                type="button"
+                                disabled=is_dirty
+                                on:click=move |_| {
+                                    grammar_rules.update(|rules| rules.push((String::new(), String::new())));
+                                }
+                            >"Add rule"</button>
+                        </div>
+                        <div title=move || {
+                            if is_dirty() { "Apply or Revert TOML changes first" }
+                            else if grammar_has_3d_symbols() && !is_3d() {
+                                "Contains 3D-only symbols — switch to 3D mode in Parameters first"
+                            } else { "" }
+                        }>
+                            <button
+                                type="button"
+                                disabled=move || !grammar_can_apply()
+                                on:click=move |_| try_apply_grammar()
+                            >"Apply"</button>
+                        </div>
                         <button
                             type="button"
-                            on:click=move |_| {
-                                grammar_rules.update(|rules| rules.push((String::new(), String::new())));
-                            }
-                        >"Add rule"</button>
-                        <button
-                            type="button"
-                            on:click=move |_| try_apply_grammar()
-                        >"Apply"</button>
+                            disabled=move || !grammar_is_dirty()
+                            on:click=move |_| sync_grammar_editor()
+                        >"Revert"</button>
                     </div>
                     {move || error.get().map(|msg| view! {
                         <span class="inline-status error">{msg}</span>
                     })}
-
-                    <Show when=move || grammar_prompt.get()>
-                        <crate::ui::WarningPrompt
-                            message="You have unapplied TOML changes. Discard them and proceed?"
-                            confirm_label="Discard & apply"
-                            on_confirm=move || {
-                                grammar_prompt.set(false);
-                                revert_dirty();
-                                try_apply_grammar();
-                            }
-                            on_cancel=move || grammar_prompt.set(false)
-                        />
-                    </Show>
-
-                    <Show when=move || grammar_3d_prompt.get()>
-                        <crate::ui::WarningPrompt
-                            message="Grammar contains 3D-only symbols. Switch to 3D to apply it."
-                            confirm_label="Switch to 3D & apply"
-                            on_confirm=move || {
-                                grammar_3d_prompt.set(false);
-                                if update_clean_config(
-                                    config_workspace,
-                                    error,
-                                    render_current,
-                                    "switch to 3D for grammar",
-                                    |clean| clean.set_dimensions(Dimensions::ThreeD),
-                                ) {
-                                    do_apply_grammar();
-                                }
-                            }
-                            on_cancel=move || grammar_3d_prompt.set(false)
-                        />
-                    </Show>
                 </crate::ui::Disclosure>
 
                 <crate::ui::Disclosure title="Parameters">
                     <div style="display:flex;flex-direction:column;gap:5px">
                         <span class="section-label">"Dimensions"</span>
+                        <div title=dirty_tooltip>
                         <crate::ui::SegmentedToggle
                             options=vec![("2d", "2D"), ("3d", "3D")]
                             selected=Signal::derive(move || match base_config.get().generation.dimensions {
@@ -1096,32 +1028,33 @@ pub(crate) fn App() -> impl IntoView {
                                 Dimensions::ThreeD => "3d",
                             })
                             on_change=move |key| try_set_dimensions(key)
+                            disabled=Signal::derive(is_dirty)
                         />
+                        </div>
                         {move || dims_3d_error.get().map(|msg| view! {
                             <span class="inline-status error">{msg}</span>
                         })}
                     </div>
 
-                    <div class="spinner-row">
+                    <div class="spinner-row" title=dirty_tooltip>
                         <span class="spinner-label">"Angle (°)"</span>
                         <crate::ui::Spinner
                             value=Signal::derive(move || format!("{:.1}", angle.get()))
                             step=0.5
+                            disabled=Signal::derive(is_dirty)
                             on_commit=move |s| {
                                 if let Ok(v) = s.parse::<f32>() {
                                     let v = v.clamp(1.0, 180.0);
-                                    try_clean_param(Box::new(move || {
-                                        update_clean_config(
-                                            config_workspace, error, render_current, "angle",
-                                            move |clean| clean.set_angle(v),
-                                        );
-                                    }));
+                                    update_clean_config(
+                                        config_workspace, error, render_current, "angle",
+                                        move |clean| clean.set_angle(v),
+                                    );
                                 }
                             }
                         />
                     </div>
 
-                    <div class="spinner-row">
+                    <div class="spinner-row" title=dirty_tooltip>
                         <span class="spinner-label">"Initial heading (°)"</span>
                         <crate::ui::Spinner
                             value=Signal::derive(move || format!(
@@ -1129,63 +1062,48 @@ pub(crate) fn App() -> impl IntoView {
                                 config_workspace.with(|ws| ws.selected().applied_config().generation.initial_heading)
                             ))
                             step=1.0
+                            disabled=Signal::derive(is_dirty)
                             on_commit=move |s| {
                                 if let Ok(v) = s.parse::<f32>() {
-                                    try_clean_param(Box::new(move || {
-                                        update_clean_config(
-                                            config_workspace, error, render_current, "initial_heading",
-                                            move |clean| clean.set_initial_heading(v),
-                                        );
-                                    }));
+                                    update_clean_config(
+                                        config_workspace, error, render_current, "initial_heading",
+                                        move |clean| clean.set_initial_heading(v),
+                                    );
                                 }
                             }
                         />
                     </div>
 
-                    <div class="spinner-row">
+                    <div class="spinner-row" title=dirty_tooltip>
                         <span class="spinner-label">"Iterations"</span>
                         <crate::ui::Spinner
                             value=Signal::derive(move || iterations.get().to_string())
                             step=1.0
+                            disabled=Signal::derive(is_dirty)
                             on_commit=move |s| {
                                 if let Ok(v) = s.parse::<u32>() {
                                     let v = v.clamp(0, max_iterations.get_untracked());
-                                    try_clean_param(Box::new(move || {
-                                        update_clean_config(
-                                            config_workspace, error, render_current, "iterations",
-                                            move |clean| clean.set_iterations(v),
-                                        );
-                                    }));
+                                    update_clean_config(
+                                        config_workspace, error, render_current, "iterations",
+                                        move |clean| clean.set_iterations(v),
+                                    );
                                 }
                             }
                         />
                     </div>
-
-                    <Show when=move || params_prompt.get()>
-                        <crate::ui::WarningPrompt
-                            message="You have unapplied TOML changes. Discard them and proceed?"
-                            confirm_label="Discard & proceed"
-                            on_confirm=move || {
-                                params_prompt.set(false);
-                                revert_dirty();
-                                sync_grammar_editor();
-                                if let Some(Some(action)) = params_pending.try_update_value(|v| v.take()) { action(); }
-                                params_pending.set_value(None);
-                            }
-                            on_cancel=move || {
-                                params_prompt.set(false);
-                                params_pending.set_value(None);
-                            }
-                        />
-                    </Show>
                 </crate::ui::Disclosure>
 
                 <crate::ui::Disclosure title="Colors">
+                    <div
+                        style="display:flex;flex-direction:column;gap:9px"
+                        title=dirty_tooltip
+                    >
                     <label class="check-row" for="background-override">
                         <input
                             id="background-override"
                             type="checkbox"
                             prop:checked=move || base_config.with(|c| c.colors.background.is_some())
+                            disabled=is_dirty
                             on:change:target=move |ev| {
                                 let current_bg =
                                     base_config.with_untracked(|c| c.colors.background);
@@ -1200,15 +1118,13 @@ pub(crate) fn App() -> impl IntoView {
                                 } else {
                                     None
                                 };
-                                try_clean_color(Box::new(move || {
-                                    update_clean_config(
-                                        config_workspace,
-                                        error,
-                                        render_current_colors,
-                                        "background checkbox",
-                                        move |clean| clean.set_background(background),
-                                    );
-                                }));
+                                update_clean_config(
+                                    config_workspace,
+                                    error,
+                                    render_current_colors,
+                                    "background checkbox",
+                                    move |clean| clean.set_background(background),
+                                );
                             }
                         />
                         <span>"Background"</span>
@@ -1225,24 +1141,23 @@ pub(crate) fn App() -> impl IntoView {
                             prop:value=move || {
                                 rgb_to_hex(base_config.with(|c| c.colors.effective_background()))
                             }
+                            disabled=is_dirty
                             on:input:target=move |ev| {
                                 let Some(color) = hex_to_rgb(&ev.target().value()) else {
                                     error.set(Some("Invalid color value.".to_string()));
                                     return;
                                 };
-                                try_clean_color(Box::new(move || {
-                                    if update_clean_config(
-                                        config_workspace,
-                                        error,
-                                        render_current_colors,
-                                        "background color input",
-                                        move |clean| clean.set_background(Some(color)),
-                                    ) {
-                                        color_memory.update(|memory| {
-                                            memory.remember_background(color);
-                                        });
-                                    }
-                                }));
+                                if update_clean_config(
+                                    config_workspace,
+                                    error,
+                                    render_current_colors,
+                                    "background color input",
+                                    move |clean| clean.set_background(Some(color)),
+                                ) {
+                                    color_memory.update(|memory| {
+                                        memory.remember_background(color);
+                                    });
+                                }
                             }
                         />
                     </div>
@@ -1255,6 +1170,7 @@ pub(crate) fn App() -> impl IntoView {
                                 .key()
                                 .to_string()
                         }
+                        disabled=is_dirty
                         on:change:target=move |ev| {
                             let mode_key = ev.target().value();
                             let Some(mode) = LineColorMode::from_key(&mode_key) else {
@@ -1274,20 +1190,18 @@ pub(crate) fn App() -> impl IntoView {
                                 ));
                                 return;
                             };
-                            try_clean_color(Box::new(move || {
-                                if update_clean_config(
-                                    config_workspace,
-                                    error,
-                                    render_current_colors,
-                                    "line color mode select",
-                                    move |clean| clean.set_line_color(line_color),
-                                ) {
-                                    color_memory.update(|memory| {
-                                        memory.remember_line(line_color);
-                                    });
-                                    resume_hsv_movement_if_active();
-                                }
-                            }));
+                            if update_clean_config(
+                                config_workspace,
+                                error,
+                                render_current_colors,
+                                "line color mode select",
+                                move |clean| clean.set_line_color(line_color),
+                            ) {
+                                color_memory.update(|memory| {
+                                    memory.remember_line(line_color);
+                                });
+                                resume_hsv_movement_if_active();
+                            }
                         }
                     >
                         <option value="solid">"Solid"</option>
@@ -1316,25 +1230,24 @@ pub(crate) fn App() -> impl IntoView {
                                     _ => unreachable!("solid mode must provide solid color"),
                                 }
                             }
+                            disabled=is_dirty
                             on:input:target=move |ev| {
                                 let Some(color) = hex_to_rgb(&ev.target().value()) else {
                                     error.set(Some("Invalid color value.".to_string()));
                                     return;
                                 };
                                 let line_color = LineColorConfig::Solid { color };
-                                try_clean_color(Box::new(move || {
-                                    if update_clean_config(
-                                        config_workspace,
-                                        error,
-                                        render_current_colors,
-                                        "solid line color input",
-                                        move |clean| clean.set_line_color(line_color),
-                                    ) {
-                                        color_memory.update(|memory| {
-                                            memory.remember_line(line_color);
-                                        });
-                                    }
-                                }));
+                                if update_clean_config(
+                                    config_workspace,
+                                    error,
+                                    render_current_colors,
+                                    "solid line color input",
+                                    move |clean| clean.set_line_color(line_color),
+                                ) {
+                                    color_memory.update(|memory| {
+                                        memory.remember_line(line_color);
+                                    });
+                                }
                             }
                         />
                     </div>
@@ -1366,6 +1279,7 @@ pub(crate) fn App() -> impl IntoView {
                                     ),
                                 }
                             }
+                            disabled=is_dirty
                             on:input:target=move |ev| {
                                 let Some(start) = hex_to_rgb(&ev.target().value()) else {
                                     error.set(Some("Invalid color value.".to_string()));
@@ -1383,19 +1297,17 @@ pub(crate) fn App() -> impl IntoView {
                                     ),
                                 };
                                 let line_color = LineColorConfig::DepthGradient { start, end };
-                                try_clean_color(Box::new(move || {
-                                    if update_clean_config(
-                                        config_workspace,
-                                        error,
-                                        render_current_colors,
-                                        "depth-gradient start color input",
-                                        move |clean| clean.set_line_color(line_color),
-                                    ) {
-                                        color_memory.update(|memory| {
-                                            memory.remember_line(line_color);
-                                        });
-                                    }
-                                }));
+                                if update_clean_config(
+                                    config_workspace,
+                                    error,
+                                    render_current_colors,
+                                    "depth-gradient start color input",
+                                    move |clean| clean.set_line_color(line_color),
+                                ) {
+                                    color_memory.update(|memory| {
+                                        memory.remember_line(line_color);
+                                    });
+                                }
                             }
                         />
 
@@ -1415,6 +1327,7 @@ pub(crate) fn App() -> impl IntoView {
                                     ),
                                 }
                             }
+                            disabled=is_dirty
                             on:input:target=move |ev| {
                                 let Some(end) = hex_to_rgb(&ev.target().value()) else {
                                     error.set(Some("Invalid color value.".to_string()));
@@ -1432,19 +1345,17 @@ pub(crate) fn App() -> impl IntoView {
                                     ),
                                 };
                                 let line_color = LineColorConfig::DepthGradient { start, end };
-                                try_clean_color(Box::new(move || {
-                                    if update_clean_config(
-                                        config_workspace,
-                                        error,
-                                        render_current_colors,
-                                        "depth-gradient end color input",
-                                        move |clean| clean.set_line_color(line_color),
-                                    ) {
-                                        color_memory.update(|memory| {
-                                            memory.remember_line(line_color);
-                                        });
-                                    }
-                                }));
+                                if update_clean_config(
+                                    config_workspace,
+                                    error,
+                                    render_current_colors,
+                                    "depth-gradient end color input",
+                                    move |clean| clean.set_line_color(line_color),
+                                ) {
+                                    color_memory.update(|memory| {
+                                        memory.remember_line(line_color);
+                                    });
+                                }
                             }
                         />
                     </div>
@@ -1472,6 +1383,7 @@ pub(crate) fn App() -> impl IntoView {
                                     _ => unreachable!("gradient mode must provide gradient color"),
                                 }
                             }
+                            disabled=is_dirty
                             on:input:target=move |ev| {
                                 let Some(start) = hex_to_rgb(&ev.target().value()) else {
                                     error.set(Some("Invalid color value.".to_string()));
@@ -1487,19 +1399,17 @@ pub(crate) fn App() -> impl IntoView {
                                     _ => unreachable!("gradient mode must provide gradient color"),
                                 };
                                 let line_color = LineColorConfig::Gradient { start, end };
-                                try_clean_color(Box::new(move || {
-                                    if update_clean_config(
-                                        config_workspace,
-                                        error,
-                                        render_current_colors,
-                                        "gradient start color input",
-                                        move |clean| clean.set_line_color(line_color),
-                                    ) {
-                                        color_memory.update(|memory| {
-                                            memory.remember_line(line_color);
-                                        });
-                                    }
-                                }));
+                                if update_clean_config(
+                                    config_workspace,
+                                    error,
+                                    render_current_colors,
+                                    "gradient start color input",
+                                    move |clean| clean.set_line_color(line_color),
+                                ) {
+                                    color_memory.update(|memory| {
+                                        memory.remember_line(line_color);
+                                    });
+                                }
                             }
                         />
 
@@ -1517,6 +1427,7 @@ pub(crate) fn App() -> impl IntoView {
                                     _ => unreachable!("gradient mode must provide gradient color"),
                                 }
                             }
+                            disabled=is_dirty
                             on:input:target=move |ev| {
                                 let Some(end) = hex_to_rgb(&ev.target().value()) else {
                                     error.set(Some("Invalid color value.".to_string()));
@@ -1532,19 +1443,17 @@ pub(crate) fn App() -> impl IntoView {
                                     _ => unreachable!("gradient mode must provide gradient color"),
                                 };
                                 let line_color = LineColorConfig::Gradient { start, end };
-                                try_clean_color(Box::new(move || {
-                                    if update_clean_config(
-                                        config_workspace,
-                                        error,
-                                        render_current_colors,
-                                        "gradient end color input",
-                                        move |clean| clean.set_line_color(line_color),
-                                    ) {
-                                        color_memory.update(|memory| {
-                                            memory.remember_line(line_color);
-                                        });
-                                    }
-                                }));
+                                if update_clean_config(
+                                    config_workspace,
+                                    error,
+                                    render_current_colors,
+                                    "gradient end color input",
+                                    move |clean| clean.set_line_color(line_color),
+                                ) {
+                                    color_memory.update(|memory| {
+                                        memory.remember_line(line_color);
+                                    });
+                                }
                             }
                         />
                     </div>
@@ -1572,56 +1481,34 @@ pub(crate) fn App() -> impl IntoView {
                                     _ => unreachable!("hue-cycle mode must provide hue-cycle color"),
                                 }
                             }
+                            disabled=is_dirty
                             on:input:target=move |ev| {
                                 let Some(initial) = hex_to_rgb(&ev.target().value()) else {
                                     error.set(Some("Invalid color value.".to_string()));
                                     return;
                                 };
                                 let line_color = LineColorConfig::HueCycle { initial };
-                                try_clean_color(Box::new(move || {
-                                    if update_clean_config(
-                                        config_workspace,
-                                        error,
-                                        render_current_colors,
-                                        "hue-cycle initial color input",
-                                        move |clean| clean.set_line_color(line_color),
-                                    ) {
-                                        color_memory.update(|memory| {
-                                            memory.remember_line(line_color);
-                                        });
-                                    }
-                                }));
+                                if update_clean_config(
+                                    config_workspace,
+                                    error,
+                                    render_current_colors,
+                                    "hue-cycle initial color input",
+                                    move |clean| clean.set_line_color(line_color),
+                                ) {
+                                    color_memory.update(|memory| {
+                                        memory.remember_line(line_color);
+                                    });
+                                }
                             }
                         />
                     </div>
-
-                    <Show when=move || colors_prompt.get()>
-                        <crate::ui::WarningPrompt
-                            message="You have unapplied TOML changes. Discard them and proceed?"
-                            confirm_label="Discard & proceed"
-                            on_confirm=move || {
-                                colors_prompt.set(false);
-                                revert_dirty();
-                                sync_grammar_editor();
-                                if let Some(action) = colors_pending.try_update_value(|v| v.take()).flatten() {
-                                    action();
-                                }
-                            }
-                            on_cancel=move || {
-                                colors_prompt.set(false);
-                                colors_pending.set_value(None);
-                            }
-                        />
-                    </Show>
+                    </div>
                 </crate::ui::Disclosure>
 
                 <crate::ui::Disclosure title="Animations">
                     <div style="display:flex;flex-direction:column;gap:6px">
-                        <span class=move || {
-                            if is_3d() { "section-label" } else { "section-label dim" }
-                        }>
-                            {move || if is_3d() { "Auto-rotate" } else { "Auto-rotate (3D only)" }}
-                        </span>
+                        <span class="section-label">"Auto-rotate"</span>
+                        <div title=move || if !is_3d() { "Switch to 3D mode in Parameters to enable auto-rotate" } else { "" }>
                         <crate::ui::SegmentedToggle
                             options=vec![("off", "Off"), ("on", "On")]
                             selected=Signal::derive(move || if auto_rotate.get() { "on" } else { "off" })
@@ -1631,6 +1518,7 @@ pub(crate) fn App() -> impl IntoView {
                             }
                             disabled=Signal::derive(move || !is_3d())
                         />
+                        </div>
                         <Show when=move || auto_rotate.get() && is_3d()>
                             <div class="spinner-row">
                                 <span class="spinner-label">"Speed (°/s)"</span>
@@ -1651,6 +1539,7 @@ pub(crate) fn App() -> impl IntoView {
 
                     <div style="display:flex;flex-direction:column;gap:6px">
                         <span class="section-label">"Hue movement"</span>
+                        <div title=move || if !matches!(current_line_color(base_config), LineColorConfig::HueCycle { .. }) { "Select Hue cycle in Colors to enable hue movement" } else { "" }>
                         <crate::ui::SegmentedToggle
                             options=vec![("off", "Off"), ("forward", "Forward"), ("backward", "Backward")]
                             selected=Signal::derive(move || {
@@ -1659,7 +1548,15 @@ pub(crate) fn App() -> impl IntoView {
                                 else { "backward" }
                             })
                             on_change=move |key| try_set_hue_movement(key)
+                            disabled_keys=Signal::derive(move || {
+                                if matches!(current_line_color(base_config), LineColorConfig::HueCycle { .. }) {
+                                    vec![]
+                                } else {
+                                    vec!["forward", "backward"]
+                                }
+                            })
                         />
+                        </div>
                         <Show when=move || hsv_movement.get()>
                             <div class="spinner-row">
                                 <span class="spinner-label">"Speed (°/s)"</span>
@@ -1676,37 +1573,6 @@ pub(crate) fn App() -> impl IntoView {
                                     }
                                 />
                             </div>
-                        </Show>
-                        <Show when=move || hue_prompt.get()>
-                            <crate::ui::WarningPrompt
-                                message="Line color is not Hue cycle. Enabling this will switch it to Hue cycle."
-                                confirm_label="Switch & enable"
-                                on_confirm=move || {
-                                    let dir = hue_pending_dir
-                                        .try_update_value(|v| v.take())
-                                        .flatten()
-                                        .unwrap_or(HsvMovementDirection::Forward);
-                                    revert_dirty();
-                                    let line_color = color_memory
-                                        .with_untracked(|m| m.line_for(LineColorMode::HueCycle));
-                                    if update_clean_config(
-                                        config_workspace,
-                                        error,
-                                        render_current_colors,
-                                        "switch to hue cycle",
-                                        move |clean| clean.set_line_color(line_color),
-                                    ) {
-                                        color_memory.update(|m| m.remember_line(line_color));
-                                        resume_hsv_movement_if_active();
-                                        apply_hue_movement(Some(dir));
-                                    }
-                                    hue_prompt.set(false);
-                                }
-                                on_cancel=move || {
-                                    hue_prompt.set(false);
-                                    hue_pending_dir.set_value(None);
-                                }
-                            />
                         </Show>
                     </div>
                 </crate::ui::Disclosure>
@@ -1922,6 +1788,13 @@ pub(crate) fn App() -> impl IntoView {
             </section>
         </main>
     }
+}
+
+fn rules_to_editor_rows(rules: &std::collections::BTreeMap<char, String>) -> Vec<(String, String)> {
+    rules
+        .iter()
+        .map(|(k, v)| (k.to_string(), v.clone()))
+        .collect()
 }
 
 fn update_clean_config(

--- a/crates/lsystem-web-app/src/app.rs
+++ b/crates/lsystem-web-app/src/app.rs
@@ -74,6 +74,16 @@ enum HsvMovementDirection {
 }
 
 impl HsvMovementDirection {
+    fn sign(self) -> f32 {
+        match self {
+            Self::Forward => 1.0,
+            Self::Reverse => -1.0,
+        }
+    }
+}
+
+#[cfg(test)]
+impl HsvMovementDirection {
     fn from_key(key: &str) -> Option<Self> {
         match key {
             "forward" => Some(Self::Forward),
@@ -95,13 +105,6 @@ impl HsvMovementDirection {
             Self::Reverse => "Reverse",
         }
     }
-
-    fn sign(self) -> f32 {
-        match self {
-            Self::Forward => 1.0,
-            Self::Reverse => -1.0,
-        }
-    }
 }
 
 fn advance_hsv_phase_degrees(
@@ -115,6 +118,10 @@ fn advance_hsv_phase_degrees(
 
 fn hsv_movement_is_active(enabled: bool, line_color: &LineColorConfig) -> bool {
     enabled && matches!(line_color, LineColorConfig::HueCycle { .. })
+}
+
+fn contains_3d_symbols(s: &str) -> bool {
+    s.contains(['&', '^', '/', '\\'])
 }
 
 #[derive(Clone, Copy)]
@@ -215,6 +222,9 @@ pub(crate) fn App() -> impl IntoView {
     let hsv_movement_speed = RwSignal::new(HSV_MOVEMENT_DEFAULT_SPEED_DEGREES_PER_SECOND);
     let hsv_movement_direction = RwSignal::new(HsvMovementDirection::Forward);
     let hsv_movement_phase = RwSignal::new(0.0f32);
+    let sidebar_collapsed = RwSignal::new(false);
+    let sheet_open = RwSignal::new(false);
+    let sheet_drag_start: StoredValue<Option<f64>, LocalStorage> = StoredValue::new_local(None);
     // Generation counter: bumped on each animation start so older rAF loops detect
     // they have been superseded and exit.
     let animation_token = RwSignal::new(0u32);
@@ -251,6 +261,50 @@ pub(crate) fn App() -> impl IntoView {
         )
     };
     let is_dirty = move || config_workspace.with(|workspace| workspace.selected().is_dirty());
+
+    let rename_mode = RwSignal::new(false);
+    let rename_draft = RwSignal::new(String::new());
+    let reset_prompt = RwSignal::new(false);
+
+    let grammar_axiom = RwSignal::new(base_config.get_untracked().generation.axiom.clone());
+    let grammar_rules: RwSignal<Vec<(String, String)>> = RwSignal::new(
+        base_config
+            .get_untracked()
+            .generation
+            .rules
+            .iter()
+            .map(|(k, v)| (k.to_string(), v.clone()))
+            .collect(),
+    );
+    let grammar_prompt = RwSignal::new(false);
+    let grammar_3d_prompt = RwSignal::new(false);
+
+    let dims_3d_error: RwSignal<Option<String>> = RwSignal::new(None);
+    let params_pending: StoredValue<Option<Box<dyn Fn()>>, LocalStorage> =
+        StoredValue::new_local(None);
+    let params_prompt = RwSignal::new(false);
+
+    let colors_pending: StoredValue<Option<Box<dyn Fn()>>, LocalStorage> =
+        StoredValue::new_local(None);
+    let colors_prompt = RwSignal::new(false);
+
+    let hue_prompt = RwSignal::new(false);
+    let hue_pending_dir: StoredValue<Option<HsvMovementDirection>, LocalStorage> =
+        StoredValue::new_local(None);
+
+    let save_format = RwSignal::new("png"); // "svg" | "png"
+
+    let sync_grammar_editor = move || {
+        let generation = base_config.get_untracked().generation.clone();
+        grammar_axiom.set(generation.axiom);
+        grammar_rules.set(
+            generation
+                .rules
+                .iter()
+                .map(|(k, v)| (k.to_string(), v.clone()))
+                .collect(),
+        );
+    };
 
     let canvas_ref = NodeRef::<Canvas>::new();
 
@@ -454,6 +508,7 @@ pub(crate) fn App() -> impl IntoView {
                 }
                 render_current();
                 resume_hsv_movement_if_active();
+                sync_grammar_editor();
             }
             Some(Err(msg)) => error.set(Some(msg)),
             None => {
@@ -469,274 +524,668 @@ pub(crate) fn App() -> impl IntoView {
         refresh_color_memory();
         render_current();
         resume_hsv_movement_if_active();
+        sync_grammar_editor();
     };
 
-    let toggle_auto_rotate = move |_: web_sys::MouseEvent| {
-        if auto_rotate.get_untracked() {
-            auto_rotate.set(false);
-        } else {
-            auto_rotate.set(true);
-            start_animation_loop();
+    // Silently reverts any in-flight dirty draft; used by confirm callbacks that
+    // need a clean entry before applying a new operation.
+    let revert_dirty = move || {
+        let _ = config_workspace.try_update(|ws| {
+            if let EntryViewMut::Dirty(dirty) = ws.selected_mut().view_mut() {
+                dirty.revert();
+            }
+        });
+    };
+
+    let commit_rename = move || {
+        let name = rename_draft.get_untracked().trim().to_string();
+        let idx = config_workspace.with_untracked(|ws| ws.selected_index());
+        match config_workspace.try_update(|ws| ws.rename(idx, &name)) {
+            Some(Ok(())) => {
+                error.set(None);
+                rename_mode.set(false);
+            }
+            Some(Err(e)) => error.set(Some(e.to_string())),
+            None => error.set(Some("Internal error: could not rename.".to_string())),
         }
     };
 
-    let toggle_hsv_movement = move |_: web_sys::MouseEvent| {
-        if hsv_movement.get_untracked() {
-            reset_hsv_movement();
-        } else if matches!(
-            base_config.with_untracked(line_color_of),
-            LineColorConfig::HueCycle { .. }
-        ) {
+    let do_reset = move || {
+        let result = config_workspace.try_update(|ws| {
+            ws.reset()
+                .map(|opt| opt.is_some())
+                .map_err(|e| e.to_string())
+        });
+        match result {
+            Some(Ok(true)) => {
+                error.set(None);
+                stop_auto_rotate_if_2d();
+                refresh_color_memory();
+                render_current();
+                resume_hsv_movement_if_active();
+                sync_grammar_editor();
+            }
+            Some(Ok(false)) => {
+                log::warn!(
+                    "do_reset: no-op for entry without a bundled default; button guard may have been bypassed"
+                );
+            }
+            Some(Err(msg)) => error.set(Some(msg)),
+            None => error.set(Some("Internal error: could not reset.".to_string())),
+        }
+    };
+
+    let try_reset = move || {
+        if config_workspace.with_untracked(|ws| ws.selected().is_dirty()) {
+            reset_prompt.set(true);
+        } else {
+            do_reset();
+        }
+    };
+
+    let grammar_has_3d_symbols = move || {
+        contains_3d_symbols(&grammar_axiom.get_untracked())
+            || grammar_rules
+                .get_untracked()
+                .iter()
+                .any(|(_, rhs)| contains_3d_symbols(rhs))
+    };
+
+    let do_apply_grammar = move || {
+        let axiom = grammar_axiom.get_untracked();
+        let rules_raw = grammar_rules.get_untracked();
+        let mut seen = std::collections::HashSet::new();
+        let mut rules: Vec<(char, String)> = Vec::with_capacity(rules_raw.len());
+        for (k, v) in rules_raw {
+            let Some(c) = k.chars().next() else {
+                error.set(Some(
+                    "Each rule must have a symbol. Remove or complete empty rows before applying."
+                        .to_string(),
+                ));
+                return;
+            };
+            if !seen.insert(c) {
+                error.set(Some(format!(
+                    "Duplicate rule symbol '{c}'. Each symbol may appear only once."
+                )));
+                return;
+            }
+            rules.push((c, v));
+        }
+        update_clean_config(
+            config_workspace,
+            error,
+            render_current,
+            "grammar apply",
+            move |clean| clean.set_grammar(&axiom, &rules),
+        );
+    };
+
+    let try_apply_grammar = move || {
+        if config_workspace.with_untracked(|ws| ws.selected().is_dirty()) {
+            grammar_prompt.set(true);
+            return;
+        }
+        if grammar_has_3d_symbols()
+            && !matches!(
+                base_config.get_untracked().generation.dimensions,
+                Dimensions::ThreeD
+            )
+        {
+            grammar_3d_prompt.set(true);
+            return;
+        }
+        do_apply_grammar();
+    };
+
+    let try_clean_param = move |action: Box<dyn Fn()>| {
+        if config_workspace.with_untracked(|ws| ws.selected().is_dirty()) {
+            params_pending.set_value(Some(action));
+            params_prompt.set(true);
+        } else {
+            action();
+        }
+    };
+
+    let try_clean_color = move |action: Box<dyn Fn()>| {
+        if config_workspace.with_untracked(|ws| ws.selected().is_dirty()) {
+            colors_pending.set_value(Some(action));
+            colors_prompt.set(true);
+        } else {
+            action();
+        }
+    };
+
+    let try_set_dimensions = move |key: &'static str| {
+        let next = if key == "3d" {
+            Dimensions::ThreeD
+        } else {
+            Dimensions::TwoD
+        };
+        if next == Dimensions::TwoD {
+            let generation = base_config.get_untracked().generation;
+            if contains_3d_symbols(&generation.axiom)
+                || generation
+                    .rules
+                    .values()
+                    .any(|rhs| contains_3d_symbols(rhs))
+            {
+                dims_3d_error.set(Some(
+                    "Remove 3D-only symbols (& ^ / \\) from the grammar before switching to 2D."
+                        .to_string(),
+                ));
+                return;
+            }
+        }
+        dims_3d_error.set(None);
+        try_clean_param(Box::new(move || {
+            update_clean_config(
+                config_workspace,
+                error,
+                render_current,
+                "set dimensions",
+                move |clean| clean.set_dimensions(next),
+            );
+            if next == Dimensions::TwoD && auto_rotate.get_untracked() {
+                auto_rotate.set(false);
+            }
+        }));
+    };
+
+    let apply_hue_movement = move |dir: Option<HsvMovementDirection>| match dir {
+        None => reset_hsv_movement(),
+        Some(d) => {
+            hsv_movement_direction.set(d);
             hsv_movement.set(true);
             start_animation_loop();
         }
     };
 
+    let try_set_hue_movement = move |key: &'static str| {
+        let dir = match key {
+            "forward" => Some(HsvMovementDirection::Forward),
+            "backward" => Some(HsvMovementDirection::Reverse),
+            _ => None,
+        };
+        if dir.is_some()
+            && !matches!(
+                base_config.with_untracked(line_color_of),
+                LineColorConfig::HueCycle { .. }
+            )
+        {
+            hue_pending_dir.set_value(dir);
+            hue_prompt.set(true);
+            return;
+        }
+        apply_hue_movement(dir);
+    };
+
     view! {
-        <main class="app-shell">
-            <aside class="controls">
-                <h1>"Grow Your Own Fractal"</h1>
-
-                <label for="preset">"Config"</label>
-                <select
-                    id="preset"
-                    prop:value=move || {
-                        config_workspace.with(|workspace| workspace.selected_index().to_string())
+        <main
+            class="app-shell"
+            class:sidebar-collapsed=move || sidebar_collapsed.get()
+        >
+            <aside
+                class="controls"
+                class:sheet-open=move || sheet_open.get()
+            >
+                <div
+                    class="sheet-handle-area"
+                    on:pointerdown=move |ev: web_sys::PointerEvent| {
+                        let target: web_sys::Element = ev.target().unwrap().unchecked_into();
+                        let _ = target.set_pointer_capture(ev.pointer_id());
+                        sheet_drag_start.set_value(Some(ev.client_y() as f64));
                     }
-                    on:change:target=move |ev| {
-                        let idx = ev.target().value().parse::<usize>().unwrap_or(0);
-                        let selected = config_workspace.try_update(|workspace| {
-                            workspace.select(idx).map(|_| ()).map_err(|e| e.to_string())
-                        });
-                        match selected {
-                            Some(Ok(())) => {
-                                select_current_config();
-                            }
-                            Some(Err(err)) => {
-                                log::error!("select preset: rejected index {idx}: {err}");
-                                error.set(Some(err));
-                            }
-                            None => {
-                                log::error!(
-                                    "select preset: config_workspace signal was unavailable"
-                                );
-                                error.set(Some(
-                                    "Internal error: could not select config.".to_string(),
-                                ));
-                            }
+                    on:pointermove=move |ev: web_sys::PointerEvent| {
+                        let Some(start) = sheet_drag_start.get_value() else { return; };
+                        let dy = ev.client_y() as f64 - start;
+                        if dy < -30.0 {
+                            sheet_open.set(true);
+                            sheet_drag_start.set_value(None);
+                        } else if dy > 30.0 {
+                            sheet_open.set(false);
+                            sheet_drag_start.set_value(None);
                         }
                     }
+                    on:pointerup=move |_| { sheet_drag_start.set_value(None); }
+                    on:click=move |_| sheet_open.update(|v| *v = !*v)
                 >
-                    {move || {
-                        config_workspace.with(|workspace| {
-                            workspace
-                                .entries()
-                                .iter()
-                                .enumerate()
-                                .map(|(idx, entry)| {
-                                    view! {
-                                        <option value=idx.to_string()>{entry.name().to_string()}</option>
-                                    }
-                                })
-                                .collect_view()
-                        })
-                    }}
-                </select>
+                    <div class="sheet-handle"></div>
+                    <span class="sheet-preset-name">
+                        {move || config_workspace.with(|ws| ws.selected().name().to_string())}
+                    </span>
+                </div>
 
-                <button
-                    type="button"
-                    on:click=move |_| {
-                        let result = config_workspace.try_update(|workspace| {
-                            workspace.copy().map(|_| ()).map_err(|e| e.to_string())
-                        });
-                        match result {
-                            Some(Ok(())) => {
-                                error.set(None);
-                                stop_auto_rotate_if_2d();
-                                refresh_color_memory();
-                                render_current();
-                                resume_hsv_movement_if_active();
-                            }
-                            Some(Err(msg)) => error.set(Some(msg)),
-                            None => {
-                                log::error!("copy: config_workspace signal was unavailable");
-                                error.set(Some(
-                                    "Internal error: could not copy config.".to_string(),
-                                ));
-                            }
-                        }
-                    }
-                >
-                    "Copy"
-                </button>
+                <div class="controls-scroll">
+                <h1 class="controls-title">"Grow Your Own Fractal"</h1>
 
-                <label for="config">"Config (TOML)"</label>
-                <textarea
-                    id="config"
-                    spellcheck="false"
-                    prop:value=move || toml_text.get()
-                    on:input:target=move |ev| {
-                        let text = ev.target().value();
-                        let updated = config_workspace.try_update(|workspace| {
-                            workspace.selected_mut().set_draft_text(text);
-                        });
-                        if updated.is_none() {
-                            log::error!("textarea input: config_workspace signal was unavailable");
-                            error.set(Some(
-                                "Internal error: could not update config.".to_string(),
-                            ));
-                        }
-                    }
-                />
-
-                <div class="row">
-                    <button
-                        type="button"
-                        disabled=move || !is_dirty()
-                        on:click=move |_| apply_current()
-                    >
-                        "Apply"
-                    </button>
-                    <button
-                        type="button"
-                        disabled=move || !is_dirty()
-                        on:click=move |_| {
-                            let ok = config_workspace.try_update(|workspace| {
-                                match workspace.selected_mut().view_mut() {
-                                    EntryViewMut::Dirty(dirty) => dirty.revert(),
-                                    EntryViewMut::Clean(_) => {
-                                        log::error!(
-                                            "revert fired while entry is clean; UI guards bypassed"
-                                        );
-                                    }
-                                }
+                <div class="preset-row">
+                    <select
+                        class:hidden=move || rename_mode.get()
+                        prop:value=move || config_workspace.with(|ws| ws.selected_index().to_string())
+                        on:change:target=move |ev| {
+                            let idx = ev.target().value().parse::<usize>().unwrap_or(0);
+                            let selected = config_workspace.try_update(|workspace| {
+                                workspace.select(idx).map(|_| ()).map_err(|e| e.to_string())
                             });
-                            if ok.is_some() {
-                                error.set(None);
-                                stop_auto_rotate_if_2d();
-                                refresh_color_memory();
-                                render_current();
-                                resume_hsv_movement_if_active();
-                            } else {
-                                log::error!("revert: config_workspace signal was unavailable");
-                                error.set(Some(
-                                    "Internal error: could not revert config.".to_string(),
-                                ));
-                            }
-                        }
-                    >
-                        "Revert"
-                    </button>
-                    <button
-                        type="button"
-                        disabled=move || {
-                            config_workspace.with(|workspace| {
-                                workspace.selected().is_dirty() || !workspace.can_reset()
-                            })
-                        }
-                        on:click=move |_| {
-                            if is_dirty() {
-                                return;
-                            }
-                            let result = config_workspace.try_update(|workspace| {
-                                workspace
-                                    .reset()
-                                    .map(|opt| opt.is_some())
-                                    .map_err(|e| e.to_string())
-                            });
-                            match result {
-                                Some(Ok(true)) => {
-                                    error.set(None);
-                                    stop_auto_rotate_if_2d();
-                                    refresh_color_memory();
-                                    render_current();
-                                    resume_hsv_movement_if_active();
+                            match selected {
+                                Some(Ok(())) => {
+                                    select_current_config();
                                 }
-                                Some(Ok(false)) => {
-                                    log::warn!(
-                                        "reset: no-op for entry without a bundled default; button guard may have been bypassed"
-                                    );
+                                Some(Err(err)) => {
+                                    log::error!("select preset: rejected index {idx}: {err}");
+                                    error.set(Some(err));
                                 }
-                                Some(Err(msg)) => error.set(Some(msg)),
                                 None => {
                                     log::error!(
-                                        "reset: config_workspace signal was unavailable"
+                                        "select preset: config_workspace signal was unavailable"
                                     );
                                     error.set(Some(
-                                        "Internal error: could not reset config.".to_string(),
+                                        "Internal error: could not select config.".to_string(),
                                     ));
                                 }
                             }
                         }
                     >
-                        "Reset"
+                        {move || {
+                            config_workspace.with(|workspace| {
+                                workspace
+                                    .entries()
+                                    .iter()
+                                    .enumerate()
+                                    .map(|(idx, entry)| {
+                                        view! {
+                                            <option value=idx.to_string()>{entry.name().to_string()}</option>
+                                        }
+                                    })
+                                    .collect_view()
+                            })
+                        }}
+                    </select>
+
+                    <input
+                        type="text"
+                        class="rename-input"
+                        class:hidden=move || !rename_mode.get()
+                        prop:value=move || rename_draft.get()
+                        on:input:target=move |ev| rename_draft.set(ev.target().value())
+                        on:keydown=move |ev: web_sys::KeyboardEvent| {
+                            if ev.key() == "Enter" { commit_rename(); }
+                            if ev.key() == "Escape" { rename_mode.set(false); }
+                        }
+                    />
+
+                    <button
+                        type="button"
+                        class:hidden=move || rename_mode.get()
+                        on:click=move |_| {
+                            let result = config_workspace.try_update(|workspace| {
+                                workspace.copy().map(|_| ()).map_err(|e| e.to_string())
+                            });
+                            match result {
+                                Some(Ok(())) => {
+                                    error.set(None);
+                                    stop_auto_rotate_if_2d();
+                                    refresh_color_memory();
+                                    render_current();
+                                    resume_hsv_movement_if_active();
+                                    sync_grammar_editor();
+                                }
+                                Some(Err(msg)) => error.set(Some(msg)),
+                                None => {
+                                    log::error!("copy: config_workspace signal was unavailable");
+                                    error.set(Some(
+                                        "Internal error: could not copy config.".to_string(),
+                                    ));
+                                }
+                            }
+                        }
+                    >
+                        "Copy"
                     </button>
+
+                    {move || if rename_mode.get() {
+                        view! {
+                            <div style="display:contents">
+                                <button
+                                    type="button"
+                                    disabled=move || {
+                                        let d = rename_draft.get();
+                                        d.trim().is_empty()
+                                            || config_workspace.with(|ws| {
+                                                ws.index_by_name(d.trim())
+                                                    .is_some_and(|i| i != ws.selected_index())
+                                            })
+                                    }
+                                    on:click=move |_| commit_rename()
+                                >"Save"</button>
+                                <button type="button" on:click=move |_| rename_mode.set(false)>"✕"</button>
+                            </div>
+                        }.into_any()
+                    } else {
+                        view! {
+                            <div style="display:contents">
+                                <button
+                                    type="button"
+                                    on:click=move |_| {
+                                        rename_draft.set(
+                                            config_workspace.with(|ws| ws.selected().name().to_string())
+                                        );
+                                        rename_mode.set(true);
+                                    }
+                                >"Rename"</button>
+                                <button
+                                    type="button"
+                                    disabled=move || config_workspace.with(|ws| !ws.can_reset())
+                                    on:click=move |_| try_reset()
+                                >"Reset"</button>
+                            </div>
+                        }.into_any()
+                    }}
                 </div>
 
-                <p class=move || if error.get().is_some() { "status error" } else { "status ok" }>
-                    {move || error.get().unwrap_or_else(|| "OK".to_string())}
-                </p>
+                <Show when=move || reset_prompt.get()>
+                    <crate::ui::WarningPrompt
+                        message="You have unapplied TOML changes. Discard them and reset?"
+                        confirm_label="Discard & reset"
+                        on_confirm=move || {
+                            reset_prompt.set(false);
+                            revert_dirty();
+                            do_reset();
+                        }
+                        on_cancel=move || reset_prompt.set(false)
+                    />
+                </Show>
 
-                <p class:hidden=move || !is_dirty() class="status">
-                    "Apply or Revert the edited config before using controls."
-                </p>
+                <crate::ui::Disclosure title="Grammar">
+                    <table class="grammar-table">
+                        <tbody>
+                            <tr>
+                                <td class="g-symbol">
+                                    <span class="grammar-axiom-label">"axiom"</span>
+                                </td>
+                                <td>
+                                    <input
+                                        type="text"
+                                        class="grammar-rhs"
+                                        prop:value=move || grammar_axiom.get()
+                                        on:input:target=move |ev| grammar_axiom.set(ev.target().value())
+                                    />
+                                </td>
+                                <td class="g-delete"></td>
+                            </tr>
+                            {move || {
+                                let rules = grammar_rules.get();
+                                let axiom = grammar_axiom.get();
+                                let all_syms: Vec<char> = axiom
+                                    .chars()
+                                    .chain(rules.iter().flat_map(|(k, _)| k.chars()))
+                                    .filter(|c| c.is_ascii_alphabetic())
+                                    .collect::<std::collections::BTreeSet<_>>()
+                                    .into_iter()
+                                    .collect();
+                                rules.into_iter().enumerate().map(|(idx, (sym, rhs))| {
+                                    let list_id = format!("sym-dl-{idx}");
+                                    view! {
+                                        <tr>
+                                            <td class="g-symbol">
+                                                <input
+                                                    type="text"
+                                                    class="grammar-combo"
+                                                    list=list_id.clone()
+                                                    maxlength="1"
+                                                    prop:value=sym.clone()
+                                                    on:input:target=move |ev| {
+                                                        grammar_rules.update(|rules| {
+                                                            if let Some(r) = rules.get_mut(idx) {
+                                                                r.0 = ev.target().value();
+                                                            }
+                                                        });
+                                                    }
+                                                />
+                                                <datalist id=list_id>
+                                                    {all_syms.iter().map(|c| {
+                                                        let s = c.to_string();
+                                                        view! { <option value=s /> }
+                                                    }).collect_view()}
+                                                </datalist>
+                                            </td>
+                                            <td>
+                                                <input
+                                                    type="text"
+                                                    class="grammar-rhs"
+                                                    prop:value=rhs.clone()
+                                                    on:input:target=move |ev| {
+                                                        grammar_rules.update(|rules| {
+                                                            if let Some(r) = rules.get_mut(idx) {
+                                                                r.1 = ev.target().value();
+                                                            }
+                                                        });
+                                                    }
+                                                />
+                                            </td>
+                                            <td class="g-delete">
+                                                <button
+                                                    type="button"
+                                                    class="grammar-delete-btn"
+                                                    on:click=move |_| {
+                                                        grammar_rules.update(|rules| { rules.remove(idx); });
+                                                    }
+                                                >"×"</button>
+                                            </td>
+                                        </tr>
+                                    }
+                                }).collect_view()
+                            }}
+                        </tbody>
+                    </table>
 
-                <div class="group" class:hidden=move || is_dirty()>
-                    <label for="iterations">"Iterations"</label>
+                    <button
+                        type="button"
+                        style="width:100%"
+                        on:click=move |_| {
+                            grammar_rules.update(|rules| rules.push((String::new(), String::new())));
+                        }
+                    >"+ Add rule"</button>
+
                     <div class="row">
-                        <input
-                            id="iterations"
-                            type="range"
-                            min="0"
-                            max=move || max_iterations.get().to_string()
-                            prop:value=move || iterations.get().to_string()
-                            on:input:target=move |ev| {
-                                let next = ev
-                                    .target()
-                                    .value()
-                                    .parse::<u32>()
-                                    .unwrap_or(0)
-                                    .clamp(0, max_iterations.get_untracked());
-                                update_clean_config(
+                        <button type="button" on:click=move |_| try_apply_grammar()>"Apply"</button>
+                        <span class=move || {
+                            if error.get().is_some() { "inline-status error" } else { "inline-status ok" }
+                        }>
+                            {move || error.get().unwrap_or_else(|| "OK".to_string())}
+                        </span>
+                    </div>
+
+                    <Show when=move || grammar_prompt.get()>
+                        <crate::ui::WarningPrompt
+                            message="You have unapplied TOML changes. Discard them and proceed?"
+                            confirm_label="Discard & apply"
+                            on_confirm=move || {
+                                grammar_prompt.set(false);
+                                revert_dirty();
+                                try_apply_grammar();
+                            }
+                            on_cancel=move || grammar_prompt.set(false)
+                        />
+                    </Show>
+
+                    <Show when=move || grammar_3d_prompt.get()>
+                        <crate::ui::WarningPrompt
+                            message="Grammar contains 3D-only symbols. Switch to 3D to apply it."
+                            confirm_label="Switch to 3D & apply"
+                            on_confirm=move || {
+                                grammar_3d_prompt.set(false);
+                                if update_clean_config(
                                     config_workspace,
                                     error,
                                     render_current,
-                                    "iterations input",
-                                    move |clean| clean.set_iterations(next),
-                                );
+                                    "switch to 3D for grammar",
+                                    |clean| clean.set_dimensions(Dimensions::ThreeD),
+                                ) {
+                                    do_apply_grammar();
+                                }
                             }
+                            on_cancel=move || grammar_3d_prompt.set(false)
                         />
-                        <output>{move || iterations.get()}</output>
-                    </div>
+                    </Show>
+                </crate::ui::Disclosure>
 
-                    <label for="angle">"Angle"</label>
+                <crate::ui::Disclosure title="Edit TOML" open=false>
+                    <textarea
+                        id="config"
+                        spellcheck="false"
+                        prop:value=move || toml_text.get()
+                        on:input:target=move |ev| {
+                            let text = ev.target().value();
+                            let updated = config_workspace.try_update(|workspace| {
+                                workspace.selected_mut().set_draft_text(text);
+                            });
+                            if updated.is_none() {
+                                log::error!("textarea input: config_workspace signal was unavailable");
+                                error.set(Some(
+                                    "Internal error: could not update config.".to_string(),
+                                ));
+                            }
+                        }
+                    />
                     <div class="row">
-                        <input
-                            id="angle"
-                            type="range"
-                            min="1"
-                            max="180"
-                            step="0.5"
-                            prop:value=move || angle.get().to_string()
-                            on:input:target=move |ev| {
-                                let next = ev
-                                    .target()
-                                    .value()
-                                    .parse::<f32>()
-                                    .unwrap_or(60.0)
-                                    .clamp(1.0, 180.0);
-                                update_clean_config(
-                                    config_workspace,
-                                    error,
-                                    render_current,
-                                    "angle input",
-                                    move |clean| clean.set_angle(next),
-                                );
+                        <button
+                            type="button"
+                            disabled=move || !is_dirty()
+                            on:click=move |_| apply_current()
+                        >
+                            "Apply"
+                        </button>
+                        <button
+                            type="button"
+                            disabled=move || !is_dirty()
+                            on:click=move |_| {
+                                let ok = config_workspace.try_update(|workspace| {
+                                    match workspace.selected_mut().view_mut() {
+                                        EntryViewMut::Dirty(dirty) => dirty.revert(),
+                                        EntryViewMut::Clean(_) => {
+                                            log::error!(
+                                                "revert fired while entry is clean; UI guards bypassed"
+                                            );
+                                        }
+                                    }
+                                });
+                                if ok.is_some() {
+                                    error.set(None);
+                                    stop_auto_rotate_if_2d();
+                                    refresh_color_memory();
+                                    render_current();
+                                    resume_hsv_movement_if_active();
+                                    sync_grammar_editor();
+                                } else {
+                                    log::error!("revert: config_workspace signal was unavailable");
+                                    error.set(Some(
+                                        "Internal error: could not revert config.".to_string(),
+                                    ));
+                                }
                             }
+                        >
+                            "Revert"
+                        </button>
+                    </div>
+                </crate::ui::Disclosure>
+
+                <crate::ui::Disclosure title="Parameters">
+                    <div style="display:flex;flex-direction:column;gap:5px">
+                        <span class="section-label">"Dimensions"</span>
+                        <crate::ui::SegmentedToggle
+                            options=vec![("2d", "2D"), ("3d", "3D")]
+                            selected=Signal::derive(move || match base_config.get().generation.dimensions {
+                                Dimensions::TwoD => "2d",
+                                Dimensions::ThreeD => "3d",
+                            })
+                            on_change=move |key| try_set_dimensions(key)
                         />
-                        <output>{move || format!("{:.1}", angle.get())}</output>
+                        {move || dims_3d_error.get().map(|msg| view! {
+                            <span class="inline-status error">{msg}</span>
+                        })}
                     </div>
 
+                    <div class="spinner-row">
+                        <span class="spinner-label">"Angle (°)"</span>
+                        <crate::ui::Spinner
+                            value=Signal::derive(move || format!("{:.1}", angle.get()))
+                            step=0.5
+                            on_commit=move |s| {
+                                if let Ok(v) = s.parse::<f32>() {
+                                    let v = v.clamp(1.0, 180.0);
+                                    try_clean_param(Box::new(move || {
+                                        update_clean_config(
+                                            config_workspace, error, render_current, "angle",
+                                            move |clean| clean.set_angle(v),
+                                        );
+                                    }));
+                                }
+                            }
+                        />
+                    </div>
+
+                    <div class="spinner-row">
+                        <span class="spinner-label">"Initial heading (°)"</span>
+                        <crate::ui::Spinner
+                            value=Signal::derive(move || format!(
+                                "{:.1}",
+                                config_workspace.with(|ws| ws.selected().applied_config().generation.initial_heading)
+                            ))
+                            step=1.0
+                            on_commit=move |s| {
+                                if let Ok(v) = s.parse::<f32>() {
+                                    try_clean_param(Box::new(move || {
+                                        update_clean_config(
+                                            config_workspace, error, render_current, "initial_heading",
+                                            move |clean| clean.set_initial_heading(v),
+                                        );
+                                    }));
+                                }
+                            }
+                        />
+                    </div>
+
+                    <div class="spinner-row">
+                        <span class="spinner-label">"Iterations"</span>
+                        <crate::ui::Spinner
+                            value=Signal::derive(move || iterations.get().to_string())
+                            step=1.0
+                            on_commit=move |s| {
+                                if let Ok(v) = s.parse::<u32>() {
+                                    let v = v.clamp(0, max_iterations.get_untracked());
+                                    try_clean_param(Box::new(move || {
+                                        update_clean_config(
+                                            config_workspace, error, render_current, "iterations",
+                                            move |clean| clean.set_iterations(v),
+                                        );
+                                    }));
+                                }
+                            }
+                        />
+                    </div>
+
+                    <Show when=move || params_prompt.get()>
+                        <crate::ui::WarningPrompt
+                            message="You have unapplied TOML changes. Discard them and proceed?"
+                            confirm_label="Discard & proceed"
+                            on_confirm=move || {
+                                params_prompt.set(false);
+                                revert_dirty();
+                                sync_grammar_editor();
+                                if let Some(Some(action)) = params_pending.try_update_value(|v| v.take()) { action(); }
+                                params_pending.set_value(None);
+                            }
+                            on_cancel=move || {
+                                params_prompt.set(false);
+                                params_pending.set_value(None);
+                            }
+                        />
+                    </Show>
+                </crate::ui::Disclosure>
+
+                <crate::ui::Disclosure title="Colors">
                     <label class="check-row" for="background-override">
                         <input
                             id="background-override"
@@ -756,13 +1205,15 @@ pub(crate) fn App() -> impl IntoView {
                                 } else {
                                     None
                                 };
-                                update_clean_config(
-                                    config_workspace,
-                                    error,
-                                    render_current_colors,
-                                    "background checkbox",
-                                    move |clean| clean.set_background(background),
-                                );
+                                try_clean_color(Box::new(move || {
+                                    update_clean_config(
+                                        config_workspace,
+                                        error,
+                                        render_current_colors,
+                                        "background checkbox",
+                                        move |clean| clean.set_background(background),
+                                    );
+                                }));
                             }
                         />
                         <span>"Background"</span>
@@ -784,17 +1235,19 @@ pub(crate) fn App() -> impl IntoView {
                                     error.set(Some("Invalid color value.".to_string()));
                                     return;
                                 };
-                                if update_clean_config(
-                                    config_workspace,
-                                    error,
-                                    render_current_colors,
-                                    "background color input",
-                                    move |clean| clean.set_background(Some(color)),
-                                ) {
-                                    color_memory.update(|memory| {
-                                        memory.remember_background(color);
-                                    });
-                                }
+                                try_clean_color(Box::new(move || {
+                                    if update_clean_config(
+                                        config_workspace,
+                                        error,
+                                        render_current_colors,
+                                        "background color input",
+                                        move |clean| clean.set_background(Some(color)),
+                                    ) {
+                                        color_memory.update(|memory| {
+                                            memory.remember_background(color);
+                                        });
+                                    }
+                                }));
                             }
                         />
                     </div>
@@ -826,18 +1279,20 @@ pub(crate) fn App() -> impl IntoView {
                                 ));
                                 return;
                             };
-                            if update_clean_config(
-                                config_workspace,
-                                error,
-                                render_current_colors,
-                                "line color mode select",
-                                move |clean| clean.set_line_color(line_color),
-                            ) {
-                                color_memory.update(|memory| {
-                                    memory.remember_line(line_color);
-                                });
-                                resume_hsv_movement_if_active();
-                            }
+                            try_clean_color(Box::new(move || {
+                                if update_clean_config(
+                                    config_workspace,
+                                    error,
+                                    render_current_colors,
+                                    "line color mode select",
+                                    move |clean| clean.set_line_color(line_color),
+                                ) {
+                                    color_memory.update(|memory| {
+                                        memory.remember_line(line_color);
+                                    });
+                                    resume_hsv_movement_if_active();
+                                }
+                            }));
                         }
                     >
                         <option value="solid">"Solid"</option>
@@ -872,17 +1327,19 @@ pub(crate) fn App() -> impl IntoView {
                                     return;
                                 };
                                 let line_color = LineColorConfig::Solid { color };
-                                if update_clean_config(
-                                    config_workspace,
-                                    error,
-                                    render_current_colors,
-                                    "solid line color input",
-                                    move |clean| clean.set_line_color(line_color),
-                                ) {
-                                    color_memory.update(|memory| {
-                                        memory.remember_line(line_color);
-                                    });
-                                }
+                                try_clean_color(Box::new(move || {
+                                    if update_clean_config(
+                                        config_workspace,
+                                        error,
+                                        render_current_colors,
+                                        "solid line color input",
+                                        move |clean| clean.set_line_color(line_color),
+                                    ) {
+                                        color_memory.update(|memory| {
+                                            memory.remember_line(line_color);
+                                        });
+                                    }
+                                }));
                             }
                         />
                     </div>
@@ -931,17 +1388,19 @@ pub(crate) fn App() -> impl IntoView {
                                     ),
                                 };
                                 let line_color = LineColorConfig::DepthGradient { start, end };
-                                if update_clean_config(
-                                    config_workspace,
-                                    error,
-                                    render_current_colors,
-                                    "depth-gradient start color input",
-                                    move |clean| clean.set_line_color(line_color),
-                                ) {
-                                    color_memory.update(|memory| {
-                                        memory.remember_line(line_color);
-                                    });
-                                }
+                                try_clean_color(Box::new(move || {
+                                    if update_clean_config(
+                                        config_workspace,
+                                        error,
+                                        render_current_colors,
+                                        "depth-gradient start color input",
+                                        move |clean| clean.set_line_color(line_color),
+                                    ) {
+                                        color_memory.update(|memory| {
+                                            memory.remember_line(line_color);
+                                        });
+                                    }
+                                }));
                             }
                         />
 
@@ -978,17 +1437,19 @@ pub(crate) fn App() -> impl IntoView {
                                     ),
                                 };
                                 let line_color = LineColorConfig::DepthGradient { start, end };
-                                if update_clean_config(
-                                    config_workspace,
-                                    error,
-                                    render_current_colors,
-                                    "depth-gradient end color input",
-                                    move |clean| clean.set_line_color(line_color),
-                                ) {
-                                    color_memory.update(|memory| {
-                                        memory.remember_line(line_color);
-                                    });
-                                }
+                                try_clean_color(Box::new(move || {
+                                    if update_clean_config(
+                                        config_workspace,
+                                        error,
+                                        render_current_colors,
+                                        "depth-gradient end color input",
+                                        move |clean| clean.set_line_color(line_color),
+                                    ) {
+                                        color_memory.update(|memory| {
+                                            memory.remember_line(line_color);
+                                        });
+                                    }
+                                }));
                             }
                         />
                     </div>
@@ -1031,17 +1492,19 @@ pub(crate) fn App() -> impl IntoView {
                                     _ => unreachable!("gradient mode must provide gradient color"),
                                 };
                                 let line_color = LineColorConfig::Gradient { start, end };
-                                if update_clean_config(
-                                    config_workspace,
-                                    error,
-                                    render_current_colors,
-                                    "gradient start color input",
-                                    move |clean| clean.set_line_color(line_color),
-                                ) {
-                                    color_memory.update(|memory| {
-                                        memory.remember_line(line_color);
-                                    });
-                                }
+                                try_clean_color(Box::new(move || {
+                                    if update_clean_config(
+                                        config_workspace,
+                                        error,
+                                        render_current_colors,
+                                        "gradient start color input",
+                                        move |clean| clean.set_line_color(line_color),
+                                    ) {
+                                        color_memory.update(|memory| {
+                                            memory.remember_line(line_color);
+                                        });
+                                    }
+                                }));
                             }
                         />
 
@@ -1074,17 +1537,19 @@ pub(crate) fn App() -> impl IntoView {
                                     _ => unreachable!("gradient mode must provide gradient color"),
                                 };
                                 let line_color = LineColorConfig::Gradient { start, end };
-                                if update_clean_config(
-                                    config_workspace,
-                                    error,
-                                    render_current_colors,
-                                    "gradient end color input",
-                                    move |clean| clean.set_line_color(line_color),
-                                ) {
-                                    color_memory.update(|memory| {
-                                        memory.remember_line(line_color);
-                                    });
-                                }
+                                try_clean_color(Box::new(move || {
+                                    if update_clean_config(
+                                        config_workspace,
+                                        error,
+                                        render_current_colors,
+                                        "gradient end color input",
+                                        move |clean| clean.set_line_color(line_color),
+                                    ) {
+                                        color_memory.update(|memory| {
+                                            memory.remember_line(line_color);
+                                        });
+                                    }
+                                }));
                             }
                         />
                     </div>
@@ -1118,109 +1583,176 @@ pub(crate) fn App() -> impl IntoView {
                                     return;
                                 };
                                 let line_color = LineColorConfig::HueCycle { initial };
-                                if update_clean_config(
-                                    config_workspace,
-                                    error,
-                                    render_current_colors,
-                                    "hue-cycle initial color input",
-                                    move |clean| clean.set_line_color(line_color),
-                                ) {
-                                    color_memory.update(|memory| {
-                                        memory.remember_line(line_color);
-                                    });
-                                }
+                                try_clean_color(Box::new(move || {
+                                    if update_clean_config(
+                                        config_workspace,
+                                        error,
+                                        render_current_colors,
+                                        "hue-cycle initial color input",
+                                        move |clean| clean.set_line_color(line_color),
+                                    ) {
+                                        color_memory.update(|memory| {
+                                            memory.remember_line(line_color);
+                                        });
+                                    }
+                                }));
                             }
                         />
                     </div>
 
-                    <div
-                        class:hidden=move || {
-                            !matches!(
-                                current_line_color(base_config),
-                                LineColorConfig::HueCycle { .. }
-                            )
-                        }
-                    >
-                        <button type="button" on:click=toggle_hsv_movement>
-                            {move || {
-                                if hsv_movement.get() {
-                                    "HSV movement: On"
-                                } else {
-                                    "HSV movement: Off"
+                    <Show when=move || colors_prompt.get()>
+                        <crate::ui::WarningPrompt
+                            message="You have unapplied TOML changes. Discard them and proceed?"
+                            confirm_label="Discard & proceed"
+                            on_confirm=move || {
+                                colors_prompt.set(false);
+                                revert_dirty();
+                                sync_grammar_editor();
+                                if let Some(action) = colors_pending.try_update_value(|v| v.take()).flatten() {
+                                    action();
                                 }
-                            }}
-                        </button>
-                        <label for="hsv-movement-direction">"Direction"</label>
-                        <select
-                            id="hsv-movement-direction"
-                            prop:value=move || hsv_movement_direction.get().key().to_string()
-                            on:change:target=move |ev| {
-                                let key = ev.target().value();
-                                let Some(direction) = HsvMovementDirection::from_key(&key) else {
-                                    log::error!("unknown HSV movement direction selected: {key}");
-                                    return;
-                                };
-                                hsv_movement_direction.set(direction);
                             }
-                        >
-                            <option value="forward">{HsvMovementDirection::Forward.label()}</option>
-                            <option value="reverse">{HsvMovementDirection::Reverse.label()}</option>
-                        </select>
-                        <label for="hsv-movement-speed">"Movement speed (°/s)"</label>
-                        <div class="row">
-                            <input
-                                id="hsv-movement-speed"
-                                type="range"
-                                min=HSV_MOVEMENT_MIN_SPEED_DEGREES_PER_SECOND.to_string()
-                                max=HSV_MOVEMENT_MAX_SPEED_DEGREES_PER_SECOND.to_string()
-                                step="1"
-                                prop:value=move || hsv_movement_speed.get().to_string()
-                                on:input:target=move |ev| {
-                                    let next = ev
-                                        .target()
-                                        .value()
-                                        .parse::<f32>()
-                                        .unwrap_or(HSV_MOVEMENT_DEFAULT_SPEED_DEGREES_PER_SECOND);
-                                    hsv_movement_speed.set(next.clamp(
-                                        HSV_MOVEMENT_MIN_SPEED_DEGREES_PER_SECOND,
-                                        HSV_MOVEMENT_MAX_SPEED_DEGREES_PER_SECOND,
-                                    ));
-                                }
-                            />
-                            <output>{move || format!("{:.0}", hsv_movement_speed.get())}</output>
-                        </div>
+                            on_cancel=move || {
+                                colors_prompt.set(false);
+                                colors_pending.set_value(None);
+                            }
+                        />
+                    </Show>
+                </crate::ui::Disclosure>
+
+                <crate::ui::Disclosure title="Animations">
+                    <div style="display:flex;flex-direction:column;gap:6px">
+                        <span class=move || {
+                            if is_3d() { "section-label" } else { "section-label dim" }
+                        }>
+                            {move || if is_3d() { "Auto-rotate" } else { "Auto-rotate (3D only)" }}
+                        </span>
+                        <crate::ui::SegmentedToggle
+                            options=vec![("off", "Off"), ("on", "On")]
+                            selected=Signal::derive(move || if auto_rotate.get() { "on" } else { "off" })
+                            on_change=move |key| {
+                                if key == "on" { auto_rotate.set(true); start_animation_loop(); }
+                                else { auto_rotate.set(false); }
+                            }
+                            disabled=Signal::derive(move || !is_3d())
+                        />
+                        <Show when=move || auto_rotate.get() && is_3d()>
+                            <div class="spinner-row">
+                                <span class="spinner-label">"Speed (°/s)"</span>
+                                <crate::ui::Spinner
+                                    value=Signal::derive(move || format!("{:.0}", auto_rotate_speed.get()))
+                                    step=5.0
+                                    on_commit=move |s| {
+                                        if let Ok(v) = s.parse::<f32>() {
+                                            auto_rotate_speed.set(v.clamp(10.0, 360.0));
+                                        }
+                                    }
+                                />
+                            </div>
+                        </Show>
                     </div>
 
-                    <label for="png-width">"PNG width"</label>
-                    <input
-                        id="png-width"
-                        type="number"
-                        min="256"
-                        max="4096"
-                        step="16"
-                        prop:value=move || png_width.get().to_string()
-                        on:input:target=move |ev| {
-                            let next = ev.target().value().parse::<u32>().unwrap_or(2048);
-                            png_width.set(next.clamp(256, 4096));
-                        }
-                    />
+                    <hr class="section-divider" />
 
-                    <div class="export-row">
-                        <button
-                            type="button"
-                            class:hidden=move || is_3d()
-                            on:click=move |_| {
-                                let mut config = base_config.get_untracked();
-                                config.generation.iterations = iterations.get_untracked();
-                                config.generation.angle = angle.get_untracked();
+                    <div style="display:flex;flex-direction:column;gap:6px">
+                        <span class="section-label">"Hue movement"</span>
+                        <crate::ui::SegmentedToggle
+                            options=vec![("off", "Off"), ("forward", "Forward"), ("backward", "Backward")]
+                            selected=Signal::derive(move || {
+                                if !hsv_movement.get() { "off" }
+                                else if hsv_movement_direction.get() == HsvMovementDirection::Forward { "forward" }
+                                else { "backward" }
+                            })
+                            on_change=move |key| try_set_hue_movement(key)
+                        />
+                        <Show when=move || hsv_movement.get()>
+                            <div class="spinner-row">
+                                <span class="spinner-label">"Speed (°/s)"</span>
+                                <crate::ui::Spinner
+                                    value=Signal::derive(move || format!("{:.0}", hsv_movement_speed.get()))
+                                    step=1.0
+                                    on_commit=move |s| {
+                                        if let Ok(v) = s.parse::<f32>() {
+                                            hsv_movement_speed.set(v.clamp(
+                                                HSV_MOVEMENT_MIN_SPEED_DEGREES_PER_SECOND,
+                                                HSV_MOVEMENT_MAX_SPEED_DEGREES_PER_SECOND,
+                                            ));
+                                        }
+                                    }
+                                />
+                            </div>
+                        </Show>
+                        <Show when=move || hue_prompt.get()>
+                            <crate::ui::WarningPrompt
+                                message="Line color is not Hue cycle. Enabling this will switch it to Hue cycle."
+                                confirm_label="Switch & enable"
+                                on_confirm=move || {
+                                    let dir = hue_pending_dir
+                                        .try_update_value(|v| v.take())
+                                        .flatten()
+                                        .unwrap_or(HsvMovementDirection::Forward);
+                                    revert_dirty();
+                                    let line_color = color_memory
+                                        .with_untracked(|m| m.line_for(LineColorMode::HueCycle));
+                                    if update_clean_config(
+                                        config_workspace,
+                                        error,
+                                        render_current_colors,
+                                        "switch to hue cycle",
+                                        move |clean| clean.set_line_color(line_color),
+                                    ) {
+                                        color_memory.update(|m| m.remember_line(line_color));
+                                        resume_hsv_movement_if_active();
+                                        apply_hue_movement(Some(dir));
+                                    }
+                                    hue_prompt.set(false);
+                                }
+                                on_cancel=move || {
+                                    hue_prompt.set(false);
+                                    hue_pending_dir.set_value(None);
+                                }
+                            />
+                        </Show>
+                    </div>
+                </crate::ui::Disclosure>
+
+                <crate::ui::Disclosure title="Save image" open=false>
+                    {move || if is_3d() {
+                        view! { <span class="section-label">"PNG"</span> }.into_any()
+                    } else {
+                        view! {
+                            <crate::ui::SegmentedToggle
+                                options=vec![("svg", "SVG"), ("png", "PNG")]
+                                selected=Signal::derive(move || save_format.get())
+                                on_change=move |key| save_format.set(key)
+                            />
+                        }.into_any()
+                    }}
+
+                    <Show when=move || save_format.get() == "png">
+                        <div class="spinner-row">
+                            <span class="spinner-label">"Width (px)"</span>
+                            <crate::ui::Spinner
+                                value=Signal::derive(move || png_width.get().to_string())
+                                step=16.0
+                                on_commit=move |s| {
+                                    if let Ok(v) = s.parse::<u32>() {
+                                        png_width.set(v.clamp(256, 4096));
+                                    }
+                                }
+                            />
+                        </div>
+                    </Show>
+
+                    <button
+                        type="button"
+                        on:click=move |_| {
+                            let mut config = base_config.get_untracked();
+                            config.generation.iterations = iterations.get_untracked();
+                            config.generation.angle = angle.get_untracked();
+                            if save_format.get_untracked() == "svg" {
                                 export_svg(config);
-                            }
-                        >
-                            "Export SVG"
-                        </button>
-                        <button
-                            type="button"
-                            on:click=move |_| {
+                            } else {
                                 let Some(Some((device, queue, camera))) =
                                     renderer.try_with_value(|opt| {
                                         opt.as_ref().map(|r| {
@@ -1229,16 +1761,9 @@ pub(crate) fn App() -> impl IntoView {
                                         })
                                     })
                                 else {
-                                    log::error!("PNG export: renderer not initialized");
-                                    error.set(Some(
-                                        "Cannot export PNG: GPU renderer is not ready yet."
-                                            .to_string(),
-                                    ));
+                                    error.set(Some("Cannot save: GPU renderer not ready.".to_string()));
                                     return;
                                 };
-                                let mut config = base_config.get_untracked();
-                                config.generation.iterations = iterations.get_untracked();
-                                config.generation.angle = angle.get_untracked();
                                 export_png(
                                     device,
                                     queue,
@@ -1248,39 +1773,17 @@ pub(crate) fn App() -> impl IntoView {
                                     move |e| error.set(Some(e)),
                                 );
                             }
-                        >
-                            "Export PNG"
-                        </button>
-                    </div>
+                        }
+                    >"Save"</button>
+                </crate::ui::Disclosure>
 
-                    <div class:hidden=move || !is_3d()>
-                        <button type="button" on:click=toggle_auto_rotate>
-                            {move || {
-                                if auto_rotate.get() {
-                                    "Auto-rotate: On"
-                                } else {
-                                    "Auto-rotate: Off"
-                                }
-                            }}
-                        </button>
-                        <label for="auto-rotate-speed">"Speed (°/s)"</label>
-                        <div class="row">
-                            <input
-                                id="auto-rotate-speed"
-                                type="range"
-                                min="10"
-                                max="360"
-                                step="10"
-                                prop:value=move || auto_rotate_speed.get().to_string()
-                                on:input:target=move |ev| {
-                                    let next =
-                                        ev.target().value().parse::<f32>().unwrap_or(45.0);
-                                    auto_rotate_speed.set(next.clamp(10.0, 360.0));
-                                }
-                            />
-                            <output>{move || format!("{:.0}", auto_rotate_speed.get())}</output>
-                        </div>
-                    </div>
+                <button
+                    type="button"
+                    class="sidebar-collapse-btn"
+                    on:click=move |_| sidebar_collapsed.update(|v| *v = !*v)
+                >
+                    {move || if sidebar_collapsed.get() { "▶" } else { "◀" }}
+                </button>
                 </div>
             </aside>
 

--- a/crates/lsystem-web-app/src/app.rs
+++ b/crates/lsystem-web-app/src/app.rs
@@ -82,31 +82,6 @@ impl HsvMovementDirection {
     }
 }
 
-#[cfg(test)]
-impl HsvMovementDirection {
-    fn from_key(key: &str) -> Option<Self> {
-        match key {
-            "forward" => Some(Self::Forward),
-            "reverse" => Some(Self::Reverse),
-            _ => None,
-        }
-    }
-
-    fn key(self) -> &'static str {
-        match self {
-            Self::Forward => "forward",
-            Self::Reverse => "reverse",
-        }
-    }
-
-    fn label(self) -> &'static str {
-        match self {
-            Self::Forward => "Forward",
-            Self::Reverse => "Reverse",
-        }
-    }
-}
-
 fn advance_hsv_phase_degrees(
     phase_degrees: f32,
     speed_degrees_per_second: f32,
@@ -222,7 +197,6 @@ pub(crate) fn App() -> impl IntoView {
     let hsv_movement_speed = RwSignal::new(HSV_MOVEMENT_DEFAULT_SPEED_DEGREES_PER_SECOND);
     let hsv_movement_direction = RwSignal::new(HsvMovementDirection::Forward);
     let hsv_movement_phase = RwSignal::new(0.0f32);
-    let sidebar_collapsed = RwSignal::new(false);
     let sheet_open = RwSignal::new(false);
     let sheet_drag_start: StoredValue<Option<f64>, LocalStorage> = StoredValue::new_local(None);
     // Generation counter: bumped on each animation start so older rAF loops detect
@@ -483,9 +457,7 @@ pub(crate) fn App() -> impl IntoView {
             Some(Ok(())) => {
                 error.set(None);
                 refresh_color_memory();
-                if !is_3d_untracked() && auto_rotate.get_untracked() {
-                    auto_rotate.set(false);
-                }
+                stop_auto_rotate_if_2d();
                 render_current();
                 resume_hsv_movement_if_active();
                 sync_grammar_editor();
@@ -696,7 +668,6 @@ pub(crate) fn App() -> impl IntoView {
     view! {
         <main
             class="app-shell"
-            class:sidebar-collapsed=move || sidebar_collapsed.get()
         >
             <aside
                 class="controls"
@@ -1638,13 +1609,6 @@ pub(crate) fn App() -> impl IntoView {
                     >"Save"</button>
                 </crate::ui::Disclosure>
 
-                <button
-                    type="button"
-                    class="sidebar-collapse-btn"
-                    on:click=move |_| sidebar_collapsed.update(|v| *v = !*v)
-                >
-                    {move || if sidebar_collapsed.get() { "▶" } else { "◀" }}
-                </button>
                 </div>
             </aside>
 
@@ -1955,18 +1919,6 @@ mod tests {
             assert_eq!(LineColorMode::from_key(mode.key()), Some(mode));
         }
         assert_eq!(LineColorMode::from_key("unknown"), None);
-    }
-
-    #[test]
-    fn hsv_movement_direction_key_and_label_round_trip() {
-        for direction in [HsvMovementDirection::Forward, HsvMovementDirection::Reverse] {
-            assert_eq!(
-                HsvMovementDirection::from_key(direction.key()),
-                Some(direction)
-            );
-            assert!(!direction.label().is_empty());
-        }
-        assert_eq!(HsvMovementDirection::from_key("sideways"), None);
     }
 
     #[test]

--- a/crates/lsystem-web-app/src/app.rs
+++ b/crates/lsystem-web-app/src/app.rs
@@ -757,8 +757,6 @@ pub(crate) fn App() -> impl IntoView {
                 </div>
 
                 <div class="controls-scroll">
-                <h1 class="controls-title">"Grow Your Own Fractal"</h1>
-
                 <div class="preset-row">
                     <select
                         class:hidden=move || rename_mode.get()
@@ -814,36 +812,9 @@ pub(crate) fn App() -> impl IntoView {
                             if ev.key() == "Escape" { rename_mode.set(false); }
                         }
                     />
+                </div>
 
-                    <button
-                        type="button"
-                        class:hidden=move || rename_mode.get()
-                        on:click=move |_| {
-                            let result = config_workspace.try_update(|workspace| {
-                                workspace.copy().map(|_| ()).map_err(|e| e.to_string())
-                            });
-                            match result {
-                                Some(Ok(())) => {
-                                    error.set(None);
-                                    stop_auto_rotate_if_2d();
-                                    refresh_color_memory();
-                                    render_current();
-                                    resume_hsv_movement_if_active();
-                                    sync_grammar_editor();
-                                }
-                                Some(Err(msg)) => error.set(Some(msg)),
-                                None => {
-                                    log::error!("copy: config_workspace signal was unavailable");
-                                    error.set(Some(
-                                        "Internal error: could not copy config.".to_string(),
-                                    ));
-                                }
-                            }
-                        }
-                    >
-                        "Copy"
-                    </button>
-
+                <div class="preset-actions">
                     {move || if rename_mode.get() {
                         view! {
                             <div style="display:contents">
@@ -865,6 +836,31 @@ pub(crate) fn App() -> impl IntoView {
                     } else {
                         view! {
                             <div style="display:contents">
+                                <button
+                                    type="button"
+                                    on:click=move |_| {
+                                        let result = config_workspace.try_update(|workspace| {
+                                            workspace.copy().map(|_| ()).map_err(|e| e.to_string())
+                                        });
+                                        match result {
+                                            Some(Ok(())) => {
+                                                error.set(None);
+                                                stop_auto_rotate_if_2d();
+                                                refresh_color_memory();
+                                                render_current();
+                                                resume_hsv_movement_if_active();
+                                                sync_grammar_editor();
+                                            }
+                                            Some(Err(msg)) => error.set(Some(msg)),
+                                            None => {
+                                                log::error!("copy: config_workspace signal was unavailable");
+                                                error.set(Some(
+                                                    "Internal error: could not copy config.".to_string(),
+                                                ));
+                                            }
+                                        }
+                                    }
+                                >"Copy"</button>
                                 <button
                                     type="button"
                                     on:click=move |_| {
@@ -896,6 +892,66 @@ pub(crate) fn App() -> impl IntoView {
                         on_cancel=move || reset_prompt.set(false)
                     />
                 </Show>
+
+                <crate::ui::Disclosure title="Edit TOML" open=false>
+                    <textarea
+                        id="config"
+                        spellcheck="false"
+                        prop:value=move || toml_text.get()
+                        on:input:target=move |ev| {
+                            let text = ev.target().value();
+                            let updated = config_workspace.try_update(|workspace| {
+                                workspace.selected_mut().set_draft_text(text);
+                            });
+                            if updated.is_none() {
+                                log::error!("textarea input: config_workspace signal was unavailable");
+                                error.set(Some(
+                                    "Internal error: could not update config.".to_string(),
+                                ));
+                            }
+                        }
+                    />
+                    <div class="btn-row">
+                        <button
+                            type="button"
+                            disabled=move || !is_dirty()
+                            on:click=move |_| apply_current()
+                        >
+                            "Apply"
+                        </button>
+                        <button
+                            type="button"
+                            disabled=move || !is_dirty()
+                            on:click=move |_| {
+                                let ok = config_workspace.try_update(|workspace| {
+                                    match workspace.selected_mut().view_mut() {
+                                        EntryViewMut::Dirty(dirty) => dirty.revert(),
+                                        EntryViewMut::Clean(_) => {
+                                            log::error!(
+                                                "revert fired while entry is clean; UI guards bypassed"
+                                            );
+                                        }
+                                    }
+                                });
+                                if ok.is_some() {
+                                    error.set(None);
+                                    stop_auto_rotate_if_2d();
+                                    refresh_color_memory();
+                                    render_current();
+                                    resume_hsv_movement_if_active();
+                                    sync_grammar_editor();
+                                } else {
+                                    log::error!("revert: config_workspace signal was unavailable");
+                                    error.set(Some(
+                                        "Internal error: could not revert config.".to_string(),
+                                    ));
+                                }
+                            }
+                        >
+                            "Revert"
+                        </button>
+                    </div>
+                </crate::ui::Disclosure>
 
                 <crate::ui::Disclosure title="Grammar">
                     <table class="grammar-table">
@@ -980,22 +1036,21 @@ pub(crate) fn App() -> impl IntoView {
                         </tbody>
                     </table>
 
-                    <button
-                        type="button"
-                        style="width:100%"
-                        on:click=move |_| {
-                            grammar_rules.update(|rules| rules.push((String::new(), String::new())));
-                        }
-                    >"+ Add rule"</button>
-
-                    <div class="row">
-                        <button type="button" on:click=move |_| try_apply_grammar()>"Apply"</button>
-                        <span class=move || {
-                            if error.get().is_some() { "inline-status error" } else { "inline-status ok" }
-                        }>
-                            {move || error.get().unwrap_or_else(|| "OK".to_string())}
-                        </span>
+                    <div class="btn-row">
+                        <button
+                            type="button"
+                            on:click=move |_| {
+                                grammar_rules.update(|rules| rules.push((String::new(), String::new())));
+                            }
+                        >"Add rule"</button>
+                        <button
+                            type="button"
+                            on:click=move |_| try_apply_grammar()
+                        >"Apply"</button>
                     </div>
+                    {move || error.get().map(|msg| view! {
+                        <span class="inline-status error">{msg}</span>
+                    })}
 
                     <Show when=move || grammar_prompt.get()>
                         <crate::ui::WarningPrompt
@@ -1029,66 +1084,6 @@ pub(crate) fn App() -> impl IntoView {
                             on_cancel=move || grammar_3d_prompt.set(false)
                         />
                     </Show>
-                </crate::ui::Disclosure>
-
-                <crate::ui::Disclosure title="Edit TOML" open=false>
-                    <textarea
-                        id="config"
-                        spellcheck="false"
-                        prop:value=move || toml_text.get()
-                        on:input:target=move |ev| {
-                            let text = ev.target().value();
-                            let updated = config_workspace.try_update(|workspace| {
-                                workspace.selected_mut().set_draft_text(text);
-                            });
-                            if updated.is_none() {
-                                log::error!("textarea input: config_workspace signal was unavailable");
-                                error.set(Some(
-                                    "Internal error: could not update config.".to_string(),
-                                ));
-                            }
-                        }
-                    />
-                    <div class="row">
-                        <button
-                            type="button"
-                            disabled=move || !is_dirty()
-                            on:click=move |_| apply_current()
-                        >
-                            "Apply"
-                        </button>
-                        <button
-                            type="button"
-                            disabled=move || !is_dirty()
-                            on:click=move |_| {
-                                let ok = config_workspace.try_update(|workspace| {
-                                    match workspace.selected_mut().view_mut() {
-                                        EntryViewMut::Dirty(dirty) => dirty.revert(),
-                                        EntryViewMut::Clean(_) => {
-                                            log::error!(
-                                                "revert fired while entry is clean; UI guards bypassed"
-                                            );
-                                        }
-                                    }
-                                });
-                                if ok.is_some() {
-                                    error.set(None);
-                                    stop_auto_rotate_if_2d();
-                                    refresh_color_memory();
-                                    render_current();
-                                    resume_hsv_movement_if_active();
-                                    sync_grammar_editor();
-                                } else {
-                                    log::error!("revert: config_workspace signal was unavailable");
-                                    error.set(Some(
-                                        "Internal error: could not revert config.".to_string(),
-                                    ));
-                                }
-                            }
-                        >
-                            "Revert"
-                        </button>
-                    </div>
                 </crate::ui::Disclosure>
 
                 <crate::ui::Disclosure title="Parameters">

--- a/crates/lsystem-web-app/src/lib.rs
+++ b/crates/lsystem-web-app/src/lib.rs
@@ -5,6 +5,7 @@ mod color_input;
 mod export;
 mod presets;
 mod renderer;
+pub(crate) mod ui;
 
 #[wasm_bindgen::prelude::wasm_bindgen(start)]
 pub fn start() {

--- a/crates/lsystem-web-app/src/ui.rs
+++ b/crates/lsystem-web-app/src/ui.rs
@@ -1,4 +1,3 @@
-#![allow(dead_code)]
 use leptos::prelude::*;
 
 /// Collapsible disclosure section with a chevron header button.
@@ -6,6 +5,9 @@ use leptos::prelude::*;
 pub fn Disclosure(
     title: &'static str,
     #[prop(default = true)] open: bool,
+    /// Amber dot shown in the header when true (e.g. unsaved state).
+    #[prop(into, default = Signal::stored(false))]
+    badge: Signal<bool>,
     children: Children,
 ) -> impl IntoView {
     let is_open = RwSignal::new(open);
@@ -16,7 +18,12 @@ pub fn Disclosure(
                 class="disclosure-header"
                 on:click=move |_| is_open.update(|v| *v = !*v)
             >
-                <span>{title}</span>
+                <span>
+                    {title}
+                    <Show when=move || badge.get()>
+                        <span class="disclosure-badge">"●"</span>
+                    </Show>
+                </span>
                 <span
                     class="disclosure-chevron"
                     class:open=move || is_open.get()
@@ -40,7 +47,7 @@ pub fn Spinner(
     value: Signal<String>,
     on_commit: impl Fn(String) + 'static + Clone,
     #[prop(default = 1.0_f64)] step: f64,
-    #[prop(default = false)] disabled: bool,
+    #[prop(into, default = Signal::stored(false))] disabled: Signal<bool>,
 ) -> impl IntoView {
     let displayed = RwSignal::new(value.get_untracked());
 
@@ -70,14 +77,14 @@ pub fn Spinner(
             <button
                 type="button"
                 class="spinner-btn"
-                disabled=disabled
+                disabled=move || disabled.get()
                 on:click=step_down
             >"−"</button>
             <input
                 type="text"
                 class="spinner-input"
                 prop:value=move || displayed.get()
-                disabled=disabled
+                disabled=move || disabled.get()
                 on:input:target=move |ev| displayed.set(ev.target().value())
                 on:keydown=move |ev: web_sys::KeyboardEvent| {
                     if ev.key() == "Enter" {
@@ -94,7 +101,7 @@ pub fn Spinner(
             <button
                 type="button"
                 class="spinner-btn"
-                disabled=disabled
+                disabled=move || disabled.get()
                 on:click=step_up
             >"+"</button>
         </div>
@@ -109,13 +116,16 @@ fn format_step(n: f64) -> String {
 
 /// Segmented toggle (pill group). `options` is `(key, label)` pairs.
 /// Fires `on_change(key)` when a non-active option is clicked.
-/// `disabled` accepts a plain bool, a closure, or a signal via `#[prop(into)]`.
+/// `disabled` disables all buttons. `disabled_keys` disables specific option keys.
 #[component]
 pub fn SegmentedToggle(
     options: Vec<(&'static str, &'static str)>,
     selected: Signal<&'static str>,
     on_change: impl Fn(&'static str) + 'static + Clone,
     #[prop(into, default = Signal::stored(false))] disabled: Signal<bool>,
+    #[prop(into, default = Signal::stored(Vec::<&'static str>::new()))] disabled_keys: Signal<
+        Vec<&'static str>,
+    >,
 ) -> impl IntoView {
     view! {
         <div class="seg-toggle">
@@ -125,40 +135,17 @@ pub fn SegmentedToggle(
                     <button
                         type="button"
                         class:seg-active=move || selected.get() == key
-                        disabled=move || disabled.get() || selected.get() == key
+                        disabled=move || {
+                            disabled.get()
+                                || selected.get() == key
+                                || disabled_keys.get().contains(&key)
+                        }
                         on:click=move |_| on_change(key)
                     >
                         {label}
                     </button>
                 }
             }).collect_view()}
-        </div>
-    }
-}
-
-/// Inline amber warning box with a confirm action and a cancel button.
-#[component]
-pub fn WarningPrompt(
-    message: &'static str,
-    confirm_label: &'static str,
-    on_confirm: impl Fn() + 'static,
-    on_cancel: impl Fn() + 'static,
-) -> impl IntoView {
-    view! {
-        <div class="warning-prompt">
-            <span>{message}</span>
-            <div class="warning-prompt-actions">
-                <button
-                    type="button"
-                    class="warning-confirm-btn"
-                    on:click=move |_| on_confirm()
-                >{confirm_label}</button>
-                <button
-                    type="button"
-                    class="warning-cancel-btn"
-                    on:click=move |_| on_cancel()
-                >"Cancel"</button>
-            </div>
         </div>
     }
 }

--- a/crates/lsystem-web-app/src/ui.rs
+++ b/crates/lsystem-web-app/src/ui.rs
@@ -1,0 +1,164 @@
+#![allow(dead_code)]
+use leptos::prelude::*;
+
+/// Collapsible disclosure section with a chevron header button.
+#[component]
+pub fn Disclosure(
+    title: &'static str,
+    #[prop(default = true)] open: bool,
+    children: Children,
+) -> impl IntoView {
+    let is_open = RwSignal::new(open);
+    view! {
+        <div class="disclosure">
+            <button
+                type="button"
+                class="disclosure-header"
+                on:click=move |_| is_open.update(|v| *v = !*v)
+            >
+                <span>{title}</span>
+                <span
+                    class="disclosure-chevron"
+                    class:open=move || is_open.get()
+                >"▶"</span>
+            </button>
+            <div class="disclosure-body" class:hidden=move || !is_open.get()>
+                {children()}
+            </div>
+        </div>
+    }
+}
+
+/// Text input flanked by − and + buttons.
+///
+/// `value` — reactive display string (controlled from outside).
+/// `on_commit` — called with the new string on Enter or ± click only; blur does not commit.
+///   On blur with unparseable content the field resets to `value`.
+/// `step` — amount added/subtracted by ± buttons (parsed as f64 from `value`).
+#[component]
+pub fn Spinner(
+    value: Signal<String>,
+    on_commit: impl Fn(String) + 'static + Clone,
+    #[prop(default = 1.0_f64)] step: f64,
+    #[prop(default = false)] disabled: bool,
+) -> impl IntoView {
+    let displayed = RwSignal::new(value.get_untracked());
+
+    // Keep displayed in sync when the authoritative value changes from outside
+    Effect::new(move |_| displayed.set(value.get()));
+
+    let step_down = {
+        let on_commit = on_commit.clone();
+        move |_: web_sys::MouseEvent| {
+            if let Ok(n) = displayed.get_untracked().parse::<f64>() {
+                on_commit(format_step(n - step));
+            }
+        }
+    };
+
+    let step_up = {
+        let on_commit = on_commit.clone();
+        move |_: web_sys::MouseEvent| {
+            if let Ok(n) = displayed.get_untracked().parse::<f64>() {
+                on_commit(format_step(n + step));
+            }
+        }
+    };
+
+    view! {
+        <div class="spinner">
+            <button
+                type="button"
+                class="spinner-btn"
+                disabled=disabled
+                on:click=step_down
+            >"−"</button>
+            <input
+                type="text"
+                class="spinner-input"
+                prop:value=move || displayed.get()
+                disabled=disabled
+                on:input:target=move |ev| displayed.set(ev.target().value())
+                on:keydown=move |ev: web_sys::KeyboardEvent| {
+                    if ev.key() == "Enter" {
+                        on_commit(displayed.get_untracked());
+                    }
+                }
+                on:blur=move |_| {
+                    // If the field contains something that won't parse, reset to last good value
+                    if displayed.get_untracked().parse::<f64>().is_err() {
+                        displayed.set(value.get_untracked());
+                    }
+                }
+            />
+            <button
+                type="button"
+                class="spinner-btn"
+                disabled=disabled
+                on:click=step_up
+            >"+"</button>
+        </div>
+    }
+}
+
+/// Format a float for spinner display: no trailing zeros, at most 4 decimal places.
+fn format_step(n: f64) -> String {
+    let s = format!("{n:.4}");
+    s.trim_end_matches('0').trim_end_matches('.').to_string()
+}
+
+/// Segmented toggle (pill group). `options` is `(key, label)` pairs.
+/// Fires `on_change(key)` when a non-active option is clicked.
+/// `disabled` accepts a plain bool, a closure, or a signal via `#[prop(into)]`.
+#[component]
+pub fn SegmentedToggle(
+    options: Vec<(&'static str, &'static str)>,
+    selected: Signal<&'static str>,
+    on_change: impl Fn(&'static str) + 'static + Clone,
+    #[prop(into, default = Signal::stored(false))] disabled: Signal<bool>,
+) -> impl IntoView {
+    view! {
+        <div class="seg-toggle">
+            {options.into_iter().map(|(key, label)| {
+                let on_change = on_change.clone();
+                view! {
+                    <button
+                        type="button"
+                        class:seg-active=move || selected.get() == key
+                        disabled=move || disabled.get() || selected.get() == key
+                        on:click=move |_| on_change(key)
+                    >
+                        {label}
+                    </button>
+                }
+            }).collect_view()}
+        </div>
+    }
+}
+
+/// Inline amber warning box with a confirm action and a cancel button.
+#[component]
+pub fn WarningPrompt(
+    message: &'static str,
+    confirm_label: &'static str,
+    on_confirm: impl Fn() + 'static,
+    on_cancel: impl Fn() + 'static,
+) -> impl IntoView {
+    view! {
+        <div class="warning-prompt">
+            <span>{message}</span>
+            <div class="warning-prompt-actions">
+                <button
+                    type="button"
+                    class="warning-confirm-btn"
+                    on:click=move |_| on_confirm()
+                >{confirm_label}</button>
+                <button
+                    type="button"
+                    class="warning-cancel-btn"
+                    on:click=move |_| on_cancel()
+                >"Cancel"</button>
+            </div>
+        </div>
+    }
+}

--- a/crates/lsystem-web-app/style.css
+++ b/crates/lsystem-web-app/style.css
@@ -34,12 +34,6 @@ textarea {
   border-right: 1px solid #303642;
 }
 
-.controls h1 {
-  margin: 0 0 8px;
-  font-size: 20px;
-  font-weight: 650;
-}
-
 .controls label {
   font-size: 13px;
   color: #aeb6c3;
@@ -93,41 +87,6 @@ textarea {
   background: #3b707d;
 }
 
-.status {
-  min-height: 22px;
-  margin: 0;
-  font-size: 13px;
-}
-
-.status.ok {
-  color: #65d894;
-}
-
-.status.error {
-  color: #ff7b7b;
-}
-
-.group {
-  display: flex;
-  flex-direction: column;
-  gap: 10px;
-  padding-top: 8px;
-  border-top: 1px solid #303642;
-}
-
-.row {
-  display: grid;
-  grid-template-columns: minmax(0, 1fr) 52px;
-  align-items: center;
-  gap: 8px;
-}
-
-.row output {
-  font-size: 13px;
-  text-align: right;
-  color: #cbd5e1;
-}
-
 .color-row {
   display: grid;
   grid-template-columns: minmax(0, 1fr) 42px;
@@ -139,12 +98,6 @@ textarea {
   width: 42px;
   min-height: 28px;
   padding: 2px;
-}
-
-.export-row {
-  display: grid;
-  grid-template-columns: 1fr 1fr;
-  gap: 8px;
 }
 
 .viewport {
@@ -336,7 +289,24 @@ textarea {
 .seg-toggle button:not(:first-child) { border-left: 1px solid #3a4352; }
 .seg-toggle button.seg-active { background: #315d68; color: #e5e7eb; cursor: default; }
 .seg-toggle button:disabled:not(.seg-active) { opacity: 0.35; cursor: not-allowed; }
-.seg-toggle button.seg-active:disabled { cursor: default; }
+.seg-toggle button.seg-active:disabled { cursor: default; opacity: 1; }
+
+/* ── Disabled interactive controls ── */
+.controls button:disabled,
+.controls input:disabled,
+.controls select:disabled,
+.controls textarea:disabled {
+  opacity: 0.4;
+  cursor: not-allowed;
+}
+
+.spinner-btn:disabled,
+.spinner-btn:disabled:hover {
+  opacity: 0.4;
+  background: #252932;
+  color: #aeb6c3;
+  cursor: not-allowed;
+}
 
 /* ── Spinner ── */
 .spinner {
@@ -401,8 +371,6 @@ textarea {
   color: #7a8899;
 }
 
-.section-label.dim { color: #4a5568; }
-
 .section-divider {
   border: none;
   border-top: 1px solid #252a35;
@@ -455,57 +423,7 @@ textarea {
 
 .grammar-delete-btn:hover { color: #f87171; background: #2a1a1a; }
 
-/* ── Warning prompt ── */
-.warning-prompt {
-  background: #1e1a0a;
-  border: 1px solid #5a4010;
-  border-radius: 5px;
-  padding: 8px 10px;
-  font-size: 12px;
-  color: #d4a840;
-  line-height: 1.45;
-  display: flex;
-  flex-direction: column;
-  gap: 7px;
-}
-
-.warning-prompt-actions { display: flex; gap: 6px; }
-
-.warning-confirm-btn {
-  flex: 1;
-  background: #2a200a;
-  border: 1px solid #7a5a10;
-  border-radius: 5px;
-  color: #f6c85a;
-  font-size: 11px;
-  min-height: 28px;
-  cursor: pointer;
-  padding: 0 8px;
-}
-
-.warning-confirm-btn:hover { background: #3a2e0e; }
-
-.warning-cancel-btn {
-  flex: 1;
-  background: #252932;
-  border: 1px solid #3a4352;
-  border-radius: 5px;
-  color: #aeb6c3;
-  font-size: 11px;
-  min-height: 28px;
-  cursor: pointer;
-  padding: 0 8px;
-}
-
-.warning-cancel-btn:hover { background: #2e3545; }
-
 /* ── Top bar additions ── */
-.controls-title {
-  margin: 0 0 6px;
-  font-size: 20px;
-  font-weight: 650;
-}
-
 .preset-row { display: flex; gap: 5px; align-items: center; }
 .preset-row select { flex: 1; min-width: 0; }
 
@@ -514,6 +432,9 @@ textarea {
 
 .btn-row { display: flex; gap: 5px; }
 .btn-row button { flex: 1; }
+/* Tooltip wrapper divs inside btn-row — must behave like flex items */
+.btn-row > div { flex: 1; display: flex; }
+.btn-row > div > button { flex: 1; }
 
 .rename-input {
   flex: 1;
@@ -529,6 +450,14 @@ textarea {
 .inline-status { font-size: 12px; min-height: 16px; }
 .inline-status.ok { color: #65d894; }
 .inline-status.error { color: #ff7b7b; }
+
+/* ── Disclosure badge (amber dot for dirty state) ── */
+.disclosure-badge {
+  color: #d4a840;
+  font-size: 9px;
+  margin-left: 6px;
+  vertical-align: middle;
+}
 
 /* ── Sidebar collapse (desktop only) ── */
 .controls { position: relative; }

--- a/crates/lsystem-web-app/style.css
+++ b/crates/lsystem-web-app/style.css
@@ -199,8 +199,6 @@ textarea {
     overscroll-behavior: contain;
   }
 
-  /* Hide desktop-only elements on mobile */
-  .sidebar-collapse-btn { display: none; }
 }
 
 @media (min-width: 761px) {
@@ -436,19 +434,9 @@ textarea {
 .btn-row > div { flex: 1; display: flex; }
 .btn-row > div > button { flex: 1; }
 
-.rename-input {
-  flex: 1;
-  min-width: 0;
-  color: #f3f4f6;
-  background: #0f1117;
-  border: 1px solid #3a4352;
-  border-radius: 6px;
-  min-height: 34px;
-  padding: 0 8px;
-}
+.rename-input { flex: 1; }
 
 .inline-status { font-size: 12px; min-height: 16px; }
-.inline-status.ok { color: #65d894; }
 .inline-status.error { color: #ff7b7b; }
 
 /* ── Disclosure badge (amber dot for dirty state) ── */
@@ -459,40 +447,3 @@ textarea {
   vertical-align: middle;
 }
 
-/* ── Sidebar collapse (desktop only) ── */
-.controls { position: relative; }
-
-.sidebar-collapse-btn {
-  position: absolute;
-  top: 50%;
-  right: -13px;
-  transform: translateY(-50%);
-  width: 24px;
-  height: 40px;
-  background: #1a1d24;
-  border: 1px solid #303642;
-  border-left: none;
-  border-radius: 0 5px 5px 0;
-  color: #5a6478;
-  cursor: pointer;
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  font-size: 10px;
-  z-index: 10;
-  padding: 0;
-  min-height: 0;
-}
-
-.sidebar-collapse-btn:hover { color: #cbd5e1; }
-
-.app-shell.sidebar-collapsed {
-  grid-template-columns: 0 1fr;
-}
-
-.app-shell.sidebar-collapsed .controls {
-  overflow: hidden;
-  width: 0;
-  padding: 0;
-  border: none;
-}

--- a/crates/lsystem-web-app/style.css
+++ b/crates/lsystem-web-app/style.css
@@ -256,27 +256,42 @@ textarea {
 }
 
 /* ── Disclosure sections ── */
-.disclosure { border-top: 1px solid #252a35; }
+.disclosure {
+  border: 1px solid #2d3548;
+  border-radius: 7px;
+  /* No overflow:hidden — it clamps flex-item height inside a fixed-height
+     flex container, causing the card to stop short of its content. Corners
+     are handled by per-element border-radius instead. */
+}
 
-.disclosure-header {
+/* Higher specificity (.controls .disclosure-header = 0,2,0)
+   overrides the global .controls button rule (0,1,1). */
+.controls .disclosure-header {
   display: flex;
   align-items: center;
   justify-content: space-between;
-  padding: 9px 14px;
+  padding: 8px 12px;
   cursor: pointer;
   user-select: none;
-  color: #cbd5e1;
+  color: #8fa3b8;
   font-weight: 600;
   font-size: 11px;
   letter-spacing: 0.05em;
   text-transform: uppercase;
-  background: none;
+  background: #1e2333;
   border: none;
+  border-radius: 7px 7px 0 0;
+  min-height: 0;
   width: 100%;
   text-align: left;
 }
 
-.disclosure-header:hover { background: #1f2330; }
+.controls .disclosure-header:hover { background: #232840; }
+
+/* When closed the header rounds all four corners */
+.controls .disclosure-header:not(:has(+ .disclosure-body:not(.hidden))) {
+  border-radius: 7px;
+}
 
 .disclosure-chevron {
   color: #5a6478;
@@ -288,10 +303,13 @@ textarea {
 .disclosure-chevron.open { transform: rotate(90deg); }
 
 .disclosure-body {
-  padding: 10px 14px 13px;
+  padding: 10px 12px 13px;
   display: flex;
   flex-direction: column;
   gap: 9px;
+  border-top: 1px solid #2d3548;
+  background: #151820;
+  border-radius: 0 0 7px 7px;
 }
 
 /* ── Segmented toggle ── */
@@ -317,7 +335,8 @@ textarea {
 
 .seg-toggle button:not(:first-child) { border-left: 1px solid #3a4352; }
 .seg-toggle button.seg-active { background: #315d68; color: #e5e7eb; cursor: default; }
-.seg-toggle button:disabled { opacity: 0.35; cursor: not-allowed; }
+.seg-toggle button:disabled:not(.seg-active) { opacity: 0.35; cursor: not-allowed; }
+.seg-toggle button.seg-active:disabled { cursor: default; }
 
 /* ── Spinner ── */
 .spinner {
@@ -489,6 +508,12 @@ textarea {
 
 .preset-row { display: flex; gap: 5px; align-items: center; }
 .preset-row select { flex: 1; min-width: 0; }
+
+.preset-actions { display: flex; gap: 5px; margin-top: 4px; }
+.preset-actions button { flex: 1; }
+
+.btn-row { display: flex; gap: 5px; }
+.btn-row button { flex: 1; }
 
 .rename-input {
   flex: 1;

--- a/crates/lsystem-web-app/style.css
+++ b/crates/lsystem-web-app/style.css
@@ -191,11 +191,354 @@ textarea {
 @media (max-width: 760px) {
   .app-shell {
     grid-template-columns: 1fr;
-    grid-template-rows: minmax(240px, 42vh) minmax(0, 1fr);
+    grid-template-rows: 1fr;
   }
 
+  .viewport { position: fixed; inset: 0; z-index: 0; }
+
   .controls {
+    position: fixed;
+    bottom: 0;
+    left: 0;
+    right: 0;
     border-right: none;
-    border-bottom: 1px solid #303642;
+    border-top: 1px solid #303642;
+    border-radius: 12px 12px 0 0;
+    max-height: 80vh;
+    transform: translateY(calc(100% - 52px));
+    transition: transform 0.25s ease;
+    z-index: 100;
+    display: flex;
+    flex-direction: column;
+    overflow: hidden;
   }
+
+  .controls.sheet-open { transform: translateY(0); }
+
+  .sheet-handle-area {
+    flex-shrink: 0;
+    padding: 10px 14px 6px;
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    gap: 4px;
+    cursor: pointer;
+    touch-action: none;
+    user-select: none;
+  }
+
+  .sheet-handle {
+    width: 36px;
+    height: 4px;
+    border-radius: 2px;
+    background: #4a5568;
+    flex-shrink: 0;
+  }
+
+  .sheet-preset-name {
+    font-size: 12px;
+    color: #7a8899;
+  }
+
+  .controls-scroll {
+    flex: 1;
+    overflow-y: auto;
+    overscroll-behavior: contain;
+  }
+
+  /* Hide desktop-only elements on mobile */
+  .sidebar-collapse-btn { display: none; }
+}
+
+@media (min-width: 761px) {
+  .sheet-handle-area { display: none; }
+  .controls-scroll { display: contents; }
+}
+
+/* ── Disclosure sections ── */
+.disclosure { border-top: 1px solid #252a35; }
+
+.disclosure-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 9px 14px;
+  cursor: pointer;
+  user-select: none;
+  color: #cbd5e1;
+  font-weight: 600;
+  font-size: 11px;
+  letter-spacing: 0.05em;
+  text-transform: uppercase;
+  background: none;
+  border: none;
+  width: 100%;
+  text-align: left;
+}
+
+.disclosure-header:hover { background: #1f2330; }
+
+.disclosure-chevron {
+  color: #5a6478;
+  font-size: 9px;
+  display: inline-block;
+  transition: transform 0.15s;
+}
+
+.disclosure-chevron.open { transform: rotate(90deg); }
+
+.disclosure-body {
+  padding: 10px 14px 13px;
+  display: flex;
+  flex-direction: column;
+  gap: 9px;
+}
+
+/* ── Segmented toggle ── */
+.seg-toggle {
+  display: flex;
+  border: 1px solid #3a4352;
+  border-radius: 5px;
+  overflow: hidden;
+}
+
+.seg-toggle button {
+  flex: 1;
+  padding: 5px 0;
+  font-size: 12px;
+  font-weight: 600;
+  color: #7a8899;
+  background: #0f1117;
+  border: none;
+  border-radius: 0;
+  cursor: pointer;
+  min-height: 0;
+}
+
+.seg-toggle button:not(:first-child) { border-left: 1px solid #3a4352; }
+.seg-toggle button.seg-active { background: #315d68; color: #e5e7eb; cursor: default; }
+.seg-toggle button:disabled { opacity: 0.35; cursor: not-allowed; }
+
+/* ── Spinner ── */
+.spinner {
+  display: flex;
+  align-items: center;
+  border: 1px solid #3a4352;
+  border-radius: 5px;
+  overflow: hidden;
+  background: #0f1117;
+}
+
+.spinner-btn {
+  width: 28px;
+  height: 30px;
+  background: #252932;
+  border: none;
+  color: #aeb6c3;
+  font-size: 16px;
+  cursor: pointer;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  flex-shrink: 0;
+  padding: 0;
+  min-height: 0;
+}
+
+.spinner-btn:hover { background: #315d68; color: #fff; }
+
+.spinner-input {
+  flex: 1;
+  min-width: 0;
+  height: 30px;
+  background: transparent;
+  border: none;
+  border-left: 1px solid #3a4352;
+  border-right: 1px solid #3a4352;
+  color: #f3f4f6;
+  text-align: center;
+  font-size: 13px;
+  padding: 0 4px;
+}
+
+.spinner-row {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+}
+
+.spinner-label {
+  flex: 0 0 126px;
+  font-size: 12px;
+  color: #aeb6c3;
+}
+
+/* ── Section label ── */
+.section-label {
+  font-size: 11px;
+  font-weight: 600;
+  letter-spacing: 0.05em;
+  text-transform: uppercase;
+  color: #7a8899;
+}
+
+.section-label.dim { color: #4a5568; }
+
+.section-divider {
+  border: none;
+  border-top: 1px solid #252a35;
+  margin: 2px 0;
+}
+
+/* ── Grammar table ── */
+.grammar-table { width: 100%; border-collapse: collapse; }
+
+.grammar-table td { padding: 2px 3px; vertical-align: middle; }
+.grammar-table td.g-symbol { width: 72px; }
+.grammar-table td.g-delete { width: 24px; text-align: center; }
+
+.grammar-axiom-label {
+  display: block;
+  text-align: center;
+  background: #0f1117;
+  border: 1px solid #3a4352;
+  border-radius: 4px;
+  color: #7ab8c8;
+  font-family: ui-monospace, SFMono-Regular, Menlo, Consolas, monospace;
+  font-size: 12px;
+  padding: 4px 0;
+}
+
+.grammar-combo,
+.grammar-rhs {
+  width: 100%;
+  background: #0f1117;
+  border: 1px solid #3a4352;
+  border-radius: 4px;
+  color: #f3f4f6;
+  padding: 4px 6px;
+  font-family: ui-monospace, SFMono-Regular, Menlo, Consolas, monospace;
+  font-size: 12px;
+  box-sizing: border-box;
+}
+
+.grammar-delete-btn {
+  background: none;
+  border: none;
+  color: #5a6478;
+  cursor: pointer;
+  font-size: 16px;
+  line-height: 1;
+  padding: 2px 3px;
+  border-radius: 3px;
+  min-height: 0;
+}
+
+.grammar-delete-btn:hover { color: #f87171; background: #2a1a1a; }
+
+/* ── Warning prompt ── */
+.warning-prompt {
+  background: #1e1a0a;
+  border: 1px solid #5a4010;
+  border-radius: 5px;
+  padding: 8px 10px;
+  font-size: 12px;
+  color: #d4a840;
+  line-height: 1.45;
+  display: flex;
+  flex-direction: column;
+  gap: 7px;
+}
+
+.warning-prompt-actions { display: flex; gap: 6px; }
+
+.warning-confirm-btn {
+  flex: 1;
+  background: #2a200a;
+  border: 1px solid #7a5a10;
+  border-radius: 5px;
+  color: #f6c85a;
+  font-size: 11px;
+  min-height: 28px;
+  cursor: pointer;
+  padding: 0 8px;
+}
+
+.warning-confirm-btn:hover { background: #3a2e0e; }
+
+.warning-cancel-btn {
+  flex: 1;
+  background: #252932;
+  border: 1px solid #3a4352;
+  border-radius: 5px;
+  color: #aeb6c3;
+  font-size: 11px;
+  min-height: 28px;
+  cursor: pointer;
+  padding: 0 8px;
+}
+
+.warning-cancel-btn:hover { background: #2e3545; }
+
+/* ── Top bar additions ── */
+.controls-title {
+  margin: 0 0 6px;
+  font-size: 20px;
+  font-weight: 650;
+}
+
+.preset-row { display: flex; gap: 5px; align-items: center; }
+.preset-row select { flex: 1; min-width: 0; }
+
+.rename-input {
+  flex: 1;
+  min-width: 0;
+  color: #f3f4f6;
+  background: #0f1117;
+  border: 1px solid #3a4352;
+  border-radius: 6px;
+  min-height: 34px;
+  padding: 0 8px;
+}
+
+.inline-status { font-size: 12px; min-height: 16px; }
+.inline-status.ok { color: #65d894; }
+.inline-status.error { color: #ff7b7b; }
+
+/* ── Sidebar collapse (desktop only) ── */
+.controls { position: relative; }
+
+.sidebar-collapse-btn {
+  position: absolute;
+  top: 50%;
+  right: -13px;
+  transform: translateY(-50%);
+  width: 24px;
+  height: 40px;
+  background: #1a1d24;
+  border: 1px solid #303642;
+  border-left: none;
+  border-radius: 0 5px 5px 0;
+  color: #5a6478;
+  cursor: pointer;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-size: 10px;
+  z-index: 10;
+  padding: 0;
+  min-height: 0;
+}
+
+.sidebar-collapse-btn:hover { color: #cbd5e1; }
+
+.app-shell.sidebar-collapsed {
+  grid-template-columns: 0 1fr;
+}
+
+.app-shell.sidebar-collapsed .controls {
+  overflow: hidden;
+  width: 0;
+  padding: 0;
+  border: none;
 }


### PR DESCRIPTION
## What changed

Replace the flat sidebar with collapsible disclosure sections and a structured grammar editor.

### New sidebar sections

- **Grammar** — two-column table (axiom row + rule rows with combobox predecessor, RHS input, and × delete). Apply button validates empty/duplicate symbols and shows an inline amber prompt when the grammar contains 3D-only symbols while in 2D mode.
- **Parameters** — spinners for Dimensions (2D/3D segmented toggle), Angle, Initial heading, and Iterations. Switching 2D→3D with 3D-only symbols in the grammar shows a blocking inline error rather than silently failing.
- **Colors** — same controls as before, wrapped in a disclosure.
- **Animations** — Off/Forward/Backward segmented toggle for hue movement (always visible; shows a discard prompt if color mode is not Hue cycle when enabling). Off/On toggle for auto-rotate (disabled in 2D).
- **Save image** — SVG/PNG segmented toggle (PNG only in 3D); PNG width spinner shown only for PNG.
- **Edit TOML** — collapsed by default; Apply/Revert buttons unchanged.

### Top bar

Rename flow: clicking Rename swaps the preset `<select>` in-place for a text input with Save/✕ buttons. Reset moves from the TOML row to the top bar and shows a discard prompt when a TOML draft is pending.

### Layout

- Desktop: collapse toggle button on the sidebar edge hides the sidebar and expands the canvas to full width.
- Mobile: canvas fills the viewport; controls slide up as a bottom sheet with a drag handle and active preset name in the minimized state.

### Discard prompts

Controls that conflict with a pending TOML draft show an inline amber prompt ("Discard & proceed") instead of being disabled. Reverting via the prompt syncs the grammar editor state so it reflects the reverted config.

### New `lsystem-core` methods

| Method | Purpose |
|---|---|
| `CleanMut::set_grammar(axiom, rules)` | Grammar Apply button |
| `CleanMut::set_initial_heading(angle)` | Initial heading spinner |
| `CleanMut::set_dimensions(dimensions)` | 2D/3D toggle |
| `ConfigWorkspace::rename(index, name)` | Top bar Rename flow |

`rename_in_place` also patches the draft name so applying a pending TOML draft after a rename does not silently revert it.

### New `lsystem-web-app` components (`ui.rs`)

`Disclosure`, `Spinner`, `SegmentedToggle`, `WarningPrompt` — reusable Leptos 0.8 components used throughout the new sidebar.