### PR TITLE
Add per-field default controls for colors

### DIFF
--- a/crates/lsystem-app-model/src/color.rs
+++ b/crates/lsystem-app-model/src/color.rs
@@ -13,15 +13,7 @@ pub enum LineColorMode {
 impl LineColorMode {
     pub const ALL: &'static [Self] = &[Self::Solid, Self::Gradient, Self::HueCycle];
 
-    pub fn from_line_color(line_color: &LineColorConfig) -> Self {
-        match line_color {
-            LineColorConfig::Solid(_) => Self::Solid,
-            LineColorConfig::Gradient { .. } => Self::Gradient,
-            LineColorConfig::HueCycle { .. } => Self::HueCycle,
-        }
-    }
-
-    pub fn from_editor_line_color(line_color: &EditorLineColorConfig) -> Self {
+    pub fn from_line_color(line_color: &EditorLineColorConfig) -> Self {
         match line_color {
             EditorLineColorConfig::Solid(_) => Self::Solid,
             EditorLineColorConfig::Gradient { .. } => Self::Gradient,
@@ -66,11 +58,11 @@ pub struct ColorControlMemory {
     hue_cycle: Option<Rgb>,
 }
 
-#[derive(Clone, Copy, Debug)]
+#[derive(Clone, Copy, Debug, Default)]
 struct RememberedGradient {
-    start: Rgb,
-    end: Rgb,
-    topological_depth: bool,
+    start: Option<Rgb>,
+    end: Option<Rgb>,
+    topological_depth: Option<bool>,
 }
 
 impl ColorControlMemory {
@@ -87,7 +79,7 @@ impl ColorControlMemory {
             gradient: None,
             hue_cycle: None,
         };
-        memory.remember_line(line_color_for_controls(editor, &defaults.line));
+        memory.remember_line(editor.line);
         memory
     }
 
@@ -104,13 +96,13 @@ impl ColorControlMemory {
     }
 
     pub fn gradient_fields(&self) -> (Rgb, Rgb, bool) {
-        let defaults = self.line_defaults.gradient;
-        let gradient = self.gradient.unwrap_or(RememberedGradient {
-            start: defaults.start,
-            end: defaults.end,
-            topological_depth: defaults.topological_depth,
-        });
-        (gradient.start, gradient.end, gradient.topological_depth)
+        let d = self.line_defaults.gradient;
+        let rg = self.gradient.unwrap_or_default();
+        (
+            rg.start.unwrap_or(d.start),
+            rg.end.unwrap_or(d.end),
+            rg.topological_depth.unwrap_or(d.topological_depth),
+        )
     }
 
     pub fn hue_cycle_initial(&self) -> Rgb {
@@ -118,38 +110,39 @@ impl ColorControlMemory {
             .unwrap_or(self.line_defaults.hue_cycle.initial)
     }
 
-    pub fn remember_line(&mut self, line_color: LineColorConfig) {
+    pub fn remember_line(&mut self, line_color: Option<EditorLineColorConfig>) {
         match line_color {
-            LineColorConfig::Solid(color) => self.solid = Some(color),
-            LineColorConfig::Gradient {
+            None => self.solid = None,
+            Some(EditorLineColorConfig::Solid(color)) => self.solid = Some(color),
+            Some(EditorLineColorConfig::Gradient {
                 start,
                 end,
                 topological_depth,
-            } => {
+            }) => {
                 self.gradient = Some(RememberedGradient {
                     start,
                     end,
                     topological_depth,
                 });
             }
-            LineColorConfig::HueCycle { initial } => self.hue_cycle = Some(initial),
+            Some(EditorLineColorConfig::HueCycle { initial }) => self.hue_cycle = initial,
         }
     }
 
-    pub fn line_for(&self, mode: LineColorMode) -> LineColorConfig {
+    pub fn line_for(&self, mode: LineColorMode) -> Option<EditorLineColorConfig> {
         match mode {
-            LineColorMode::Solid => LineColorConfig::Solid(self.solid_color()),
+            LineColorMode::Solid => self.solid.map(EditorLineColorConfig::Solid),
             LineColorMode::Gradient => {
-                let (start, end, topological_depth) = self.gradient_fields();
-                LineColorConfig::Gradient {
-                    start,
-                    end,
-                    topological_depth,
-                }
+                let rg = self.gradient.unwrap_or_default();
+                Some(EditorLineColorConfig::Gradient {
+                    start: rg.start,
+                    end: rg.end,
+                    topological_depth: rg.topological_depth,
+                })
             }
-            LineColorMode::HueCycle => LineColorConfig::HueCycle {
-                initial: self.hue_cycle_initial(),
-            },
+            LineColorMode::HueCycle => Some(EditorLineColorConfig::HueCycle {
+                initial: self.hue_cycle,
+            }),
         }
     }
 }
@@ -177,7 +170,7 @@ pub fn selected_line_color_mode(editor: &EditorColorConfig) -> LineColorMode {
     editor
         .line
         .as_ref()
-        .map(LineColorMode::from_editor_line_color)
+        .map(LineColorMode::from_line_color)
         .unwrap_or(LineColorMode::Solid)
 }
 
@@ -191,21 +184,6 @@ mod tests {
     use super::{
         ColorControlMemory, LineColorMode, line_color_for_controls, selected_line_color_mode,
     };
-
-    fn default_gradient() -> LineColorConfig {
-        let defaults = ConfigDefaults::embedded().colors.line.gradient;
-        LineColorConfig::Gradient {
-            start: defaults.start,
-            end: defaults.end,
-            topological_depth: defaults.topological_depth,
-        }
-    }
-
-    fn default_hue_cycle() -> LineColorConfig {
-        LineColorConfig::HueCycle {
-            initial: ConfigDefaults::embedded().colors.line.hue_cycle.initial,
-        }
-    }
 
     fn custom_color_defaults() -> ColorDefaults {
         let mut defaults = ConfigDefaults::embedded().colors;
@@ -300,7 +278,7 @@ mod tests {
     }
 
     #[test]
-    fn color_memory_inactive_line_slots_use_supplied_defaults() {
+    fn color_memory_inactive_line_slots_use_none_for_defaults() {
         let defaults = custom_color_defaults();
         let hue_active_memory = ColorControlMemory::from_editor_config(
             &EditorColorConfig {
@@ -312,17 +290,14 @@ mod tests {
             &defaults,
         );
 
-        assert_eq!(
-            hue_active_memory.line_for(LineColorMode::Solid),
-            LineColorConfig::Solid(defaults.line.solid)
-        );
+        assert_eq!(hue_active_memory.line_for(LineColorMode::Solid), None);
         assert_eq!(
             hue_active_memory.line_for(LineColorMode::Gradient),
-            LineColorConfig::Gradient {
-                start: defaults.line.gradient.start,
-                end: defaults.line.gradient.end,
-                topological_depth: defaults.line.gradient.topological_depth,
-            }
+            Some(EditorLineColorConfig::Gradient {
+                start: None,
+                end: None,
+                topological_depth: None,
+            })
         );
 
         let solid_active_memory = ColorControlMemory::from_editor_config(
@@ -335,9 +310,7 @@ mod tests {
 
         assert_eq!(
             solid_active_memory.line_for(LineColorMode::HueCycle),
-            LineColorConfig::HueCycle {
-                initial: defaults.line.hue_cycle.initial,
-            }
+            Some(EditorLineColorConfig::HueCycle { initial: None })
         );
     }
 
@@ -356,38 +329,8 @@ mod tests {
     }
 
     #[test]
-    fn line_color_mode_from_line_color() {
-        assert_eq!(
-            LineColorMode::from_line_color(&LineColorConfig::Solid(Rgb::new(0x1a, 0x33, 0x4d))),
-            LineColorMode::Solid
-        );
-        assert_eq!(
-            LineColorMode::from_line_color(&LineColorConfig::Gradient {
-                start: Rgb::new(0x1a, 0x33, 0x4d),
-                end: Rgb::new(0x80, 0x99, 0xb3),
-                topological_depth: false,
-            }),
-            LineColorMode::Gradient
-        );
-        assert_eq!(
-            LineColorMode::from_line_color(&LineColorConfig::HueCycle {
-                initial: Rgb::new(0xe5, 0x1a, 0x33),
-            }),
-            LineColorMode::HueCycle
-        );
-        assert_eq!(
-            LineColorMode::from_line_color(&LineColorConfig::Gradient {
-                start: Rgb::new(0x1a, 0x33, 0x4d),
-                end: Rgb::new(0x80, 0x99, 0xb3),
-                topological_depth: true,
-            }),
-            LineColorMode::Gradient
-        );
-    }
-
-    #[test]
     fn color_memory_remembers_solid_across_mode_switch() {
-        let solid = LineColorConfig::Solid(Rgb::new(0xff, 0x00, 0x00));
+        let solid = Some(EditorLineColorConfig::Solid(Rgb::new(0xff, 0x00, 0x00)));
         let mut memory = ColorControlMemory::from_editor_config(
             &EditorColorConfig {
                 background: None,
@@ -395,25 +338,37 @@ mod tests {
             },
             &ConfigDefaults::embedded().colors,
         );
-        memory.remember_line(default_gradient());
+        memory.remember_line(Some(EditorLineColorConfig::Gradient {
+            start: None,
+            end: None,
+            topological_depth: None,
+        }));
         assert_eq!(memory.line_for(LineColorMode::Solid), solid);
     }
 
     #[test]
-    fn color_memory_falls_back_to_default_when_slot_unset() {
+    fn color_memory_unvisited_slots_return_all_none() {
         let memory = ColorControlMemory::from_editor_config(
             &EditorColorConfig::default(),
             &ConfigDefaults::embedded().colors,
         );
-        assert_eq!(memory.line_for(LineColorMode::Gradient), default_gradient());
+        assert_eq!(memory.line_for(LineColorMode::Solid), None);
+        assert_eq!(
+            memory.line_for(LineColorMode::Gradient),
+            Some(EditorLineColorConfig::Gradient {
+                start: None,
+                end: None,
+                topological_depth: None,
+            })
+        );
         assert_eq!(
             memory.line_for(LineColorMode::HueCycle),
-            default_hue_cycle()
+            Some(EditorLineColorConfig::HueCycle { initial: None })
         );
     }
 
     #[test]
-    fn editor_line_color_preserves_authored_topological_depth() {
+    fn line_color_preserves_authored_topological_depth() {
         let editor = EditorColorConfig {
             background: None,
             line: Some(EditorLineColorConfig::Gradient {
@@ -423,29 +378,27 @@ mod tests {
             }),
         };
 
-        let expected = LineColorConfig::Gradient {
-            start: Rgb::new(0x1a, 0x33, 0x4d),
-            end: Rgb::new(0x80, 0x99, 0xb3),
-            topological_depth: true,
-        };
         assert_eq!(
             line_color_for_controls(&editor, &ConfigDefaults::embedded().colors.line),
-            expected
+            LineColorConfig::Gradient {
+                start: Rgb::new(0x1a, 0x33, 0x4d),
+                end: Rgb::new(0x80, 0x99, 0xb3),
+                topological_depth: true,
+            }
         );
         assert_eq!(
             ColorControlMemory::from_editor_config(&editor, &ConfigDefaults::embedded().colors)
                 .line_for(LineColorMode::Gradient),
-            expected
+            Some(EditorLineColorConfig::Gradient {
+                start: Some(Rgb::new(0x1a, 0x33, 0x4d)),
+                end: Some(Rgb::new(0x80, 0x99, 0xb3)),
+                topological_depth: Some(true),
+            })
         );
     }
 
     #[test]
     fn color_memory_preserves_gradient_topological_depth_flag() {
-        let topological = LineColorConfig::Gradient {
-            start: Rgb::new(0x1a, 0x33, 0x4d),
-            end: Rgb::new(0xb3, 0xcc, 0xe6),
-            topological_depth: true,
-        };
         let mut memory = ColorControlMemory::from_editor_config(
             &EditorColorConfig {
                 background: None,
@@ -457,11 +410,18 @@ mod tests {
             },
             &ConfigDefaults::embedded().colors,
         );
-        memory.remember_line(LineColorConfig::HueCycle {
-            initial: Rgb::new(0xff, 0x00, 0x00),
-        });
+        memory.remember_line(Some(EditorLineColorConfig::HueCycle {
+            initial: Some(Rgb::new(0xff, 0x00, 0x00)),
+        }));
 
-        assert_eq!(memory.line_for(LineColorMode::Gradient), topological);
+        assert_eq!(
+            memory.line_for(LineColorMode::Gradient),
+            Some(EditorLineColorConfig::Gradient {
+                start: Some(Rgb::new(0x1a, 0x33, 0x4d)),
+                end: Some(Rgb::new(0xb3, 0xcc, 0xe6)),
+                topological_depth: Some(true),
+            })
+        );
     }
 
     #[test]
@@ -475,10 +435,7 @@ mod tests {
             &ConfigDefaults::embedded().colors,
         );
         assert_eq!(memory.background(), bg);
-        assert_eq!(
-            memory.line_for(LineColorMode::Solid),
-            LineColorConfig::Solid(ConfigDefaults::embedded().colors.line.solid)
-        );
+        assert_eq!(memory.line_for(LineColorMode::Solid), None);
         let new_bg = Rgb::new(0xe5, 0xcc, 0xb3);
         memory.remember_background(new_bg);
         assert_eq!(memory.background(), new_bg);

--- a/crates/lsystem-app-model/src/config_workspace.rs
+++ b/crates/lsystem-app-model/src/config_workspace.rs
@@ -3,10 +3,10 @@ use std::collections::BTreeSet;
 
 use thiserror::Error;
 
-use lsystem_core::{Dimensions, LineColorConfig, Rgb};
+use lsystem_core::{Dimensions, Rgb};
 
 use crate::config_defaults::ParseConfigError;
-use crate::editor_config::{ConfigDocument, ConfigSource, EditorConfig};
+use crate::editor_config::{ConfigDocument, ConfigSource, EditorConfig, EditorLineColorConfig};
 
 #[derive(Debug, Error)]
 pub enum ConfigWorkspaceError {
@@ -380,9 +380,12 @@ impl CleanMut<'_> {
             .update_last_applied_source(|source| source.set_background(background))
     }
 
-    pub fn set_line_color(&mut self, line_color: LineColorConfig) -> Result<(), ParseConfigError> {
+    pub fn set_line_color(
+        &mut self,
+        line_color: Option<EditorLineColorConfig>,
+    ) -> Result<(), ParseConfigError> {
         self.0
-            .update_last_applied_source(|source| source.set_line_color(&line_color))
+            .update_last_applied_source(|source| source.set_line_color(line_color.as_ref()))
     }
 }
 
@@ -398,7 +401,7 @@ impl DirtyMut<'_> {
 mod tests {
     use super::*;
 
-    use lsystem_core::ConfigError;
+    use lsystem_core::{ConfigError, LineColorConfig};
 
     use crate::config_defaults::ConfigDefaults;
 
@@ -998,7 +1001,9 @@ solid = "#00e680"
         let mut workspace = ConfigWorkspace::from_presets(vec![("First", first)]).unwrap();
 
         clean_mut(&mut workspace)
-            .set_line_color(LineColorConfig::Solid(Rgb::new(0x33, 0x4d, 0x66)))
+            .set_line_color(Some(EditorLineColorConfig::Solid(Rgb::new(
+                0x33, 0x4d, 0x66,
+            ))))
             .unwrap();
         assert_eq!(
             runtime_config(workspace.selected()).colors.line,
@@ -1006,11 +1011,11 @@ solid = "#00e680"
         );
 
         clean_mut(&mut workspace)
-            .set_line_color(LineColorConfig::Gradient {
-                start: Rgb::new(0x1a, 0x33, 0x4d),
-                end: Rgb::new(0xb3, 0xcc, 0xe6),
-                topological_depth: false,
-            })
+            .set_line_color(Some(EditorLineColorConfig::Gradient {
+                start: Some(Rgb::new(0x1a, 0x33, 0x4d)),
+                end: Some(Rgb::new(0xb3, 0xcc, 0xe6)),
+                topological_depth: Some(false),
+            }))
             .unwrap();
         assert_eq!(
             runtime_config(workspace.selected()).colors.line,
@@ -1022,9 +1027,9 @@ solid = "#00e680"
         );
 
         clean_mut(&mut workspace)
-            .set_line_color(LineColorConfig::HueCycle {
-                initial: Rgb::new(0x40, 0x80, 0xbf),
-            })
+            .set_line_color(Some(EditorLineColorConfig::HueCycle {
+                initial: Some(Rgb::new(0x40, 0x80, 0xbf)),
+            }))
             .unwrap();
         assert_eq!(
             runtime_config(workspace.selected()).colors.line,
@@ -1036,11 +1041,11 @@ solid = "#00e680"
         // topological_depth: true is preserved faithfully even for bracketless grammars —
         // normalization happens at the geometry-allocation boundary, not in resolved Config.
         clean_mut(&mut workspace)
-            .set_line_color(LineColorConfig::Gradient {
-                start: Rgb::new(0x33, 0x4d, 0x66),
-                end: Rgb::new(0x80, 0x99, 0xb3),
-                topological_depth: true,
-            })
+            .set_line_color(Some(EditorLineColorConfig::Gradient {
+                start: Some(Rgb::new(0x33, 0x4d, 0x66)),
+                end: Some(Rgb::new(0x80, 0x99, 0xb3)),
+                topological_depth: Some(true),
+            }))
             .unwrap();
         assert_eq!(
             runtime_config(workspace.selected()).colors.line,
@@ -1058,11 +1063,11 @@ solid = "#00e680"
         let mut workspace = ConfigWorkspace::from_presets(vec![("First", first)]).unwrap();
 
         clean_mut(&mut workspace)
-            .set_line_color(LineColorConfig::Gradient {
-                start: Rgb::new(0x1a, 0x33, 0x4d),
-                end: Rgb::new(0xb3, 0xcc, 0xe6),
-                topological_depth: false,
-            })
+            .set_line_color(Some(EditorLineColorConfig::Gradient {
+                start: Some(Rgb::new(0x1a, 0x33, 0x4d)),
+                end: Some(Rgb::new(0xb3, 0xcc, 0xe6)),
+                topological_depth: Some(false),
+            }))
             .unwrap();
         let text = workspace.selected().draft_text().into_owned();
         assert!(text.contains("[colors.line.gradient]"));
@@ -1072,9 +1077,9 @@ solid = "#00e680"
         assert!(!text.contains("initial ="));
 
         clean_mut(&mut workspace)
-            .set_line_color(LineColorConfig::HueCycle {
-                initial: Rgb::new(0x66, 0x80, 0x99),
-            })
+            .set_line_color(Some(EditorLineColorConfig::HueCycle {
+                initial: Some(Rgb::new(0x66, 0x80, 0x99)),
+            }))
             .unwrap();
         let text = workspace.selected().draft_text().into_owned();
         assert!(text.contains("[colors.line.hue_cycle]"));
@@ -1084,7 +1089,9 @@ solid = "#00e680"
         assert!(!text.contains("end ="));
 
         clean_mut(&mut workspace)
-            .set_line_color(LineColorConfig::Solid(Rgb::new(0x33, 0x4d, 0x66)))
+            .set_line_color(Some(EditorLineColorConfig::Solid(Rgb::new(
+                0x33, 0x4d, 0x66,
+            ))))
             .unwrap();
         let text = workspace.selected().draft_text().into_owned();
         assert!(text.contains("solid = \"#334d66\""));
@@ -1093,11 +1100,11 @@ solid = "#00e680"
         assert!(!text.contains("end ="));
 
         clean_mut(&mut workspace)
-            .set_line_color(LineColorConfig::Gradient {
-                start: Rgb::new(0x1a, 0x33, 0x4d),
-                end: Rgb::new(0x66, 0x80, 0x99),
-                topological_depth: true,
-            })
+            .set_line_color(Some(EditorLineColorConfig::Gradient {
+                start: Some(Rgb::new(0x1a, 0x33, 0x4d)),
+                end: Some(Rgb::new(0x66, 0x80, 0x99)),
+                topological_depth: Some(true),
+            }))
             .unwrap();
         let text = workspace.selected().draft_text().into_owned();
         assert!(text.contains("[colors.line.gradient]"));
@@ -1139,7 +1146,9 @@ solid = "#00e680" # keep line color comment
             .set_background(Some(Rgb::new(0x1a, 0x33, 0x4d)))
             .unwrap();
         clean_mut(&mut workspace)
-            .set_line_color(LineColorConfig::Solid(Rgb::new(0x66, 0x80, 0x99)))
+            .set_line_color(Some(EditorLineColorConfig::Solid(Rgb::new(
+                0x66, 0x80, 0x99,
+            ))))
             .unwrap();
 
         let text = workspace.selected().draft_text().into_owned();
@@ -1179,11 +1188,11 @@ end = "#ffffff"
             .set_background(Some(Rgb::new(0x1a, 0x33, 0x4d)))
             .unwrap();
         clean_mut(&mut workspace)
-            .set_line_color(LineColorConfig::Gradient {
-                start: Rgb::new(0x66, 0x80, 0x99),
-                end: Rgb::new(0xb3, 0xcc, 0xe6),
-                topological_depth: false,
-            })
+            .set_line_color(Some(EditorLineColorConfig::Gradient {
+                start: Some(Rgb::new(0x66, 0x80, 0x99)),
+                end: Some(Rgb::new(0xb3, 0xcc, 0xe6)),
+                topological_depth: Some(false),
+            }))
             .unwrap();
 
         let text = workspace.selected().draft_text().into_owned();
@@ -1208,7 +1217,9 @@ end = "#ffffff"
         assert!(!workspace.can_reset());
 
         clean_mut(&mut workspace)
-            .set_line_color(LineColorConfig::Solid(Rgb::new(0x1a, 0x33, 0x4d)))
+            .set_line_color(Some(EditorLineColorConfig::Solid(Rgb::new(
+                0x1a, 0x33, 0x4d,
+            ))))
             .unwrap();
 
         assert!(workspace.can_reset());
@@ -1247,11 +1258,11 @@ end = "#ffffff"
                 .set_background(Some(Rgb::new(0x1a, 0x33, 0x4d)))
                 .unwrap();
             clean
-                .set_line_color(LineColorConfig::Gradient {
-                    start: Rgb::new(0x66, 0x80, 0x99),
-                    end: Rgb::new(0xb3, 0xcc, 0xe6),
-                    topological_depth: true,
-                })
+                .set_line_color(Some(EditorLineColorConfig::Gradient {
+                    start: Some(Rgb::new(0x66, 0x80, 0x99)),
+                    end: Some(Rgb::new(0xb3, 0xcc, 0xe6)),
+                    topological_depth: Some(true),
+                }))
                 .unwrap();
         }
 
@@ -1425,6 +1436,70 @@ end = "#ffffff"
         let err = workspace.rename(0, "Second").unwrap_err();
         assert!(matches!(err, ConfigWorkspaceError::DuplicateName(ref n) if n == "Second"));
         assert_eq!(workspace.selected().name(), "First");
+    }
+
+    #[test]
+    fn clean_entry_set_line_color_none_removes_colors_line_and_resolves_to_solid_default() {
+        let first = config_text("First", "F", 60.0);
+        let mut workspace = ConfigWorkspace::from_presets(vec![("First", first)]).unwrap();
+
+        clean_mut(&mut workspace).set_line_color(None).unwrap();
+
+        let entry = workspace.selected();
+        assert!(
+            !entry.draft_text().contains("[colors.line"),
+            "colors.line must be absent"
+        );
+        assert!(
+            !entry.draft_text().contains("solid ="),
+            "solid key must be absent"
+        );
+        assert!(entry.editor_config().colors.line.is_none());
+        assert!(matches!(
+            runtime_config(entry).colors.line,
+            LineColorConfig::Solid(_)
+        ));
+    }
+
+    #[test]
+    fn clean_entry_set_line_color_gradient_preserves_none_fields() {
+        let first = config_text("First", "F", 60.0);
+        let mut workspace = ConfigWorkspace::from_presets(vec![("First", first)]).unwrap();
+
+        clean_mut(&mut workspace)
+            .set_line_color(Some(EditorLineColorConfig::Gradient {
+                start: Some(Rgb::new(0x11, 0x22, 0x33)),
+                end: None,
+                topological_depth: None,
+            }))
+            .unwrap();
+
+        let entry = workspace.selected();
+        assert!(
+            entry.draft_text().contains("#112233"),
+            "authored start present"
+        );
+        assert!(
+            !entry.draft_text().contains("end ="),
+            "absent end must not appear"
+        );
+        assert!(
+            !entry.draft_text().contains("topological_depth"),
+            "absent td must not appear"
+        );
+        assert_eq!(
+            entry.editor_config().colors.line,
+            Some(EditorLineColorConfig::Gradient {
+                start: Some(Rgb::new(0x11, 0x22, 0x33)),
+                end: None,
+                topological_depth: None,
+            })
+        );
+        let expected_end = ConfigDefaults::embedded().colors.line.gradient.end;
+        assert!(matches!(
+            runtime_config(entry).colors.line,
+            LineColorConfig::Gradient { end, .. } if end == expected_end
+        ));
     }
 
     #[test]

--- a/crates/lsystem-app-model/src/editor_config.rs
+++ b/crates/lsystem-app-model/src/editor_config.rs
@@ -118,6 +118,19 @@ pub enum EditorLineColorConfig {
 }
 
 impl EditorLineColorConfig {
+    /// Returns the gradient fields `(start, end, topological_depth)` if `self` is
+    /// `Gradient`, or `(None, None, None)` for any other variant.
+    pub fn gradient_fields(self) -> (Option<Rgb>, Option<Rgb>, Option<bool>) {
+        match self {
+            Self::Gradient {
+                start,
+                end,
+                topological_depth,
+            } => (start, end, topological_depth),
+            _ => (None, None, None),
+        }
+    }
+
     pub fn resolve(self, defaults: &LineColorDefaults) -> LineColorConfig {
         match self {
             Self::Solid(color) => LineColorConfig::Solid(color),
@@ -435,34 +448,35 @@ impl ConfigSource {
         }
     }
 
-    pub fn set_line_color(&mut self, line_color: &LineColorConfig) {
-        let line = line_table_mut(&mut self.document);
+    pub fn set_line_color(&mut self, line_color: Option<&EditorLineColorConfig>) {
         match line_color {
-            LineColorConfig::Solid(color) => {
+            None => {
+                if let Some(colors) = self.document["colors"].as_table_mut() {
+                    colors.remove("line");
+                }
+            }
+            Some(EditorLineColorConfig::Solid(color)) => {
+                let line = line_table_mut(&mut self.document);
                 remove_inactive_line_color_entries(line, "solid");
                 set_value_preserving_decor(&mut line["solid"], Value::from(color.to_string()));
             }
-            LineColorConfig::Gradient {
+            Some(EditorLineColorConfig::Gradient {
                 start,
                 end,
                 topological_depth,
-            } => {
+            }) => {
+                let line = line_table_mut(&mut self.document);
                 remove_inactive_line_color_entries(line, "gradient");
                 let gradient = line_color_table_mut(line, "gradient");
-                set_value_preserving_decor(&mut gradient["start"], Value::from(start.to_string()));
-                set_value_preserving_decor(&mut gradient["end"], Value::from(end.to_string()));
-                set_value_preserving_decor(
-                    &mut gradient["topological_depth"],
-                    Value::from(*topological_depth),
-                );
+                set_or_remove_optional_rgb(gradient, "start", *start);
+                set_or_remove_optional_rgb(gradient, "end", *end);
+                set_or_remove_optional_bool(gradient, "topological_depth", *topological_depth);
             }
-            LineColorConfig::HueCycle { initial } => {
+            Some(EditorLineColorConfig::HueCycle { initial }) => {
+                let line = line_table_mut(&mut self.document);
                 remove_inactive_line_color_entries(line, "hue_cycle");
                 let hue_cycle = line_color_table_mut(line, "hue_cycle");
-                set_value_preserving_decor(
-                    &mut hue_cycle["initial"],
-                    Value::from(initial.to_string()),
-                );
+                set_or_remove_optional_rgb(hue_cycle, "initial", *initial);
             }
         }
     }
@@ -576,6 +590,24 @@ fn line_table_mut(document: &mut DocumentMut) -> &mut Table {
     colors["line"]
         .as_table_mut()
         .expect("colors.line table was just ensured")
+}
+
+fn set_or_remove_optional_rgb(table: &mut Table, key: &str, value: Option<Rgb>) {
+    match value {
+        Some(rgb) => set_value_preserving_decor(&mut table[key], Value::from(rgb.to_string())),
+        None => {
+            table.remove(key);
+        }
+    }
+}
+
+fn set_or_remove_optional_bool(table: &mut Table, key: &str, value: Option<bool>) {
+    match value {
+        Some(b) => set_value_preserving_decor(&mut table[key], Value::from(b)),
+        None => {
+            table.remove(key);
+        }
+    }
 }
 
 #[cfg(test)]
@@ -739,6 +771,83 @@ background = "#000000"
 solid = "#00e680"
 "##
         )
+    }
+
+    fn minimal_toml(name: &str) -> String {
+        format!(
+            r#"[metadata]
+name = "{name}"
+
+[l-system]
+dimensions = "2D"
+axiom = "F"
+iterations = 1
+
+[l-system.rules]
+F = "F"
+
+[turtle]
+angle = 90.0
+
+[colors]
+"#
+        )
+    }
+
+    #[test]
+    fn set_line_color_none_removes_colors_line() {
+        let toml = r##"
+[metadata]
+name = "t"
+[l-system]
+dimensions = "2D"
+axiom = "F"
+iterations = 1
+[l-system.rules]
+F = "F"
+[turtle]
+angle = 90.0
+[colors.line.hue_cycle]
+initial = "#e60000"
+"##;
+        let mut source = ConfigSource::parse(toml).unwrap();
+        source.set_line_color(None);
+        let out = source.to_toml_string();
+        assert!(!out.contains("hue_cycle"), "colors.line must be removed");
+    }
+
+    #[test]
+    fn set_line_color_gradient_omits_none_fields() {
+        let toml = minimal_toml("t");
+        let mut source = ConfigSource::parse(&toml).unwrap();
+        source.set_line_color(Some(&EditorLineColorConfig::Gradient {
+            start: Some(Rgb::new(0x11, 0x22, 0x33)),
+            end: None,
+            topological_depth: None,
+        }));
+        let out = source.to_toml_string();
+        assert!(out.contains("#112233"), "start must be written");
+        assert!(!out.contains("end"), "absent end must not be written");
+        assert!(
+            !out.contains("topological_depth"),
+            "absent td must not be written"
+        );
+    }
+
+    #[test]
+    fn set_line_color_hue_cycle_omits_none_initial() {
+        let toml = minimal_toml("t");
+        let mut source = ConfigSource::parse(&toml).unwrap();
+        source.set_line_color(Some(&EditorLineColorConfig::HueCycle { initial: None }));
+        let out = source.to_toml_string();
+        assert!(
+            out.contains("[colors.line"),
+            "hue_cycle table header must be present"
+        );
+        assert!(
+            !out.contains("initial"),
+            "absent initial must not be written"
+        );
     }
 
     #[test]
@@ -1964,146 +2073,6 @@ solid = "#00e680"
         assert_eq!(
             resolve_doc(&doc).colors.background,
             Rgb::new(0xff, 0x80, 0x00)
-        );
-    }
-
-    #[test]
-    fn set_line_color_writes_hex_strings() {
-        let toml = test_toml(Dimensions::TwoD, "F", 1, "90.0", "1.0", "0.0", "");
-        let mut source = ConfigSource::parse(&toml).unwrap();
-        source.set_line_color(&LineColorConfig::Gradient {
-            start: Rgb::new(0x00, 0x11, 0x22),
-            end: Rgb::new(0xaa, 0xbb, 0xcc),
-            topological_depth: false,
-        });
-        let result = source.to_toml_string();
-        assert!(
-            result.contains(r##"start = "#001122""##),
-            "expected start hex, got: {result}"
-        );
-        assert!(
-            result.contains(r##"end = "#aabbcc""##),
-            "expected end hex, got: {result}"
-        );
-        // Round-trip
-        let doc = ConfigDocument::try_from(ConfigSource::parse(&result).unwrap()).unwrap();
-        assert_eq!(
-            resolve_doc(&doc).colors.line,
-            LineColorConfig::Gradient {
-                start: Rgb::new(0x00, 0x11, 0x22),
-                end: Rgb::new(0xaa, 0xbb, 0xcc),
-                topological_depth: false,
-            }
-        );
-    }
-
-    #[test]
-    fn set_line_color_updates_gradient_topological_depth_in_place() {
-        let original = r##"[metadata]
-name = "Decorated Gradient"
-
-[l-system]
-dimensions = "2D"
-axiom = "F"
-iterations = 1
-
-[l-system.rules]
-F = "FF"
-
-[turtle]
-angle = 90.0
-step = 1.0
-initial_heading = 0.0
-
-[colors]
-background = "#000000"
-
-[colors.line.gradient] # keep gradient table comment
-start = "#001122" # keep start comment
-end = "#aabbcc" # keep end comment
-"##;
-        let mut source = ConfigSource::parse(original).unwrap();
-
-        source.set_line_color(&LineColorConfig::Gradient {
-            start: Rgb::new(0x00, 0x11, 0x22),
-            end: Rgb::new(0xaa, 0xbb, 0xcc),
-            topological_depth: true,
-        });
-
-        let result = source.to_toml_string();
-        assert!(result.contains("[colors.line.gradient] # keep gradient table comment"));
-        assert!(result.contains("start = \"#001122\" # keep start comment"));
-        assert!(result.contains("end = \"#aabbcc\" # keep end comment"));
-        assert!(result.contains("topological_depth = true"));
-        assert!(!result.contains("[colors.line]\nsolid"));
-        let doc = ConfigDocument::try_from(ConfigSource::parse(&result).unwrap()).unwrap();
-        assert_eq!(
-            doc.editor_config().colors.line,
-            Some(EditorLineColorConfig::Gradient {
-                start: Some(Rgb::new(0x00, 0x11, 0x22)),
-                end: Some(Rgb::new(0xaa, 0xbb, 0xcc)),
-                topological_depth: Some(true),
-            })
-        );
-        // Faithful resolve: topological_depth = true preserved (bracketless axiom "F").
-        assert_eq!(
-            resolve_doc(&doc).colors.line,
-            LineColorConfig::Gradient {
-                start: Rgb::new(0x00, 0x11, 0x22),
-                end: Rgb::new(0xaa, 0xbb, 0xcc),
-                topological_depth: true,
-            }
-        );
-    }
-
-    #[test]
-    fn set_line_color_updates_gradient_topological_depth_false_in_place() {
-        let original = r##"[metadata]
-name = "Decorated Gradient"
-
-[l-system]
-dimensions = "2D"
-axiom = "F"
-iterations = 1
-
-[l-system.rules]
-F = "FF"
-
-[turtle]
-angle = 90.0
-step = 1.0
-initial_heading = 0.0
-
-[colors]
-background = "#000000"
-
-[colors.line.gradient] # keep gradient table comment
-start = "#001122" # keep start comment
-end = "#aabbcc" # keep end comment
-topological_depth = true # keep flag comment
-"##;
-        let mut source = ConfigSource::parse(original).unwrap();
-
-        source.set_line_color(&LineColorConfig::Gradient {
-            start: Rgb::new(0x00, 0x11, 0x22),
-            end: Rgb::new(0xaa, 0xbb, 0xcc),
-            topological_depth: false,
-        });
-
-        let result = source.to_toml_string();
-        assert!(result.contains("[colors.line.gradient] # keep gradient table comment"));
-        assert!(result.contains("start = \"#001122\" # keep start comment"));
-        assert!(result.contains("end = \"#aabbcc\" # keep end comment"));
-        assert!(result.contains("topological_depth = false # keep flag comment"));
-        assert!(!result.contains("topological_depth = true"));
-        let doc = ConfigDocument::try_from(ConfigSource::parse(&result).unwrap()).unwrap();
-        assert_eq!(
-            resolve_doc(&doc).colors.line,
-            LineColorConfig::Gradient {
-                start: Rgb::new(0x00, 0x11, 0x22),
-                end: Rgb::new(0xaa, 0xbb, 0xcc),
-                topological_depth: false,
-            }
         );
     }
 }

--- a/crates/lsystem-app/src/ui/app_state.rs
+++ b/crates/lsystem-app/src/ui/app_state.rs
@@ -2,9 +2,9 @@ use iced::keyboard;
 use iced::widget::row;
 use iced::{Element, Event, Length, Point, Size, Subscription, Task, event, window};
 use lsystem_app_model::{
-    CleanMut, ColorControlMemory, ConfigDefaults, ConfigWorkspace, EditorConfig, EntryViewMut,
-    HueRotation, HueRotationDirection, LineColorMode, ParseConfigError,
-    advance_hue_rotation_phase_degrees, line_color_for_controls, load_presets,
+    CleanMut, ColorControlMemory, ConfigDefaults, ConfigWorkspace, EditorConfig,
+    EditorLineColorConfig, EntryViewMut, HueRotation, HueRotationDirection, LineColorMode,
+    ParseConfigError, advance_hue_rotation_phase_degrees, line_color_for_controls, load_presets,
 };
 use lsystem_core::{ColorConfig, Config, Dimensions, LineColorConfig, Rgb};
 use std::sync::{
@@ -22,6 +22,14 @@ use super::{PNG_MAX_WIDTH, PNG_MIN_WIDTH};
 const ROTATION_STEP_DEG: f32 = 5.0;
 const AUTO_ROTATE_DT_SECS: f32 = 1.0 / 60.0;
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(super) enum ColorDefaultField {
+    SolidLine,
+    GradientStart,
+    GradientEnd,
+    HueCycleInitial,
+}
+
 #[derive(Debug, Clone)]
 pub(super) enum Message {
     PresetSelected(String),
@@ -32,10 +40,14 @@ pub(super) enum Message {
     ResetConfig,
     IterationsChanged(u32),
     AngleChanged(f32),
-    BackgroundOverrideToggled(bool),
+    BackgroundDefaultToggled(bool),
     BackgroundColorChanged(Rgb),
     LineColorModeSelected(LineColorMode),
-    LineColorChanged(LineColorConfig),
+    LineColorChanged(Option<EditorLineColorConfig>),
+    LineColorDefaultToggled {
+        field: ColorDefaultField,
+        use_default: bool,
+    },
     PngWidthChanged(String),
     ExportSvg,
     ExportPng,
@@ -182,16 +194,17 @@ impl FractalApp {
             Message::AngleChanged(angle) => {
                 self.update_clean_config("angle slider", |clean| clean.set_angle(angle))
             }
-            Message::BackgroundOverrideToggled(enabled) => {
-                if let Some(bg) = self.selected_editor_config().colors.background {
-                    self.color_memory.remember_background(bg);
+            Message::BackgroundDefaultToggled(is_default) => {
+                if is_default {
+                    self.color_memory
+                        .remember_background(self.render_colors().background);
                 }
-                let background = if enabled {
-                    Some(self.color_memory.background())
-                } else {
+                let background = if is_default {
                     None
+                } else {
+                    Some(self.color_memory.background())
                 };
-                self.update_clean_color_config("background override toggle", |clean| {
+                self.update_clean_color_config("background", |clean| {
                     clean.set_background(background)
                 })
             }
@@ -202,23 +215,60 @@ impl FractalApp {
                 })
             }
             Message::LineColorModeSelected(mode) => {
-                let current = {
-                    let entry = self.config_workspace.selected();
-                    line_color_for_controls(
-                        &entry.editor_config().colors,
-                        &ConfigDefaults::embedded().colors.line,
-                    )
-                };
-                self.color_memory.remember_line(current);
-                let line_color = self.color_memory.line_for(mode);
-                self.update_clean_color_config("line color mode select", |clean| {
-                    clean.set_line_color(line_color)
+                let editor_line = self.config_workspace.selected().editor_config().colors.line;
+                self.color_memory.remember_line(editor_line);
+                let new_editor_line = self.color_memory.line_for(mode);
+                self.update_clean_color_config("line color mode", |clean| {
+                    clean.set_line_color(new_editor_line)
                 })
             }
             Message::LineColorChanged(line_color) => self
-                .update_clean_color_config("line color control", |clean| {
-                    clean.set_line_color(line_color)
-                }),
+                .update_clean_color_config("line color", |clean| clean.set_line_color(line_color)),
+            Message::LineColorDefaultToggled { field, use_default } => {
+                use ColorDefaultField::*;
+                let editor_line = self.config_workspace.selected().editor_config().colors.line;
+                if use_default {
+                    self.color_memory.remember_line(editor_line);
+                }
+                let (editor_start, editor_end, editor_td) =
+                    editor_line.map(|l| l.gradient_fields()).unwrap_or_default();
+                let (mem_start, mem_end, _) = self.color_memory.gradient_fields();
+                let new_line = match (field, use_default) {
+                    (SolidLine, true) => None,
+                    (SolidLine, false) => Some(EditorLineColorConfig::Solid(
+                        self.color_memory.solid_color(),
+                    )),
+                    (GradientStart, true) => Some(EditorLineColorConfig::Gradient {
+                        start: None,
+                        end: editor_end,
+                        topological_depth: editor_td,
+                    }),
+                    (GradientStart, false) => Some(EditorLineColorConfig::Gradient {
+                        start: Some(mem_start),
+                        end: editor_end,
+                        topological_depth: editor_td,
+                    }),
+                    (GradientEnd, true) => Some(EditorLineColorConfig::Gradient {
+                        start: editor_start,
+                        end: None,
+                        topological_depth: editor_td,
+                    }),
+                    (GradientEnd, false) => Some(EditorLineColorConfig::Gradient {
+                        start: editor_start,
+                        end: Some(mem_end),
+                        topological_depth: editor_td,
+                    }),
+                    (HueCycleInitial, true) => {
+                        Some(EditorLineColorConfig::HueCycle { initial: None })
+                    }
+                    (HueCycleInitial, false) => Some(EditorLineColorConfig::HueCycle {
+                        initial: Some(self.color_memory.hue_cycle_initial()),
+                    }),
+                };
+                self.update_clean_color_config("line color default", |clean| {
+                    clean.set_line_color(new_line)
+                })
+            }
             Message::PngWidthChanged(value) => {
                 self.png_width_text = value;
                 self.export_status = None;
@@ -649,17 +699,17 @@ mod tests {
 
     #[test]
     fn color_control_memory_uses_defaults_and_restores_edits() {
-        let solid = LineColorConfig::Solid(Rgb::new(0x1a, 0x33, 0x4d));
-        let gradient = LineColorConfig::Gradient {
-            start: Rgb::new(0x66, 0x80, 0x99),
-            end: Rgb::new(0xb3, 0xcc, 0xe5),
-            topological_depth: false,
-        };
-        let topological_gradient = LineColorConfig::Gradient {
-            start: Rgb::new(0x33, 0x4d, 0x66),
-            end: Rgb::new(0x80, 0x99, 0xb3),
-            topological_depth: true,
-        };
+        let solid = Some(EditorLineColorConfig::Solid(Rgb::new(0x1a, 0x33, 0x4d)));
+        let gradient = Some(EditorLineColorConfig::Gradient {
+            start: Some(Rgb::new(0x66, 0x80, 0x99)),
+            end: Some(Rgb::new(0xb3, 0xcc, 0xe5)),
+            topological_depth: Some(false),
+        });
+        let topological_gradient = Some(EditorLineColorConfig::Gradient {
+            start: Some(Rgb::new(0x33, 0x4d, 0x66)),
+            end: Some(Rgb::new(0x80, 0x99, 0xb3)),
+            topological_depth: Some(true),
+        });
 
         let mut memory = ColorControlMemory::from_editor_config(
             &lsystem_app_model::EditorColorConfig {
@@ -673,20 +723,17 @@ mod tests {
 
         assert_eq!(memory.background(), Rgb::new(0xcc, 0xcc, 0xcc));
         assert_eq!(memory.line_for(LineColorMode::Solid), solid);
-        let defaults = lsystem_app_model::ConfigDefaults::embedded().colors.line;
         assert_eq!(
             memory.line_for(LineColorMode::Gradient),
-            LineColorConfig::Gradient {
-                start: defaults.gradient.start,
-                end: defaults.gradient.end,
-                topological_depth: defaults.gradient.topological_depth,
-            }
+            Some(EditorLineColorConfig::Gradient {
+                start: None,
+                end: None,
+                topological_depth: None,
+            })
         );
         assert_eq!(
             memory.line_for(LineColorMode::HueCycle),
-            LineColorConfig::HueCycle {
-                initial: defaults.hue_cycle.initial,
-            }
+            Some(EditorLineColorConfig::HueCycle { initial: None })
         );
 
         memory.remember_background(Rgb::new(0xe5, 0x1a, 0x33));
@@ -704,11 +751,11 @@ mod tests {
     #[test]
     fn clean_apply_preserves_inactive_line_color_memory() {
         let (mut app, _) = FractalApp::new();
-        let gradient = LineColorConfig::Gradient {
-            start: Rgb::new(0x66, 0x80, 0x99),
-            end: Rgb::new(0xb3, 0xcc, 0xe5),
-            topological_depth: false,
-        };
+        let gradient = Some(EditorLineColorConfig::Gradient {
+            start: Some(Rgb::new(0x66, 0x80, 0x99)),
+            end: Some(Rgb::new(0xb3, 0xcc, 0xe5)),
+            topological_depth: Some(false),
+        });
         app.color_memory.remember_line(gradient);
 
         let _ = app.update(Message::ApplyConfig);
@@ -730,20 +777,14 @@ mod tests {
 
         let start = Rgb::new(0x33, 0x4d, 0x66);
         let end = Rgb::new(0x80, 0x99, 0xb3);
-        let _ = app.update(Message::LineColorChanged(LineColorConfig::Gradient {
-            start,
-            end,
-            topological_depth: true,
-        }));
+        let _ = app.update(Message::LineColorChanged(Some(
+            EditorLineColorConfig::Gradient {
+                start: Some(start),
+                end: Some(end),
+                topological_depth: Some(true),
+            },
+        )));
 
-        assert_eq!(
-            app.control_line_color(),
-            LineColorConfig::Gradient {
-                start,
-                end,
-                topological_depth: true,
-            }
-        );
         // render_colors() is now a faithful resolve — no normalization.
         assert_eq!(
             app.render_colors().line,
@@ -789,7 +830,7 @@ mod tests {
         let background = Rgb::new(0x33, 0x4d, 0x66);
 
         let _ = app.update(Message::BackgroundColorChanged(background));
-        let _ = app.update(Message::BackgroundOverrideToggled(false));
+        let _ = app.update(Message::BackgroundDefaultToggled(true)); // true = use default (remove)
 
         assert_eq!(
             app.config_workspace
@@ -800,7 +841,7 @@ mod tests {
             None
         );
 
-        let _ = app.update(Message::BackgroundOverrideToggled(true));
+        let _ = app.update(Message::BackgroundDefaultToggled(false)); // false = explicit (restore)
 
         assert_eq!(
             app.config_workspace

--- a/crates/lsystem-app/src/ui/controls.rs
+++ b/crates/lsystem-app/src/ui/controls.rs
@@ -3,7 +3,7 @@ use iced::widget::{
     text_input,
 };
 use iced::{Color, Element, Length, Theme};
-use lsystem_app_model::{ConfigDefaults, EditorColorConfig};
+use lsystem_app_model::{ConfigDefaults, EditorColorConfig, EditorLineColorConfig};
 use lsystem_app_model::{
     HUE_ROTATION_MAX_SPEED_DEGREES_PER_SECOND, HUE_ROTATION_MIN_SPEED_DEGREES_PER_SECOND,
     HueRotation, HueRotationDirection, LineColorMode, line_color_for_controls,
@@ -11,7 +11,7 @@ use lsystem_app_model::{
 };
 use lsystem_core::{LineColorConfig, Rgb};
 
-use super::app_state::{FractalApp, Message};
+use super::app_state::{ColorDefaultField, FractalApp, Message};
 use super::{CONTROL_WIDTH, TITLE};
 
 impl FractalApp {
@@ -155,18 +155,17 @@ fn push_color_controls<'a>(
     let background = editor_colors
         .background
         .unwrap_or(color_defaults.background);
-    controls = controls.push(
-        checkbox(has_authored_background)
-            .label("Background")
-            .on_toggle(Message::BackgroundOverrideToggled),
-    );
-    if has_authored_background {
-        controls = controls.push(rgb_controls(
+    controls = controls
+        .push(
+            checkbox(!has_authored_background)
+                .label("Background: use default")
+                .on_toggle(Message::BackgroundDefaultToggled),
+        )
+        .push(rgb_controls(
             "Background RGB",
             background,
             Message::BackgroundColorChanged,
         ));
-    }
 
     let line_color = line_color_for_controls(editor_colors, &color_defaults.line);
     let selected_mode = Some(selected_line_color_mode(editor_colors));
@@ -179,48 +178,96 @@ fn push_color_controls<'a>(
     );
 
     match line_color {
-        LineColorConfig::Solid(color) => controls.push(rgb_controls("Line RGB", color, |hex| {
-            Message::LineColorChanged(LineColorConfig::Solid(hex))
-        })),
+        LineColorConfig::Solid(color) => {
+            let is_default_solid = editor_colors.line.is_none();
+            controls
+                .push(
+                    checkbox(is_default_solid)
+                        .label("Solid: use default")
+                        .on_toggle(|use_default| Message::LineColorDefaultToggled {
+                            field: ColorDefaultField::SolidLine,
+                            use_default,
+                        }),
+                )
+                .push(rgb_controls("Line RGB", color, |hex| {
+                    Message::LineColorChanged(Some(EditorLineColorConfig::Solid(hex)))
+                }))
+        }
         LineColorConfig::Gradient {
             start,
             end,
             topological_depth,
-        } => controls
-            .push(rgb_controls("Gradient start", start, move |hex| {
-                Message::LineColorChanged(LineColorConfig::Gradient {
-                    start: hex,
-                    end,
-                    topological_depth,
-                })
-            }))
-            .push(rgb_controls("Gradient end", end, move |hex| {
-                Message::LineColorChanged(LineColorConfig::Gradient {
-                    start,
-                    end: hex,
-                    topological_depth,
-                })
-            }))
-            .push(
-                checkbox(topological_depth)
-                    .label("Topological depth")
-                    .on_toggle(move |enabled| {
-                        Message::LineColorChanged(LineColorConfig::Gradient {
-                            start,
-                            end,
-                            topological_depth: enabled,
-                        })
-                    }),
-            ),
+        } => {
+            let (editor_start, editor_end, editor_td) = editor_colors
+                .line
+                .map(|l| l.gradient_fields())
+                .unwrap_or_default();
+            controls
+                .push(
+                    checkbox(editor_start.is_none())
+                        .label("Gradient start: use default")
+                        .on_toggle(|use_default| Message::LineColorDefaultToggled {
+                            field: ColorDefaultField::GradientStart,
+                            use_default,
+                        }),
+                )
+                .push(rgb_controls("Gradient start", start, move |hex| {
+                    Message::LineColorChanged(Some(EditorLineColorConfig::Gradient {
+                        start: Some(hex),
+                        end: editor_end,
+                        topological_depth: editor_td,
+                    }))
+                }))
+                .push(
+                    checkbox(editor_end.is_none())
+                        .label("Gradient end: use default")
+                        .on_toggle(|use_default| Message::LineColorDefaultToggled {
+                            field: ColorDefaultField::GradientEnd,
+                            use_default,
+                        }),
+                )
+                .push(rgb_controls("Gradient end", end, move |hex| {
+                    Message::LineColorChanged(Some(EditorLineColorConfig::Gradient {
+                        start: editor_start,
+                        end: Some(hex),
+                        topological_depth: editor_td,
+                    }))
+                }))
+                .push(
+                    checkbox(topological_depth)
+                        .label("Topological depth")
+                        .on_toggle(move |enabled| {
+                            Message::LineColorChanged(Some(EditorLineColorConfig::Gradient {
+                                start: editor_start,
+                                end: editor_end,
+                                topological_depth: Some(enabled),
+                            }))
+                        }),
+                )
+        }
         LineColorConfig::HueCycle { initial } => {
+            let editor_initial = match editor_colors.line {
+                Some(EditorLineColorConfig::HueCycle { initial }) => initial,
+                _ => None,
+            };
             let rotation_label = if hue_rotation.is_enabled() {
                 "Hue rotation: On"
             } else {
                 "Hue rotation: Off"
             };
             controls
+                .push(
+                    checkbox(editor_initial.is_none())
+                        .label("Initial: use default")
+                        .on_toggle(|use_default| Message::LineColorDefaultToggled {
+                            field: ColorDefaultField::HueCycleInitial,
+                            use_default,
+                        }),
+                )
                 .push(rgb_controls("Initial RGB", initial, |hex| {
-                    Message::LineColorChanged(LineColorConfig::HueCycle { initial: hex })
+                    Message::LineColorChanged(Some(EditorLineColorConfig::HueCycle {
+                        initial: Some(hex),
+                    }))
                 }))
                 .push(button(rotation_label).on_press(Message::ToggleHueRotation))
                 .push(

--- a/crates/lsystem-web-app/src/app.rs
+++ b/crates/lsystem-web-app/src/app.rs
@@ -4,9 +4,10 @@ use crate::renderer::{CanvasRenderer, RenderStatus};
 use leptos::html::Canvas;
 use leptos::prelude::*;
 use lsystem_app_model::{
-    CleanMut, ColorControlMemory, ConfigDefaults, ConfigWorkspace, EntryViewMut, HueRotation,
-    HueRotationDirection, LineColorMode, ParseConfigError, advance_hue_rotation_phase_degrees,
-    line_color_for_controls, load_presets, selected_line_color_mode,
+    CleanMut, ColorControlMemory, ConfigDefaults, ConfigWorkspace, EditorLineColorConfig,
+    EntryViewMut, HueRotation, HueRotationDirection, LineColorMode, ParseConfigError,
+    advance_hue_rotation_phase_degrees, line_color_for_controls, load_presets,
+    selected_line_color_mode,
 };
 use lsystem_core::{
     ColorConfig, Config, Dimensions, GenerationConfig, LineColorConfig, Rgb, contains_3d_symbols,
@@ -905,51 +906,44 @@ pub(crate) fn App() -> impl IntoView {
                         style="display:flex;flex-direction:column;gap:9px"
                         title=dirty_tooltip
                     >
-                    <label class="check-row" for="background-override">
-                        <input
-                            id="background-override"
-                            type="checkbox"
-                            prop:checked=move || {
-                                editor_color_config.with(|c| c.background.is_some())
-                            }
-                            disabled=is_dirty
-                            on:change:target=move |ev| {
-                                let current_bg = editor_color_config.with_untracked(|editor| {
-                                    editor
-                                        .background
-                                        .unwrap_or(ConfigDefaults::embedded().colors.background)
-                                });
-                                if editor_color_config
-                                    .with_untracked(|c| c.background.is_some())
-                                {
-                                    color_memory.update(|memory| {
-                                        memory.remember_background(current_bg);
-                                    });
+                    <span class="section-label">"Background"</span>
+                    <div class="color-row">
+                        <label class="check-row" for="background-override">
+                            <input
+                                id="background-override"
+                                type="checkbox"
+                                prop:checked=move || {
+                                    editor_color_config.with(|c| c.background.is_none())
                                 }
-                                let enabled = ev.target().checked();
-                                let background = if enabled {
-                                    Some(color_memory.get_untracked().background())
-                                } else {
-                                    None
-                                };
-                                update_clean_config(
-                                    config_workspace,
-                                    error,
-                                    "background checkbox",
-                                    move |clean| clean.set_background(background),
-                                );
-                            }
-                        />
-                        <span>"Background"</span>
-                    </label>
-
-                    <div
-                        class="color-row"
-                        class:hidden=move || {
-                            editor_color_config.with(|c| c.background.is_none())
-                        }
-                    >
-                        <label for="background-color">"Background color"</label>
+                                disabled=is_dirty
+                                on:change:target=move |ev| {
+                                    let use_default = ev.target().checked();
+                                    if use_default {
+                                        let current_bg =
+                                            editor_color_config.with_untracked(|editor| {
+                                                editor.background.unwrap_or(
+                                                    ConfigDefaults::embedded().colors.background,
+                                                )
+                                            });
+                                        color_memory.update(|memory| {
+                                            memory.remember_background(current_bg);
+                                        });
+                                    }
+                                    let background = if use_default {
+                                        None
+                                    } else {
+                                        Some(color_memory.get_untracked().background())
+                                    };
+                                    update_clean_config(
+                                        config_workspace,
+                                        error,
+                                        "background checkbox",
+                                        move |clean| clean.set_background(background),
+                                    );
+                                }
+                            />
+                            <span>"Default"</span>
+                        </label>
                         <input
                             id="background-color"
                             type="color"
@@ -999,13 +993,10 @@ pub(crate) fn App() -> impl IntoView {
                                 log::error!("unknown line color mode selected: {mode_key}");
                                 return;
                             };
-                            let editor = editor_color_config.get_untracked();
-                            let current = line_color_for_controls(
-                                &editor,
-                                &ConfigDefaults::embedded().colors.line,
-                            );
-                            let Some(line_color) = color_memory.try_update(|memory| {
-                                memory.remember_line(current);
+                            let editor_line =
+                                editor_color_config.with_untracked(|e| e.line);
+                            let Some(new_editor_line) = color_memory.try_update(|memory| {
+                                memory.remember_line(editor_line);
                                 memory.line_for(mode)
                             }) else {
                                 log::error!(
@@ -1020,10 +1011,10 @@ pub(crate) fn App() -> impl IntoView {
                                 config_workspace,
                                 error,
                                 "line color mode select",
-                                move |clean| clean.set_line_color(line_color),
+                                move |clean| clean.set_line_color(new_editor_line),
                             ) {
                                 color_memory.update(|memory| {
-                                    memory.remember_line(line_color);
+                                    memory.remember_line(new_editor_line);
                                 });
                             }
                         }
@@ -1034,129 +1025,251 @@ pub(crate) fn App() -> impl IntoView {
                     </select>
 
                     <div
-                        class="color-row"
                         class:hidden=move || {
                             !matches!(
                                 control_line_color.get(),
                                 LineColorConfig::Solid(_)
                             )
                         }
+                        style="display:flex;flex-direction:column;gap:6px"
                     >
-                        <label for="line-solid-color">"Line color"</label>
-                        <input
-                            id="line-solid-color"
-                            type="color"
-                            prop:value=move || {
-                                solid_color_for_mode(control_line_color, color_memory)
-                                .to_string()
-                            }
-                            disabled=is_dirty
-                            on:input:target=move |ev| {
-                                let Ok(color) = ev.target().value().parse::<Rgb>() else {
-                                    error.set(Some("Invalid color value.".to_string()));
-                                    return;
-                                };
-                                let line_color = LineColorConfig::Solid(color);
-                                if update_clean_config(
-                                    config_workspace,
-                                    error,
-                                    "solid line color input",
-                                    move |clean| clean.set_line_color(line_color),
-                                ) {
-                                    color_memory.update(|memory| {
-                                        memory.remember_line(line_color);
-                                    });
+                        <span class="section-label">"Color"</span>
+                        <div class="color-row">
+                            <label class="check-row" for="line-solid-use-default">
+                                <input
+                                    id="line-solid-use-default"
+                                    type="checkbox"
+                                    prop:checked=move || {
+                                        editor_color_config.with(|c| c.line.is_none())
+                                    }
+                                    disabled=is_dirty
+                                    on:change:target=move |ev| {
+                                        let use_default = ev.target().checked();
+                                        if use_default {
+                                            let editor_line =
+                                                editor_color_config.with_untracked(|e| e.line);
+                                            color_memory.update(|m| m.remember_line(editor_line));
+                                        }
+                                        let line_color = if use_default {
+                                            None
+                                        } else {
+                                            Some(EditorLineColorConfig::Solid(
+                                                color_memory.get_untracked().solid_color(),
+                                            ))
+                                        };
+                                        update_clean_config(
+                                            config_workspace,
+                                            error,
+                                            "solid use-default checkbox",
+                                            move |clean| clean.set_line_color(line_color),
+                                        );
+                                    }
+                                />
+                                <span>"Default"</span>
+                            </label>
+                            <input
+                                id="line-solid-color"
+                                type="color"
+                                prop:value=move || {
+                                    solid_color_for_mode(control_line_color, color_memory)
+                                    .to_string()
                                 }
-                            }
-                        />
+                                disabled=is_dirty
+                                on:input:target=move |ev| {
+                                    let Ok(color) = ev.target().value().parse::<Rgb>() else {
+                                        error.set(Some("Invalid color value.".to_string()));
+                                        return;
+                                    };
+                                    let line_color = Some(EditorLineColorConfig::Solid(color));
+                                    if update_clean_config(
+                                        config_workspace,
+                                        error,
+                                        "solid line color input",
+                                        move |clean| clean.set_line_color(line_color),
+                                    ) {
+                                        color_memory.update(|memory| {
+                                            memory.remember_line(Some(
+                                                EditorLineColorConfig::Solid(color),
+                                            ));
+                                        });
+                                    }
+                                }
+                            />
+                        </div>
                     </div>
 
                     <div
-                        class="color-row"
                         class:hidden=move || {
                             !matches!(
                                 control_line_color.get(),
                                 LineColorConfig::Gradient { .. }
                             )
                         }
+                        style="display:flex;flex-direction:column;gap:6px"
                     >
-                        <label for="line-gradient-start">"Gradient start"</label>
-                        <input
-                            id="line-gradient-start"
-                            type="color"
-                            prop:value=move || {
-                                let (start, _, _) = gradient_fields_for_mode(
-                                    control_line_color,
-                                    color_memory,
-                                );
-                                start.to_string()
-                            }
-                            disabled=is_dirty
-                            on:input:target=move |ev| {
-                                let Ok(start) = ev.target().value().parse::<Rgb>() else {
-                                    error.set(Some("Invalid color value.".to_string()));
-                                    return;
-                                };
-                                let (_, end, topological_depth) = gradient_fields_for_mode_untracked(
-                                    control_line_color,
-                                    color_memory,
-                                );
-                                let line_color = LineColorConfig::Gradient {
-                                    start,
-                                    end,
-                                    topological_depth,
-                                };
-                                if update_clean_config(
-                                    config_workspace,
-                                    error,
-                                    "gradient start color input",
-                                    move |clean| clean.set_line_color(line_color),
-                                ) {
-                                    color_memory.update(|memory| {
-                                        memory.remember_line(line_color);
-                                    });
+                        <span class="section-label">"Start"</span>
+                        <div class="color-row">
+                            <label class="check-row" for="line-gradient-start-use-default">
+                                <input
+                                    id="line-gradient-start-use-default"
+                                    type="checkbox"
+                                    prop:checked=move || {
+                                        editor_color_config.with(|c| {
+                                            c.line.map(|l| l.gradient_fields()).unwrap_or_default().0.is_none()
+                                        })
+                                    }
+                                    disabled=is_dirty
+                                    on:change:target=move |ev| {
+                                        let use_default = ev.target().checked();
+                                        let editor_line =
+                                            editor_color_config.with_untracked(|e| e.line);
+                                        if use_default {
+                                            color_memory.update(|m| m.remember_line(editor_line));
+                                        }
+                                        let (_, editor_end, editor_td) =
+                                            editor_line.map(|l| l.gradient_fields()).unwrap_or_default();
+                                        let start = if use_default {
+                                            None
+                                        } else {
+                                            Some(color_memory.get_untracked().gradient_fields().0)
+                                        };
+                                        let line_color =
+                                            Some(EditorLineColorConfig::Gradient {
+                                                start,
+                                                end: editor_end,
+                                                topological_depth: editor_td,
+                                            });
+                                        update_clean_config(
+                                            config_workspace,
+                                            error,
+                                            "gradient start use-default",
+                                            move |clean| clean.set_line_color(line_color),
+                                        );
+                                    }
+                                />
+                                <span>"Default"</span>
+                            </label>
+                            <input
+                                id="line-gradient-start"
+                                type="color"
+                                prop:value=move || {
+                                    let (start, _, _) = gradient_fields_for_mode(
+                                        control_line_color,
+                                        color_memory,
+                                    );
+                                    start.to_string()
                                 }
-                            }
-                        />
+                                disabled=is_dirty
+                                on:input:target=move |ev| {
+                                    let Ok(start) = ev.target().value().parse::<Rgb>() else {
+                                        error.set(Some("Invalid color value.".to_string()));
+                                        return;
+                                    };
+                                    let editor_line =
+                                        editor_color_config.get_untracked().line;
+                                    let (_, editor_end, editor_td) =
+                                        editor_line.map(|l| l.gradient_fields()).unwrap_or_default();
+                                    let line_color =
+                                        Some(EditorLineColorConfig::Gradient {
+                                            start: Some(start),
+                                            end: editor_end,
+                                            topological_depth: editor_td,
+                                        });
+                                    if update_clean_config(
+                                        config_workspace,
+                                        error,
+                                        "gradient start color input",
+                                        move |clean| clean.set_line_color(line_color),
+                                    ) {
+                                        color_memory.update(|memory| {
+                                            memory.remember_line(line_color);
+                                        });
+                                    }
+                                }
+                            />
+                        </div>
 
-                        <label for="line-gradient-end">"Gradient end"</label>
-                        <input
-                            id="line-gradient-end"
-                            type="color"
-                            prop:value=move || {
-                                let (_, end, _) = gradient_fields_for_mode(
-                                    control_line_color,
-                                    color_memory,
-                                );
-                                end.to_string()
-                            }
-                            disabled=is_dirty
-                            on:input:target=move |ev| {
-                                let Ok(end) = ev.target().value().parse::<Rgb>() else {
-                                    error.set(Some("Invalid color value.".to_string()));
-                                    return;
-                                };
-                                let (start, _, topological_depth) = gradient_fields_for_mode_untracked(
-                                    control_line_color,
-                                    color_memory,
-                                );
-                                let line_color = LineColorConfig::Gradient {
-                                    start,
-                                    end,
-                                    topological_depth,
-                                };
-                                if update_clean_config(
-                                    config_workspace,
-                                    error,
-                                    "gradient end color input",
-                                    move |clean| clean.set_line_color(line_color),
-                                ) {
-                                    color_memory.update(|memory| {
-                                        memory.remember_line(line_color);
-                                    });
+                        <span class="section-label">"End"</span>
+                        <div class="color-row">
+                            <label class="check-row" for="line-gradient-end-use-default">
+                                <input
+                                    id="line-gradient-end-use-default"
+                                    type="checkbox"
+                                    prop:checked=move || {
+                                        editor_color_config.with(|c| {
+                                            c.line.map(|l| l.gradient_fields()).unwrap_or_default().1.is_none()
+                                        })
+                                    }
+                                    disabled=is_dirty
+                                    on:change:target=move |ev| {
+                                        let use_default = ev.target().checked();
+                                        let editor_line =
+                                            editor_color_config.with_untracked(|e| e.line);
+                                        if use_default {
+                                            color_memory.update(|m| m.remember_line(editor_line));
+                                        }
+                                        let (editor_start, _, editor_td) =
+                                            editor_line.map(|l| l.gradient_fields()).unwrap_or_default();
+                                        let end = if use_default {
+                                            None
+                                        } else {
+                                            Some(color_memory.get_untracked().gradient_fields().1)
+                                        };
+                                        let line_color =
+                                            Some(EditorLineColorConfig::Gradient {
+                                                start: editor_start,
+                                                end,
+                                                topological_depth: editor_td,
+                                            });
+                                        update_clean_config(
+                                            config_workspace,
+                                            error,
+                                            "gradient end use-default",
+                                            move |clean| clean.set_line_color(line_color),
+                                        );
+                                    }
+                                />
+                                <span>"Default"</span>
+                            </label>
+                            <input
+                                id="line-gradient-end"
+                                type="color"
+                                prop:value=move || {
+                                    let (_, end, _) = gradient_fields_for_mode(
+                                        control_line_color,
+                                        color_memory,
+                                    );
+                                    end.to_string()
                                 }
-                            }
-                        />
+                                disabled=is_dirty
+                                on:input:target=move |ev| {
+                                    let Ok(end) = ev.target().value().parse::<Rgb>() else {
+                                        error.set(Some("Invalid color value.".to_string()));
+                                        return;
+                                    };
+                                    let editor_line =
+                                        editor_color_config.get_untracked().line;
+                                    let (editor_start, _, editor_td) =
+                                        editor_line.map(|l| l.gradient_fields()).unwrap_or_default();
+                                    let line_color =
+                                        Some(EditorLineColorConfig::Gradient {
+                                            start: editor_start,
+                                            end: Some(end),
+                                            topological_depth: editor_td,
+                                        });
+                                    if update_clean_config(
+                                        config_workspace,
+                                        error,
+                                        "gradient end color input",
+                                        move |clean| clean.set_line_color(line_color),
+                                    ) {
+                                        color_memory.update(|memory| {
+                                            memory.remember_line(line_color);
+                                        });
+                                    }
+                                }
+                            />
+                        </div>
 
                         <label for="line-gradient-topological-depth">"Topological depth"</label>
                         <input
@@ -1171,15 +1284,15 @@ pub(crate) fn App() -> impl IntoView {
                             }
                             disabled=is_dirty
                             on:change:target=move |ev| {
-                                let (start, end, _) = gradient_fields_for_mode_untracked(
-                                    control_line_color,
-                                    color_memory,
-                                );
-                                let line_color = LineColorConfig::Gradient {
-                                    start,
-                                    end,
-                                    topological_depth: ev.target().checked(),
-                                };
+                                let editor_line = editor_color_config.get_untracked().line;
+                                let (editor_start, editor_end, _) =
+                                    editor_line.map(|l| l.gradient_fields()).unwrap_or_default();
+                                let checked = ev.target().checked();
+                                let line_color = Some(EditorLineColorConfig::Gradient {
+                                    start: editor_start,
+                                    end: editor_end,
+                                    topological_depth: Some(checked),
+                                });
                                 if update_clean_config(
                                     config_workspace,
                                     error,
@@ -1195,41 +1308,87 @@ pub(crate) fn App() -> impl IntoView {
                     </div>
 
                     <div
-                        class="color-row"
                         class:hidden=move || {
                             !matches!(
                                 control_line_color.get(),
                                 LineColorConfig::HueCycle { .. }
                             )
                         }
+                        style="display:flex;flex-direction:column;gap:6px"
                     >
-                        <label for="line-hue-cycle-initial">"Initial color"</label>
-                        <input
-                            id="line-hue-cycle-initial"
-                            type="color"
-                            prop:value=move || {
-                                hue_cycle_initial_for_mode(control_line_color, color_memory)
-                                .to_string()
-                            }
-                            disabled=is_dirty
-                            on:input:target=move |ev| {
-                                let Ok(initial) = ev.target().value().parse::<Rgb>() else {
-                                    error.set(Some("Invalid color value.".to_string()));
-                                    return;
-                                };
-                                let line_color = LineColorConfig::HueCycle { initial };
-                                if update_clean_config(
-                                    config_workspace,
-                                    error,
-                                    "hue-cycle initial color input",
-                                    move |clean| clean.set_line_color(line_color),
-                                ) {
-                                    color_memory.update(|memory| {
-                                        memory.remember_line(line_color);
-                                    });
+                        <span class="section-label">"Initial"</span>
+                        <div class="color-row">
+                            <label class="check-row" for="line-hue-cycle-use-default">
+                                <input
+                                    id="line-hue-cycle-use-default"
+                                    type="checkbox"
+                                    prop:checked=move || {
+                                        matches!(
+                                            editor_color_config.with(|c| c.line),
+                                            None | Some(EditorLineColorConfig::HueCycle {
+                                                initial: None
+                                            })
+                                        )
+                                    }
+                                    disabled=is_dirty
+                                    on:change:target=move |ev| {
+                                        let use_default = ev.target().checked();
+                                        if use_default {
+                                            let editor_line =
+                                                editor_color_config.with_untracked(|e| e.line);
+                                            color_memory.update(|m| m.remember_line(editor_line));
+                                        }
+                                        let line_color = if use_default {
+                                            Some(EditorLineColorConfig::HueCycle { initial: None })
+                                        } else {
+                                            Some(EditorLineColorConfig::HueCycle {
+                                                initial: Some(
+                                                    color_memory.get_untracked().hue_cycle_initial(),
+                                                ),
+                                            })
+                                        };
+                                        update_clean_config(
+                                            config_workspace,
+                                            error,
+                                            "hue-cycle use-default checkbox",
+                                            move |clean| clean.set_line_color(line_color),
+                                        );
+                                    }
+                                />
+                                <span>"Default"</span>
+                            </label>
+                            <input
+                                id="line-hue-cycle-initial"
+                                type="color"
+                                prop:value=move || {
+                                    hue_cycle_initial_for_mode(control_line_color, color_memory)
+                                    .to_string()
                                 }
-                            }
-                        />
+                                disabled=is_dirty
+                                on:input:target=move |ev| {
+                                    let Ok(initial) = ev.target().value().parse::<Rgb>() else {
+                                        error.set(Some("Invalid color value.".to_string()));
+                                        return;
+                                    };
+                                    let line_color =
+                                        Some(EditorLineColorConfig::HueCycle { initial: Some(initial) });
+                                    if update_clean_config(
+                                        config_workspace,
+                                        error,
+                                        "hue-cycle initial color input",
+                                        move |clean| clean.set_line_color(line_color),
+                                    ) {
+                                        color_memory.update(|memory| {
+                                            memory.remember_line(Some(
+                                                EditorLineColorConfig::HueCycle {
+                                                    initial: Some(initial),
+                                                },
+                                            ));
+                                        });
+                                    }
+                                }
+                            />
+                        </div>
                     </div>
                     </div>
                 </crate::ui::Disclosure>
@@ -1599,16 +1758,6 @@ fn gradient_fields_for_mode(
     memory: RwSignal<ColorControlMemory>,
 ) -> (Rgb, Rgb, bool) {
     gradient_fields_from(line_color.get(), memory.with(|m| m.gradient_fields()))
-}
-
-fn gradient_fields_for_mode_untracked(
-    line_color: Memo<LineColorConfig>,
-    memory: RwSignal<ColorControlMemory>,
-) -> (Rgb, Rgb, bool) {
-    gradient_fields_from(
-        line_color.get_untracked(),
-        memory.with_untracked(|m| m.gradient_fields()),
-    )
 }
 
 fn hue_cycle_initial_for_mode(

--- a/presets/dragon_curve.toml
+++ b/presets/dragon_curve.toml
@@ -13,8 +13,4 @@ Y = "-FX-Y"
 [turtle]
 angle = 90.0
 
-[colors]
-background = "#000000"
-
 [colors.line.hue_cycle]
-initial = "#e60000"

--- a/presets/gosper_curve.toml
+++ b/presets/gosper_curve.toml
@@ -13,8 +13,4 @@ Y = "-FX+YFYF++YF+FX--FX-Y"
 [turtle]
 angle = 60.0
 
-[colors]
-background = "#000000"
-
 [colors.line.hue_cycle]
-initial = "#e60000"

--- a/presets/hilbert_curve.toml
+++ b/presets/hilbert_curve.toml
@@ -13,8 +13,4 @@ B = "+AF-BFB-FA+"
 [turtle]
 angle = 90.0
 
-[colors]
-background = "#000000"
-
 [colors.line.hue_cycle]
-initial = "#e60000"

--- a/presets/hilbert_curve_3d.toml
+++ b/presets/hilbert_curve_3d.toml
@@ -12,8 +12,4 @@ X = '^\XF^\XFX-F^//XFX&F+//XFX-F/X-/'
 [turtle]
 angle = 90.0
 
-[colors]
-background = "#000000"
-
 [colors.line.hue_cycle]
-initial = "#e60000"

--- a/presets/koch_snowflake.toml
+++ b/presets/koch_snowflake.toml
@@ -12,8 +12,4 @@ F = "F-F++F-F"
 [turtle]
 angle = 60.0
 
-[colors]
-background = "#000000"
-
 [colors.line.hue_cycle]
-initial = "#e60000"

--- a/presets/peano_curve.toml
+++ b/presets/peano_curve.toml
@@ -13,8 +13,4 @@ R = "RFLFR+F+LFRFL-F-RFLFR"
 [turtle]
 angle = 90.0
 
-[colors]
-background = "#000000"
-
 [colors.line.hue_cycle]
-initial = "#e60000"

--- a/presets/plant_3d.toml
+++ b/presets/plant_3d.toml
@@ -14,9 +14,6 @@ F = "FF"
 angle = 30.0
 initial_heading = 90.0
 
-[colors]
-background = "#000000"
-
 [colors.line.gradient]
 start = "#59590d"
 end = "#33d940"

--- a/presets/plant_a.toml
+++ b/presets/plant_a.toml
@@ -14,9 +14,6 @@ F = "FF"
 angle = 25.0
 initial_heading = 90.0
 
-[colors]
-background = "#000000"
-
 [colors.line.gradient]
 start = "#0d590d"
 end = "#99e61a"

--- a/presets/sierpinski_curve.toml
+++ b/presets/sierpinski_curve.toml
@@ -12,8 +12,4 @@ X = "XF-F+F-XF+F+XF-F+F-X"
 [turtle]
 angle = 90.0
 
-[colors]
-background = "#000000"
-
 [colors.line.hue_cycle]
-initial = "#e60000"

--- a/presets/sierpinski_triangle.toml
+++ b/presets/sierpinski_triangle.toml
@@ -13,8 +13,4 @@ X = "-FXF+FXF+FXF-"
 [turtle]
 angle = 120.0
 
-[colors]
-background = "#000000"
-
 [colors.line.hue_cycle]
-initial = "#e60000"

--- a/presets/snowflake.toml
+++ b/presets/snowflake.toml
@@ -12,9 +12,6 @@ F = "F[+FF][-FF]FF[+F][-F]FF"
 [turtle]
 angle = 60.0
 
-[colors]
-background = "#000000"
-
 [colors.line.gradient]
 start = "#e699ff"
 end = "#1a80ff"

--- a/presets/ternary_tree_3d.toml
+++ b/presets/ternary_tree_3d.toml
@@ -14,9 +14,6 @@ F = 'FF'
 angle = 40.0
 initial_heading = 90.0
 
-[colors]
-background = "#000000"
-
 [colors.line.gradient]
 start = "#8c400d"
 end = "#1af273"

--- a/presets/tree_3d.toml
+++ b/presets/tree_3d.toml
@@ -14,8 +14,4 @@ F = 'FF'
 angle = 40.0
 initial_heading = 90.0
 
-[colors]
-background = "#000000"
-
 [colors.line.hue_cycle]
-initial = "#e60000"


### PR DESCRIPTION
## What changed

Add a **\"Default\" checkbox** next to each color field in both UIs — background, solid line, gradient start, gradient end, and hue-cycle initial. When the checkbox is on, the field is omitted from TOML and resolved from `defaults.toml` at render time. When unchecked, the last explicit value is restored from `ColorControlMemory`, not the currently displayed default.

Preset TOMLs are cleaned up: `background = "#000000"` and `hue_cycle.initial = "#e60000"` lines that matched defaults are removed, making the authored intent clearer.

## Leptos UI redesign

The Colors section is restructured: each field now has a section label (styled like \"Dimensions\" in Parameters) followed by a single row containing the Default checkbox and a color input that is always visible.

## Implementation

- `CleanMut::set_line_color` now accepts `Option<EditorLineColorConfig>` instead of the resolved `LineColorConfig`, so each field's `None`/`Some` optionality round-trips through the TOML layer.
- `ColorControlMemory` stores `EditorLineColorConfig` (with `Option` fields) instead of resolved `LineColorConfig`, so per-field default state is preserved across line-color mode switches.
- `EditorLineColorConfig::gradient_fields()` extracts the three gradient `Option` fields, shared by both UIs and the Iced message handler.