### PR TITLE
Bind trunk servers to 0.0.0.0 for LAN access

### DIFF
--- a/crates/lsystem-app/Trunk.toml
+++ b/crates/lsystem-app/Trunk.toml
@@ -3,6 +3,6 @@ target = "index.html"
 dist = "dist"
 
 [serve]
-addresses = ["127.0.0.1"]
+addresses = ["0.0.0.0"]
 port = 8080
 open = false

--- a/crates/lsystem-web-app/Trunk.toml
+++ b/crates/lsystem-web-app/Trunk.toml
@@ -3,6 +3,6 @@ target = "index.html"
 dist = "dist"
 
 [serve]
-addresses = ["127.0.0.1"]
+addresses = ["0.0.0.0"]
 port = 8081
 open = false


### PR DESCRIPTION
## Summary

- Changed `addresses` from `["127.0.0.1"]` to `["0.0.0.0"]` in both `crates/lsystem-web-app/Trunk.toml` (port 8081) and `crates/lsystem-app/Trunk.toml` (port 8080)
- This allows `trunk serve` to accept connections from any network interface, enabling testing on mobile devices and other machines on the same local network