### PR TITLE
Consolidate Leptos HSV movement into RwSignal<HsvMovement>

### DIFF
--- a/crates/lsystem-web-app/src/app.rs
+++ b/crates/lsystem-web-app/src/app.rs
@@ -10,15 +10,13 @@ use wasm_bindgen::closure::Closure;
 
 use crate::color_input::{hex_to_rgb, rgb_to_hex};
 use crate::export::{export_png, export_svg};
+use crate::hsv_movement::{HsvMovement, HsvMovementDirection, advance_hsv_phase_degrees};
 use crate::presets::{load_presets, max_iterations_for_config};
 use crate::renderer::{CanvasRenderer, RenderStatus};
 
 type RendererState = StoredValue<Option<CanvasRenderer>, LocalStorage>;
 
 const ROTATION_STEP_DEG: f32 = 5.0;
-const HSV_MOVEMENT_DEFAULT_SPEED_DEGREES_PER_SECOND: f32 = 15.0;
-const HSV_MOVEMENT_MIN_SPEED_DEGREES_PER_SECOND: f32 = 1.0;
-const HSV_MOVEMENT_MAX_SPEED_DEGREES_PER_SECOND: f32 = 60.0;
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 enum LineColorMode {
@@ -65,34 +63,6 @@ impl LineColorMode {
             Self::DepthGradient => LineColorConfig::DEFAULT_DEPTH_GRADIENT,
         }
     }
