### PR TITLE
Replace sphere framing with bounding-cylinder frustum-fit for 3D camera

### DIFF
--- a/crates/lsystem-renderer/src/camera.rs
+++ b/crates/lsystem-renderer/src/camera.rs
@@ -5,6 +5,7 @@ use crate::lsystem_bridge::{fitted_pixels_per_unit, viewport_transform};
 
 const ORBIT_DEG_PER_PIXEL: f32 = 0.3;
 const FOV_Y_RAD: f32 = std::f32::consts::FRAC_PI_4; // 45°
+const NEAR_CLIP_RATIO: f32 = 0.001;
 
 #[derive(Clone, Debug)]
 pub struct Camera {
@@ -13,6 +14,10 @@ pub struct Camera {
     pub azimuth: f32,
     pub elevation: f32,
     pub roll: f32,
+    /// Elevation at the time of the last `reset_position` call; determines the
+    /// framing distance for the bounding square prism.  Azimuth is not needed
+    /// because the prism is azimuth-symmetric.
+    framing_elevation: f32,
 }
 
 impl Camera {
@@ -23,6 +28,7 @@ impl Camera {
             azimuth: 0.0,
             elevation: 20.0,
             roll: 0.0,
+            framing_elevation: 20.0,
         }
     }
 
@@ -32,12 +38,16 @@ impl Camera {
         self.azimuth = 0.0;
         self.elevation = 20.0;
         self.roll = 0.0;
+        self.framing_elevation = 20.0;
     }
 
     /// Preserves azimuth/elevation/roll; only resets pan and zoom.
+    /// Captures the current elevation as the new framing reference so the
+    /// cylinder-fit framing stays stable for the current view.
     pub fn reset_position(&mut self) {
         self.pan = [0.0, 0.0];
         self.zoom = 1.0;
+        self.framing_elevation = self.elevation;
     }
 
     fn px_per_unit(
@@ -137,12 +147,45 @@ impl Camera {
         let min = Vec3::from(bounds_min);
         let max = Vec3::from(bounds_max);
         let center = (min + max) * 0.5;
-        let extent = max - min;
-        let radius = (extent.length() * 0.5).max(1.0);
+        let half_y = (max.y - min.y) * 0.5;
 
-        // Base distance to frame the geometry at 45° FOV, then apply zoom.
-        let base_distance = radius / (FOV_Y_RAD * 0.5).tan();
-        let distance = (base_distance / self.zoom).max(radius * 0.01);
+        // Bounding cylinder centred on the AABB XZ centre.  The radius is the
+        // XZ diagonal of the half-extents, which is the farthest any AABB corner
+        // can be from the centre along any horizontal direction.  Framing is done
+        // against the circumscribed square prism (cyl_half below) rather than the
+        // cylinder surface itself, which is conservative but keeps framing
+        // distance independent of azimuth so the scene never clips during
+        // auto-rotation regardless of shape.
+        let hx = (max.x - min.x) * 0.5;
+        let hz = (max.z - min.z) * 0.5;
+        let r_cyl = hx.hypot(hz);
+
+        // A cylinder is azimuth-symmetric, so evaluate at faz=0 (right = X,
+        // eye toward +Z) using only the captured elevation.
+        let fel = self.framing_elevation.to_radians();
+        let (fel_sin, fel_cos) = fel.sin_cos();
+        let framing_eye_dir = Vec3::new(0.0, fel_sin, fel_cos);
+        let framing_up = Vec3::new(0.0, fel_cos, -fel_sin);
+        // Use r_cyl for both horizontal extents so any azimuth is covered.
+        let cyl_half = Vec3::new(r_cyl, half_y, r_cyl);
+
+        let aspect = (width as f32 / height as f32).max(0.001);
+        let half_fov_y_tan = (FOV_Y_RAD * 0.5).tan();
+        let half_fov_x_tan = half_fov_y_tan * aspect;
+
+        // Exact frustum-fit for the square prism: d ≥ max(|(±axis/tan_fov + eye_dir)| ⊙ cyl_half).
+        // Conservative relative to the actual AABB when hx ≠ hz.
+        let fit_dist = |axis: Vec3, tan_fov: f32| -> f32 {
+            let vp = axis / tan_fov + framing_eye_dir;
+            let vn = -axis / tan_fov + framing_eye_dir;
+            vp.abs().dot(cyl_half).max(vn.abs().dot(cyl_half))
+        };
+
+        let base_distance =
+            fit_dist(Vec3::X, half_fov_x_tan).max(fit_dist(framing_up, half_fov_y_tan));
+        let distance = (base_distance / self.zoom)
+            .max(r_cyl.max(half_y) * NEAR_CLIP_RATIO)
+            .max(1e-4);
 
         let az = self.azimuth.to_radians();
         let el = self.elevation.to_radians();
@@ -160,8 +203,7 @@ impl Camera {
         let up = roll_quat * world_up;
 
         let view = Mat4::look_at_rh(eye, center, up);
-        let aspect = (width as f32 / height as f32).max(0.001);
-        let z_near = distance * 0.001;
+        let z_near = distance * NEAR_CLIP_RATIO;
         let z_far = distance * 10.0;
         let proj = Mat4::perspective_rh(FOV_Y_RAD, aspect, z_near, z_far);
 
@@ -182,6 +224,9 @@ mod tests {
     use super::*;
 
     const EPS: f32 = 1e-5;
+    // Tall plant-like bounds used across several framing tests.
+    const TALL_MIN: [f32; 3] = [-10.0, 0.0, -10.0];
+    const TALL_MAX: [f32; 3] = [10.0, 60.0, 10.0];
 
     fn close(a: f32, b: f32) -> bool {
         (a - b).abs() < EPS
@@ -301,5 +346,179 @@ mod tests {
         assert!(cam.elevation <= 89.0, "elevation={}", cam.elevation);
         cam.orbit_by(0.0, -999.0);
         assert!(cam.elevation >= -89.0, "elevation={}", cam.elevation);
+    }
+
+    fn bounding_box_corners(min: [f32; 3], max: [f32; 3]) -> [[f32; 3]; 8] {
+        [
+            [min[0], min[1], min[2]],
+            [min[0], min[1], max[2]],
+            [min[0], max[1], min[2]],
+            [min[0], max[1], max[2]],
+            [max[0], min[1], min[2]],
+            [max[0], min[1], max[2]],
+            [max[0], max[1], min[2]],
+            [max[0], max[1], max[2]],
+        ]
+    }
+
+    fn all_corners_fit_in_frustum(mvp: &Mvp, min: [f32; 3], max: [f32; 3]) -> bool {
+        let tolerance = 1.001;
+        for corner in bounding_box_corners(min, max) {
+            let clip = mvp.matrix * glam::Vec4::new(corner[0], corner[1], corner[2], 1.0);
+            let ndc_x = clip.x / clip.w;
+            let ndc_y = clip.y / clip.w;
+            if ndc_x.abs() > tolerance || ndc_y.abs() > tolerance {
+                return false;
+            }
+        }
+        true
+    }
+
+    #[test]
+    fn mvp_3d_portrait_viewport_fits_wide_geometry() {
+        // Wide box on a portrait (aspect=0.5) screen: horizontal FOV is narrower,
+        // so projected-fit must use the horizontal constraint.
+        let cam = Camera::new();
+        let min = [-10.0f32, -3.0, -3.0];
+        let max = [10.0f32, 3.0, 3.0];
+        let mvp = cam.compute_mvp_3d(min, max, 400, 800);
+        assert!(
+            all_corners_fit_in_frustum(&mvp, min, max),
+            "portrait viewport: corners outside frustum"
+        );
+    }
+
+    #[test]
+    fn mvp_3d_landscape_viewport_fits_geometry() {
+        let cam = Camera::new();
+        let min = [-5.0f32, -5.0, -5.0];
+        let max = [5.0f32, 5.0, 5.0];
+        let mvp = cam.compute_mvp_3d(min, max, 800, 600);
+        assert!(
+            all_corners_fit_in_frustum(&mvp, min, max),
+            "landscape viewport: corners outside frustum"
+        );
+    }
+
+    #[test]
+    fn mvp_3d_fills_viewport_at_reset_orientation() {
+        // At the framing elevation (el=20°) the tight axis should reach ≥ 80% NDC.
+        // The cylinder framing uses r_cyl ≥ half.x so the scene is slightly farther
+        // than the exact AABB fit, but non-cubic geometry must not be over-scaled.
+        let cam = Camera::new();
+        let mvp = cam.compute_mvp_3d(TALL_MIN, TALL_MAX, 800, 600);
+
+        let max_ndc_y = bounding_box_corners(TALL_MIN, TALL_MAX)
+            .iter()
+            .map(|&c| {
+                let clip = mvp.matrix * glam::Vec4::new(c[0], c[1], c[2], 1.0);
+                (clip.y / clip.w).abs()
+            })
+            .fold(0.0f32, f32::max);
+
+        assert!(
+            max_ndc_y >= 0.80,
+            "geometry fills only {max_ndc_y:.3} of viewport height, expected ≥ 0.80"
+        );
+    }
+
+    #[test]
+    fn mvp_3d_distance_stable_under_orbit() {
+        // Orbiting must not change the framing distance; otherwise the scene
+        // appears to pulse in size during auto-rotation.
+        // clip_w of the bounding-box center equals the camera-to-center distance.
+        let mut cam = Camera::new();
+        let dist0 = center_clip_w(&cam, TALL_MIN, TALL_MAX);
+        cam.orbit_by(45.0, 0.0);
+        let dist45 = center_clip_w(&cam, TALL_MIN, TALL_MAX);
+        assert!(
+            (dist0 - dist45).abs() < 0.01,
+            "distance changed after orbit: {dist0:.3} vs {dist45:.3}"
+        );
+    }
+
+    fn center_clip_w(cam: &Camera, min: [f32; 3], max: [f32; 3]) -> f32 {
+        let [cx, cy, cz] = [
+            (min[0] + max[0]) * 0.5,
+            (min[1] + max[1]) * 0.5,
+            (min[2] + max[2]) * 0.5,
+        ];
+        (cam.compute_mvp_3d(min, max, 800, 600).matrix * glam::Vec4::new(cx, cy, cz, 1.0)).w
+    }
+
+    #[test]
+    fn mvp_3d_zoom_halves_framing_distance() {
+        let mut cam = Camera::new();
+        let dist1 = center_clip_w(&cam, TALL_MIN, TALL_MAX);
+        cam.zoom_3d(2.0);
+        let dist2 = center_clip_w(&cam, TALL_MIN, TALL_MAX);
+        assert!(
+            (dist2 - dist1 * 0.5).abs() < 0.01,
+            "2× zoom should halve distance: {dist1:.3} → {dist2:.3}"
+        );
+    }
+
+    #[test]
+    fn mvp_3d_framing_distance_stable_under_elevation_orbit() {
+        // framing_elevation is fixed at reset; orbiting elevation must not
+        // reprice the framing distance (which would cause size pulsing).
+        let mut cam = Camera::new();
+        let dist0 = center_clip_w(&cam, TALL_MIN, TALL_MAX);
+        cam.orbit_by(0.0, 50.0);
+        let dist50 = center_clip_w(&cam, TALL_MIN, TALL_MAX);
+        assert!(
+            (dist0 - dist50).abs() < 0.01,
+            "distance changed after elevation orbit: {dist0:.3} vs {dist50:.3}"
+        );
+    }
+
+    #[test]
+    fn mvp_3d_reset_restores_framing_elevation() {
+        // reset() must restore framing_elevation to 20° so the framing distance
+        // is identical to a freshly constructed Camera.
+        let dist_fresh = center_clip_w(&Camera::new(), TALL_MIN, TALL_MAX);
+        let mut cam = Camera::new();
+        cam.orbit_by(0.0, 60.0); // move to a different elevation
+        cam.reset();
+        let dist_after_reset = center_clip_w(&cam, TALL_MIN, TALL_MAX);
+        assert!(
+            (dist_fresh - dist_after_reset).abs() < 0.01,
+            "reset() should restore framing: fresh={dist_fresh:.3}, after reset={dist_after_reset:.3}"
+        );
+    }
+
+    #[test]
+    fn mvp_3d_reset_position_captures_elevation() {
+        // reset_position() must update framing_elevation to the live elevation.
+        // After calling it at 60°, the framing distance must differ from the
+        // default 20° framing distance (i.e. the capture actually took effect).
+        let dist_default = center_clip_w(&Camera::new(), TALL_MIN, TALL_MAX);
+        let mut cam = Camera::new();
+        cam.orbit_by(0.0, 60.0);
+        cam.reset_position();
+        let dist_captured = center_clip_w(&cam, TALL_MIN, TALL_MAX);
+        assert!(
+            (dist_captured - dist_default).abs() > 1.0,
+            "reset_position() should have updated framing_elevation: \
+             default={dist_default:.3}, captured={dist_captured:.3}"
+        );
+    }
+
+    #[test]
+    fn mvp_3d_cylinder_fits_corners_at_all_azimuths() {
+        // The bounding cylinder framing must keep all AABB corners inside the
+        // frustum at every azimuth during auto-rotation.
+        let min = [-8.0f32, 0.0, -6.0];
+        let max = [8.0f32, 50.0, 6.0]; // asymmetric XZ — worst case for AABB-only framing
+        let mut cam = Camera::new();
+        for az_step in 0..8 {
+            cam.azimuth = az_step as f32 * 45.0;
+            let mvp = cam.compute_mvp_3d(min, max, 800, 600);
+            assert!(
+                all_corners_fit_in_frustum(&mvp, min, max),
+                "corners outside frustum at azimuth={}°",
+                cam.azimuth
+            );
+        }
     }
 }


### PR DESCRIPTION
## Summary

Rewrites `compute_mvp_3d` to use an aspect-ratio-aware bounding-cylinder frustum-fit instead of a fixed bounding-sphere distance.

**What changed in `compute_mvp_3d`:**
- Previously, camera distance was derived from the bounding-sphere radius and sized only for the vertical FOV, ignoring viewport aspect ratio. Wide geometry on portrait screens and tall geometry on landscape screens were framed too loosely.
- Now, a bounding cylinder is computed (radius = `hypot(hx, hz)`, the XZ diagonal of the AABB half-extents). The minimum camera distance is solved analytically for both the horizontal and vertical frustum planes using the actual `half_fov_x_tan` and `half_fov_y_tan`, so geometry fills the tighter axis regardless of aspect ratio or shape.
- Framing is evaluated at a fixed `framing_elevation` (captured on `reset`/`reset_position`) rather than the live orbit elevation. Because the cylinder is azimuth-symmetric, the framing distance is constant at all azimuths during auto-rotation.
- The hard `max(1.0)` distance floor is replaced with `max(r_cyl.max(half_y) * NEAR_CLIP_RATIO)`, which scales with scene size. `NEAR_CLIP_RATIO` is shared with the `z_near` computation.

**New `framing_elevation` field on `Camera`:**
- Stores the elevation at the time of the last `reset` or `reset_position` call.
- Decouples the framing distance from the live orbit elevation, so the apparent size of the scene stays constant while the user orbits.

**Known limitation:** `r_cyl = hypot(hx, hz)` is the radius of a circumscribed square prism rather than the true bounding cylinder. For shapes where the XZ extents are unequal (e.g. flat `[-10,0,-10]..[10,0,10]` in an 800×800 viewport), the fit uses only ~63% of the viewport. Computing the exact cylinder radius requires streaming over all geometry vertices to find the maximum XZ distance from the rotation axis; tracked in #102.

## Tests

Nine new tests added to `camera.rs`: corner containment at all 8 azimuths for asymmetric XZ geometry, framing distance stability under azimuth and elevation orbit, zoom scaling, `reset`/`reset_position` contracts, portrait viewport, and landscape viewport.