### PR TITLE
Improve git agent rules for commands and branching

### DIFF
--- a/.agents/rules/git-and-github.md
+++ b/.agents/rules/git-and-github.md
@@ -2,19 +2,41 @@
 
 ## Git command conventions
 
-Avoid using `git -C <path>` to run git commands from a different directory. Instead, rely on the shell's working directory or `cd` into the target directory first. Some AI-agent permission matchers only recognize commands run from the repository working directory.
+Always run git commands from the current working directory. Never use `git -C <path>` or `cd <path> && git ...` to target a different directory — both patterns trigger permission prompts and signal a workflow problem.
 
-## Branch naming convention
+The right directory is always implied by context:
+
+- When working in the main repository, it is the current directory.
+- When working in a worktree, the worktree root is the current directory.
+
+If you find yourself wanting to run a git command against a path that is not the current directory, treat that as a red flag: you are likely reaching across worktree boundaries. Stay in your working directory instead.
+
+## Branch naming
 
 All branches must follow a descriptive, prefix-based naming convention. Use lowercase letters and hyphens for word separation.
 
-Standard prefixes:
+| Prefix | When to use |
+|--------|-------------|
+| `feature/` | New functionality |
+| `fix/` | Bug fixes |
+| `docs/`, `refactor/`, `perf/`, `chore/`, `test/`, … | When the above don't fit |
 
-Features: feature/<short-description>
+## Branch setup before committing
 
-Bug Fixes: fix/<short-description>
+Before creating a commit, verify you are on the correct branch for the work at hand.
 
-Flexibility Note: You are encouraged to select alternative prefixes (e.g., docs/, refactor/, perf/, chore/, or test/) if the standard "feature" or "fix" categories do not accurately represent the scope of the work.
+**Adding to an existing PR branch** — if the branch already exists and matches the work, just commit.
+
+**Starting a new PR** — if the current branch belongs to unrelated work:
+
+1. Inspect uncommitted changes (`git diff`, `git status`) and determine which files belong to the current branch and which to the new PR.
+2. Stash selectively as needed — use `git stash push -- <paths>` to move only specific files into the stash, keeping unrelated changes on the current branch.
+3. Switch to `main` and pull: `git switch main && git pull`.
+4. Create the new branch: `git switch -c <prefix>/<description>`.
+5. Restore the stashed changes: `git stash pop`.
+6. Commit.
+
+Never commit work intended for a new PR onto an existing feature branch or directly onto `main`.
 
 ## Commits
 


### PR DESCRIPTION
## What changed and why

- **`git -C` and `cd <path> && git` both prohibited** — the old rule only banned `git -C` and redirected agents to `cd` instead. `cd <path> && git` also triggers permission prompts and signals the same workflow error (reaching across worktree boundaries), so both are now explicitly disallowed.

- **Branch naming table** — replaced the prose prefix list with a compact two-row table; the alternative-prefix row now ends with `…` to make clear the list is not exhaustive.

- **Branch setup before committing** — new section that tells agents to check the current branch before committing, handle mixed changes via per-path `git stash push -- <paths>`, switch to `main` and pull, then create a PR branch. Committing directly onto `main` is now also forbidden alongside committing onto an unrelated feature branch.

- **`git switch` throughout** — replaced `git checkout` / `git checkout -b` with `git switch` / `git switch -c`.