-}
-
-#[derive(Clone, Copy, Debug, PartialEq, Eq)]
-enum HsvMovementDirection {
-    Forward,
-    Reverse,
-}
-
-impl HsvMovementDirection {
-    fn sign(self) -> f32 {
-        match self {
-            Self::Forward => 1.0,
-            Self::Reverse => -1.0,
-        }
-    }
-}
-
-fn advance_hsv_phase_degrees(
-    phase_degrees: f32,
-    speed_degrees_per_second: f32,
-    dt_seconds: f32,
-    direction: HsvMovementDirection,
-) -> f32 {
-    (phase_degrees + direction.sign() * speed_degrees_per_second * dt_seconds).rem_euclid(360.0)
-}
-
-fn hsv_movement_is_active(enabled: bool, line_color: &LineColorConfig) -> bool {
-    enabled && matches!(line_color, LineColorConfig::HueCycle { .. })
 }
 
 fn contains_3d_symbols(s: &str) -> bool {
@@ -193,10 +163,8 @@ pub(crate) fn App() -> impl IntoView {
     let gpu_error = RwSignal::new(None::<String>);
     let auto_rotate = RwSignal::new(true);
     let auto_rotate_speed = RwSignal::new(20.0f32);
-    let hsv_movement = RwSignal::new(false);
-    let hsv_movement_speed = RwSignal::new(HSV_MOVEMENT_DEFAULT_SPEED_DEGREES_PER_SECOND);
-    let hsv_movement_direction = RwSignal::new(HsvMovementDirection::Forward);
-    let hsv_movement_phase = RwSignal::new(0.0f32);
+    let hsv_movement = RwSignal::new(HsvMovement::default());
+    let hsv_movement_phase = StoredValue::new(0.0f32);
     let sheet_open = RwSignal::new(false);
     let sheet_drag_start: StoredValue<Option<f64>, LocalStorage> = StoredValue::new_local(None);
     // Generation counter: bumped on each animation start so older rAF loops detect
@@ -317,7 +285,7 @@ pub(crate) fn App() -> impl IntoView {
 
     let animation_active = Memo::new(move |_| {
         (auto_rotate.get() && is_3d())
-            || hsv_movement_is_active(hsv_movement.get(), &color_config.with(|c| c.line))
+            || hsv_movement.with(|m| m.is_active(&color_config.with(|c| c.line)))
     });
 
     let start_animation_loop = move || {
@@ -331,8 +299,8 @@ pub(crate) fn App() -> impl IntoView {
                     Err(reason) => {
                         log::error!("requestAnimationFrame failed ({reason}); stopping animation");
                         auto_rotate.set(false);
-                        hsv_movement.set(false);
-                        hsv_movement_phase.set(0.0);
+                        hsv_movement.update(|m| m.stop());
+                        hsv_movement_phase.set_value(0.0);
                         error.set(Some(
                             "Animation stopped unexpectedly. Try toggling it again.".to_string(),
                         ));
@@ -352,7 +320,8 @@ pub(crate) fn App() -> impl IntoView {
                         Dimensions::ThreeD
                     );
                 let line_color = color_config.with_untracked(|c| c.line);
-                let hsv_active = hsv_movement_is_active(hsv_movement.get_untracked(), &line_color);
+                let movement = hsv_movement.get_untracked();
+                let hsv_active = movement.is_active(&line_color);
 
                 // Clamp dt to 100 ms to prevent a large jump after the tab was backgrounded.
                 let dt = prev_ts
@@ -363,12 +332,12 @@ pub(crate) fn App() -> impl IntoView {
                 let auto_degrees = auto_active.then(|| auto_rotate_speed.get_untracked() * dt);
                 let hue_phase = hsv_active.then(|| {
                     let next = advance_hsv_phase_degrees(
-                        hsv_movement_phase.get_untracked(),
-                        hsv_movement_speed.get_untracked(),
+                        hsv_movement_phase.get_value(),
+                        movement.speed_degrees_per_second(),
                         dt,
-                        hsv_movement_direction.get_untracked(),
+                        movement.direction(),
                     );
-                    hsv_movement_phase.set(next);
+                    hsv_movement_phase.set_value(next);
                     next
                 });
 
@@ -412,9 +381,10 @@ pub(crate) fn App() -> impl IntoView {
     };
 
     let reset_hsv_movement = move || {
-        let was_active = hsv_movement.get_untracked() || hsv_movement_phase.get_untracked() != 0.0;
-        hsv_movement.set(false);
-        hsv_movement_phase.set(0.0);
+        let was_active = hsv_movement.with_untracked(|m| m.is_enabled())
+            || hsv_movement_phase.get_value() != 0.0;
+        hsv_movement.update(|m| m.stop());
+        hsv_movement_phase.set_value(0.0);
         if was_active && let Some(canvas) = canvas_ref.get_untracked() {
             with_renderer(canvas, renderer, recover_after_render, |r, c| {
                 r.animate_and_render(c, None, Some(0.0))
@@ -626,10 +596,10 @@ pub(crate) fn App() -> impl IntoView {
 
     let apply_hue_movement = move |dir: Option<HsvMovementDirection>| match dir {
         None => reset_hsv_movement(),
-        Some(d) => {
-            hsv_movement_direction.set(d);
-            hsv_movement.set(true);
-        }
+        Some(d) => hsv_movement.update(|m| {
+            m.set_direction(d);
+            m.start();
+        }),
     };
 
     let try_set_hue_movement = move |key: &'static str| {
@@ -1487,9 +1457,11 @@ pub(crate) fn App() -> impl IntoView {
                         <crate::ui::SegmentedToggle
                             options=vec![("off", "Off"), ("forward", "Forward"), ("backward", "Backward")]
                             selected=Signal::derive(move || {
-                                if !hsv_movement.get() { "off" }
-                                else if hsv_movement_direction.get() == HsvMovementDirection::Forward { "forward" }
-                                else { "backward" }
+                                hsv_movement.with(|m| {
+                                    if !m.is_enabled() { "off" }
+                                    else if m.direction() == HsvMovementDirection::Forward { "forward" }
+                                    else { "backward" }
+                                })
                             })
                             on_change=move |key| try_set_hue_movement(key)
                             disabled_keys=Signal::derive(move || {
@@ -1501,18 +1473,15 @@ pub(crate) fn App() -> impl IntoView {
                             })
                         />
                         </div>
-                        <Show when=move || hsv_movement.get()>
+                        <Show when=move || hsv_movement.with(|m| m.is_enabled())>
                             <div class="spinner-row">
                                 <span class="spinner-label">"Speed (°/s)"</span>
                                 <crate::ui::Spinner
-                                    value=Signal::derive(move || format!("{:.0}", hsv_movement_speed.get()))
+                                    value=Signal::derive(move || hsv_movement.with(|m| format!("{:.0}", m.speed_degrees_per_second())))
                                     step=1.0
                                     on_commit=move |s| {
                                         if let Ok(v) = s.parse::<f32>() {
-                                            hsv_movement_speed.set(v.clamp(
-                                                HSV_MOVEMENT_MIN_SPEED_DEGREES_PER_SECOND,
-                                                HSV_MOVEMENT_MAX_SPEED_DEGREES_PER_SECOND,
-                                            ));
+                                            hsv_movement.update(|m| m.set_speed(v));
                                         }
                                     }
                                 />
@@ -1871,10 +1840,8 @@ async fn next_animation_frame() -> Result<f64, &'static str> {
 mod tests {
     use lsystem_core::{ColorConfig, LineColorConfig};
 
-    use super::{
-        ColorControlMemory, HsvMovementDirection, LineColorMode, advance_hsv_phase_degrees,
-        hsv_movement_is_active,
-    };
+    use super::{ColorControlMemory, LineColorMode};
+    use crate::hsv_movement::{HsvMovementDirection, advance_hsv_phase_degrees};
 
     #[test]
     fn line_color_mode_key_round_trip() {
@@ -1899,22 +1866,6 @@ mod tests {
             advance_hsv_phase_degrees(10.0, 20.0, 1.0, HsvMovementDirection::Reverse),
             350.0
         );
-    }
-
-    #[test]
-    fn hsv_movement_is_only_active_for_hue_cycle_line_color() {
-        assert!(hsv_movement_is_active(
-            true,
-            &LineColorConfig::DEFAULT_HUE_CYCLE
-        ));
-        assert!(!hsv_movement_is_active(
-            true,
-            &LineColorConfig::DEFAULT_SOLID
-        ));
-        assert!(!hsv_movement_is_active(
-            false,
-            &LineColorConfig::DEFAULT_HUE_CYCLE
-        ));
     }
 
     #[test]

--- a/crates/lsystem-web-app/src/hsv_movement.rs
+++ b/crates/lsystem-web-app/src/hsv_movement.rs
@@ -1,0 +1,123 @@
+use lsystem_core::LineColorConfig;
+
+pub(crate) const HSV_MOVEMENT_DEFAULT_SPEED_DEGREES_PER_SECOND: f32 = 15.0;
+pub(crate) const HSV_MOVEMENT_MIN_SPEED_DEGREES_PER_SECOND: f32 = 1.0;
+pub(crate) const HSV_MOVEMENT_MAX_SPEED_DEGREES_PER_SECOND: f32 = 60.0;
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub(crate) enum HsvMovementDirection {
+    Forward,
+    Reverse,
+}
+
+impl HsvMovementDirection {
+    pub(crate) fn sign(self) -> f32 {
+        match self {
+            Self::Forward => 1.0,
+            Self::Reverse => -1.0,
+        }
+    }
+}
+
+/// User-driven configuration for HSV hue-cycle animation.
+/// The phase accumulator is stored separately as a non-reactive `StoredValue<f32>`.
+#[derive(Clone, Copy, Debug)]
+pub(crate) struct HsvMovement {
+    enabled: bool,
+    speed_degrees_per_second: f32,
+    direction: HsvMovementDirection,
+}
+
+impl HsvMovement {
+    pub(crate) fn is_enabled(self) -> bool {
+        self.enabled
+    }
+
+    pub(crate) fn speed_degrees_per_second(self) -> f32 {
+        self.speed_degrees_per_second
+    }
+
+    pub(crate) fn direction(self) -> HsvMovementDirection {
+        self.direction
+    }
+
+    pub(crate) fn stop(&mut self) {
+        self.enabled = false;
+    }
+
+    pub(crate) fn start(&mut self) {
+        self.enabled = true;
+    }
+
+    pub(crate) fn set_speed(&mut self, speed: f32) {
+        self.speed_degrees_per_second = speed.clamp(
+            HSV_MOVEMENT_MIN_SPEED_DEGREES_PER_SECOND,
+            HSV_MOVEMENT_MAX_SPEED_DEGREES_PER_SECOND,
+        );
+    }
+
+    pub(crate) fn set_direction(&mut self, direction: HsvMovementDirection) {
+        self.direction = direction;
+    }
+
+    pub(crate) fn is_active(self, line_color: &LineColorConfig) -> bool {
+        self.enabled && matches!(line_color, LineColorConfig::HueCycle { .. })
+    }
+}
+
+impl Default for HsvMovement {
+    fn default() -> Self {
+        Self {
+            enabled: false,
+            speed_degrees_per_second: HSV_MOVEMENT_DEFAULT_SPEED_DEGREES_PER_SECOND,
+            direction: HsvMovementDirection::Forward,
+        }
+    }
+}
+
+/// Pure phase-advance computation. Kept as a free function so it remains testable
+/// without constructing signal infrastructure.
+pub(crate) fn advance_hsv_phase_degrees(
+    phase_degrees: f32,
+    speed_degrees_per_second: f32,
+    dt_seconds: f32,
+    direction: HsvMovementDirection,
+) -> f32 {
+    (phase_degrees + direction.sign() * speed_degrees_per_second * dt_seconds).rem_euclid(360.0)
+}
+
+#[cfg(test)]
+mod tests {
+    use lsystem_core::LineColorConfig;
+
+    use super::{
+        HSV_MOVEMENT_MAX_SPEED_DEGREES_PER_SECOND, HSV_MOVEMENT_MIN_SPEED_DEGREES_PER_SECOND,
+        HsvMovement,
+    };
+
+    #[test]
+    fn set_speed_clamps_to_valid_range() {
+        let mut m = HsvMovement::default();
+        m.set_speed(0.0);
+        assert_eq!(
+            m.speed_degrees_per_second(),
+            HSV_MOVEMENT_MIN_SPEED_DEGREES_PER_SECOND
+        );
+        m.set_speed(1000.0);
+        assert_eq!(
+            m.speed_degrees_per_second(),
+            HSV_MOVEMENT_MAX_SPEED_DEGREES_PER_SECOND
+        );
+        m.set_speed(30.0);
+        assert_eq!(m.speed_degrees_per_second(), 30.0);
+    }
+
+    #[test]
+    fn is_active_requires_enabled_and_hue_cycle_mode() {
+        let mut m = HsvMovement::default();
+        assert!(!m.is_active(&LineColorConfig::DEFAULT_HUE_CYCLE));
+        m.start();
+        assert!(m.is_active(&LineColorConfig::DEFAULT_HUE_CYCLE));
+        assert!(!m.is_active(&LineColorConfig::DEFAULT_SOLID));
+    }
+}

--- a/crates/lsystem-web-app/src/lib.rs
+++ b/crates/lsystem-web-app/src/lib.rs
@@ -3,6 +3,7 @@
 mod app;
 mod color_input;
 mod export;
+mod hsv_movement;
 mod presets;
 mod renderer;
 pub(crate) mod ui;


### PR DESCRIPTION
## What changed

Extracted HSV hue-cycle animation state from four separate `RwSignal`s in `app.rs` into a new `hsv_movement` module:

- **`HsvMovement`** struct — user-driven config: `enabled`, `speed_degrees_per_second`, `direction`
- **`HsvMovementDirection`** enum with `sign() -> f32`
- **`advance_hsv_phase_degrees`** — pure free function (remains testable without signal infrastructure)
- **`HsvMovement::is_active(&LineColorConfig)`** — replaces the `hsv_movement_is_active` free function that took a pre-extracted `bool`

In `app.rs`, the four signals become:

```rust
let hsv_movement = RwSignal::new(HsvMovement::default());  // user config
let hsv_movement_phase = StoredValue::new(0.0f32);         // per-frame accumulator
```

## Why

**Phase is not reactive state.** It is mutated every animation frame via the rAF loop and never subscribed to by any reactive context. Storing it in an `RwSignal` would require `update_untracked` suppression at every frame to prevent spurious re-runs of the `animation_active` memo. `StoredValue` is the right primitive — the memo now re-runs only when `enabled` or the color mode actually changes, correct by construction.

**Cohesion.** The three user-driven config fields (`enabled`, `speed`, `direction`) change together on user actions and are read together by the UI. One signal reflects that.

**`is_active` as a method.** The previous `hsv_movement_is_active(enabled: bool, line_color)` required callers to extract `is_enabled()` before calling, splitting the logic from its data. The method form `movement.is_active(&line_color)` is direct.

**rAF hot path.** Two `with_untracked` closures on a `Copy` signal replaced with one `get_untracked()` copy; speed and direction are then accessed as plain method calls.

## Tests added

- `HsvMovement::set_speed` clamping (below-min and above-max inputs)
- `HsvMovement::is_active` (disabled state, enabled + HueCycle, enabled + non-HueCycle)