### PR TITLE
Replace wasm Blob/URL/timer boilerplate with gloo

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1406,6 +1406,29 @@ dependencies = [
 ]
 
 [[package]]
+name = "gloo-events"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "27c26fb45f7c385ba980f5fa87ac677e363949e065a083722697ef1b2cc91e41"
+dependencies = [
+ "wasm-bindgen",
+ "web-sys",
+]
+
+[[package]]
+name = "gloo-file"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "97563d71863fb2824b2e974e754a81d19c4a7ec47b09ced8a0e6656b6d54bd1f"
+dependencies = [
+ "futures-channel",
+ "gloo-events",
+ "js-sys",
+ "wasm-bindgen",
+ "web-sys",
+]
+
+[[package]]
 name = "gloo-net"
 version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1424,6 +1447,18 @@ dependencies = [
  "wasm-bindgen",
  "wasm-bindgen-futures",
  "web-sys",
+]
+
+[[package]]
+name = "gloo-timers"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bbb143cf96099802033e0d4f4963b19fd2e0b728bcf076cd9cf7f6634f092994"
+dependencies = [
+ "futures-channel",
+ "futures-core",
+ "js-sys",
+ "wasm-bindgen",
 ]
 
 [[package]]
@@ -2340,15 +2375,15 @@ dependencies = [
  "console_error_panic_hook",
  "console_log",
  "env_logger",
+ "gloo-file",
+ "gloo-timers",
  "iced",
- "js-sys",
  "log",
  "lsystem-app-model",
  "lsystem-core",
  "lsystem-renderer",
  "rfd",
  "wasm-bindgen",
- "wasm-bindgen-futures",
  "web-sys",
  "wgpu",
 ]
@@ -2393,6 +2428,7 @@ version = "0.1.0"
 dependencies = [
  "console_error_panic_hook",
  "console_log",
+ "gloo-file",
  "js-sys",
  "leptos",
  "log",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,6 +13,8 @@ license = "MIT OR Apache-2.0"
 
 [workspace.dependencies]
 console_error_panic_hook = "0.1"
+gloo-file = "0.3"
+gloo-timers = "0.3"
 console_log = "1"
 glam = "0.33"
 iced = { git = "https://github.com/iced-rs/iced", rev = "51e9c2d06613efe42c591397c91769761640570d", default-features = false }

--- a/crates/lsystem-app/Cargo.toml
+++ b/crates/lsystem-app/Cargo.toml
@@ -23,18 +23,15 @@ rfd = "0.17"
 iced = { workspace = true, features = ["advanced", "wgpu", "webgl", "web-colors", "fira-sans", "crisp"] }
 console_error_panic_hook.workspace = true
 console_log.workspace = true
-js-sys.workspace = true
+gloo-file.workspace = true
+gloo-timers = { workspace = true, features = ["futures"] }
 wasm-bindgen.workspace = true
-wasm-bindgen-futures.workspace = true
 web-sys = { workspace = true, features = [
-    "Blob",
-    "BlobPropertyBag",
     "CssStyleDeclaration",
     "Document",
     "Element",
     "HtmlAnchorElement",
     "HtmlCanvasElement",
     "HtmlElement",
-    "Url",
     "Window",
 ] }

--- a/crates/lsystem-app/src/export.rs
+++ b/crates/lsystem-app/src/export.rs
@@ -133,13 +133,7 @@ async fn save_png(cfg: Config, width: u32, path: PathBuf, camera: Camera) -> Exp
 
 #[cfg(target_arch = "wasm32")]
 fn save_svg(svg: String, suggested_name: String) -> ExportOutcome {
-    let array = js_sys::Array::new();
-    array.push(&wasm_bindgen::JsValue::from_str(&svg));
-    let props = web_sys::BlobPropertyBag::new();
-    props.set_type("image/svg+xml");
-    let Ok(blob) = web_sys::Blob::new_with_str_sequence_and_options(&array, &props) else {
-        return ExportOutcome::Failed("failed to create SVG Blob".to_string());
-    };
+    let blob = gloo_file::Blob::new_with_options(svg.as_str(), Some("image/svg+xml"));
     download_blob(blob, suggested_name);
     ExportOutcome::Saved("SVG")
 }
@@ -153,15 +147,7 @@ async fn save_png(
 ) -> ExportOutcome {
     match lsystem_renderer::png_export::render_png_standalone(&cfg, width, &camera).await {
         Ok(png) => {
-            let array = js_sys::Array::new();
-            let bytes = js_sys::Uint8Array::from(png.bytes.as_slice());
-            array.push(&bytes);
-            let props = web_sys::BlobPropertyBag::new();
-            props.set_type("image/png");
-            let Ok(blob) = web_sys::Blob::new_with_u8_array_sequence_and_options(&array, &props)
-            else {
-                return ExportOutcome::Failed("failed to create PNG Blob".to_string());
-            };
+            let blob = gloo_file::Blob::new_with_options(png.bytes.as_slice(), Some("image/png"));
             download_blob(blob, suggested_name);
             ExportOutcome::Saved("PNG")
         }
@@ -173,7 +159,7 @@ async fn save_png(
 }
 
 #[cfg(target_arch = "wasm32")]
-fn download_blob(blob: web_sys::Blob, suggested_name: String) {
+fn download_blob(blob: gloo_file::Blob, suggested_name: String) {
     use wasm_bindgen::JsCast;
 
     let Some(window) = web_sys::window() else {
@@ -183,9 +169,7 @@ fn download_blob(blob: web_sys::Blob, suggested_name: String) {
         return;
     };
 
-    let Ok(url) = web_sys::Url::create_object_url_with_blob(&blob) else {
-        return;
-    };
+    let url = gloo_file::ObjectUrl::from(blob);
 
     let Ok(el) = document.create_element("a") else {
         return;
@@ -201,5 +185,4 @@ fn download_blob(blob: web_sys::Blob, suggested_name: String) {
         anchor.click();
         let _ = body.remove_child(&anchor);
     }
-    let _ = web_sys::Url::revoke_object_url(&url);
 }

--- a/crates/lsystem-app/src/ui/fractal_canvas.rs
+++ b/crates/lsystem-app/src/ui/fractal_canvas.rs
@@ -487,28 +487,7 @@ async fn yield_generation() {
 
 #[cfg(target_arch = "wasm32")]
 async fn yield_generation() {
-    use wasm_bindgen::{JsCast, JsValue, closure::Closure};
-
-    let promise = js_sys::Promise::new(&mut |resolve, _reject| {
-        let Some(window) = web_sys::window() else {
-            let _ = resolve.call0(&JsValue::UNDEFINED);
-            return;
-        };
-
-        let fallback_resolve = resolve.clone();
-        let callback = Closure::once_into_js(move || {
-            let _ = resolve.call0(&JsValue::UNDEFINED);
-        });
-
-        if window
-            .set_timeout_with_callback_and_timeout_and_arguments_0(callback.unchecked_ref(), 0)
-            .is_err()
-        {
-            let _ = fallback_resolve.call0(&JsValue::UNDEFINED);
-        }
-    });
-
-    let _ = wasm_bindgen_futures::JsFuture::from(promise).await;
+    gloo_timers::future::TimeoutFuture::new(0).await;
 }
 
 impl Default for Scene {

--- a/crates/lsystem-web-app/Cargo.toml
+++ b/crates/lsystem-web-app/Cargo.toml
@@ -13,14 +13,13 @@ lsystem-app-model = { workspace = true }
 lsystem-renderer = { workspace = true, features = ["png"] }
 console_error_panic_hook.workspace = true
 console_log.workspace = true
+gloo-file = { workspace = true, features = ["futures"] }
 js-sys.workspace = true
 leptos = { version = "0.8", features = ["csr"] }
 log.workspace = true
 wasm-bindgen.workspace = true
 wasm-bindgen-futures.workspace = true
 web-sys = { workspace = true, features = [
-    "Blob",
-    "BlobPropertyBag",
     "Document",
     "DomRect",
     "Element",
@@ -35,7 +34,6 @@ web-sys = { workspace = true, features = [
     "KeyboardEvent",
     "MouseEvent",
     "PointerEvent",
-    "Url",
     "WheelEvent",
     "Window",
 ] }

--- a/crates/lsystem-web-app/src/app.rs
+++ b/crates/lsystem-web-app/src/app.rs
@@ -680,9 +680,7 @@ pub(crate) fn App() -> impl IntoView {
                                             workspace_error.set(None);
                                             let name = config_workspace
                                                 .with_untracked(|ws| ws.selected().name().to_string());
-                                            download_toml(&name, &toml_text.get_untracked(), |msg| {
-                                                workspace_error.set(Some(msg));
-                                            });
+                                            download_toml(&name, &toml_text.get_untracked());
                                         }
                                     >"Save"</button>
                                 </div>
@@ -713,24 +711,10 @@ pub(crate) fn App() -> impl IntoView {
                             return;
                         };
                         let Some(file) = files.get(0) else { return };
-                        let promise = file.text();
+                        let file = gloo_file::File::from(file);
                         wasm_bindgen_futures::spawn_local(async move {
-                            match wasm_bindgen_futures::JsFuture::from(promise).await {
-                                Ok(val) => {
-                                    let Some(text) = val.as_string() else {
-                                        log::error!(
-                                            "import_toml: File.text() resolved to a \
-                                             non-string JS value: {val:?}"
-                                        );
-                                        workspace_error.set(Some(
-                                            "Failed to read file: unexpected content type."
-                                                .to_string(),
-                                        ));
-                                        if let Some(input) = file_input_ref.get_untracked() {
-                                            input.set_value("");
-                                        }
-                                        return;
-                                    };
+                            match gloo_file::futures::read_as_text(&file).await {
+                                Ok(text) => {
                                     let result = config_workspace
                                         .try_update(|ws| ws.import_toml(&text));
                                     match result {
@@ -752,7 +736,7 @@ pub(crate) fn App() -> impl IntoView {
                                 }
                                 Err(e) => {
                                     workspace_error
-                                        .set(Some(format!("Failed to read file: {e:?}")));
+                                        .set(Some(format!("Failed to read file: {e}")));
                                 }
                             }
                             if let Some(input) = file_input_ref.get_untracked() {

--- a/crates/lsystem-web-app/src/export.rs
+++ b/crates/lsystem-web-app/src/export.rs
@@ -8,14 +8,8 @@ use wasm_bindgen::JsCast;
 pub(crate) fn export_svg(config: Config) {
     let filename = sanitize_filename(&config.name, "svg");
     let svg = lsystem_core::svg_export::export_svg(&config);
-    let array = js_sys::Array::new();
-    array.push(&wasm_bindgen::JsValue::from_str(&svg));
-    let props = web_sys::BlobPropertyBag::new();
-    props.set_type("image/svg+xml");
-    match web_sys::Blob::new_with_str_sequence_and_options(&array, &props) {
-        Ok(blob) => download_blob(blob, filename),
-        Err(err) => log::error!("Failed to create SVG export blob: {err:?}"),
-    }
+    let blob = gloo_file::Blob::new_with_options(svg.as_str(), Some("image/svg+xml"));
+    download_blob(blob, filename);
 }
 
 pub(crate) fn export_png(
@@ -32,15 +26,9 @@ pub(crate) fn export_png(
             .await
         {
             Ok(png) => {
-                let array = js_sys::Array::new();
-                let bytes = js_sys::Uint8Array::from(png.bytes.as_slice());
-                array.push(&bytes);
-                let props = web_sys::BlobPropertyBag::new();
-                props.set_type("image/png");
-                match web_sys::Blob::new_with_u8_array_sequence_and_options(&array, &props) {
-                    Ok(blob) => download_blob(blob, filename),
-                    Err(err) => log::error!("Failed to create PNG export blob: {err:?}"),
-                }
+                let blob =
+                    gloo_file::Blob::new_with_options(png.bytes.as_slice(), Some("image/png"));
+                download_blob(blob, filename);
             }
             Err(err) => {
                 let error = format!("Failed to export PNG: {err}");
@@ -51,23 +39,13 @@ pub(crate) fn export_png(
     });
 }
 
-pub(crate) fn download_toml(name: &str, text: &str, on_error: impl Fn(String)) {
+pub(crate) fn download_toml(name: &str, text: &str) {
     let filename = sanitize_filename(name, "toml");
-    let array = js_sys::Array::new();
-    array.push(&wasm_bindgen::JsValue::from_str(text));
-    let props = web_sys::BlobPropertyBag::new();
-    props.set_type("application/toml");
-    match web_sys::Blob::new_with_str_sequence_and_options(&array, &props) {
-        Ok(blob) => download_blob(blob, filename),
-        Err(err) => {
-            let msg = format!("Failed to create TOML download blob: {err:?}");
-            log::error!("{msg}");
-            on_error(msg);
-        }
-    }
+    let blob = gloo_file::Blob::new_with_options(text, Some("application/toml"));
+    download_blob(blob, filename);
 }
 
-fn download_blob(blob: web_sys::Blob, suggested_name: String) {
+fn download_blob(blob: gloo_file::Blob, suggested_name: String) {
     let Some(window) = web_sys::window() else {
         log::error!("Cannot download export: window is unavailable");
         return;
@@ -76,18 +54,11 @@ fn download_blob(blob: web_sys::Blob, suggested_name: String) {
         log::error!("Cannot download export: document is unavailable");
         return;
     };
-    let url = match web_sys::Url::create_object_url_with_blob(&blob) {
-        Ok(url) => url,
-        Err(err) => {
-            log::error!("Failed to create export object URL: {err:?}");
-            return;
-        }
-    };
+    let url = gloo_file::ObjectUrl::from(blob);
     let el = match document.create_element("a") {
         Ok(el) => el,
         Err(err) => {
             log::error!("Failed to create export download link: {err:?}");
-            let _ = web_sys::Url::revoke_object_url(&url);
             return;
         }
     };
@@ -95,7 +66,6 @@ fn download_blob(blob: web_sys::Blob, suggested_name: String) {
         Ok(anchor) => anchor,
         Err(err) => {
             log::error!("Export download link was not an anchor element: {err:?}");
-            let _ = web_sys::Url::revoke_object_url(&url);
             return;
         }
     };
@@ -106,5 +76,4 @@ fn download_blob(blob: web_sys::Blob, suggested_name: String) {
         anchor.click();
         let _ = body.remove_child(&anchor);
     }
-    let _ = web_sys::Url::revoke_object_url(&url);
 }


### PR DESCRIPTION
## What changed

Adopts `gloo-file 0.3` and `gloo-timers 0.3` in both browser crates (`lsystem-web-app`, `lsystem-app`) to remove hand-rolled `js-sys`/`web-sys` plumbing.

### `gloo-file` — downloads and file upload

- **Blob construction** (`export_svg`, `export_png`, `download_toml` in both crates): replaces `js_sys::Array` + `BlobPropertyBag` + `Blob::new_with_*_and_options` with `gloo_file::Blob::new_with_options(content, Some(mime))`.
- **Object URL lifetime**: replaces four separate `Url::revoke_object_url` calls (one per early-return path) with a single `gloo_file::ObjectUrl` RAII wrapper that revokes on drop. The URL remains valid for the full synchronous `anchor.click()` dispatch before being revoked.
- **TOML file upload** (`lsystem-web-app/src/app.rs`): replaces `JsFuture::from(file.text()).await` + `val.as_string()` + a spurious "unexpected content type" branch with `gloo_file::futures::read_as_text(&file).await`, which returns a typed `Result<String, FileReadError>`. The `on_error` callback on `download_toml` was also removed since that function is now infallible.

### `gloo-timers` — cooperative yield

- `yield_generation` in `lsystem-app/src/ui/fractal_canvas.rs` shrinks from ~20 lines of manual `js_sys::Promise`/`Closure` construction to `gloo_timers::future::TimeoutFuture::new(0).await`. Behaviour is identical.

### Dependency cleanup

- `js-sys` removed from `lsystem-app`'s wasm32 target table (no remaining direct uses).
- `wasm-bindgen-futures` removed from `lsystem-app`'s wasm32 target table (no remaining direct uses; still available transitively via iced/gloo-timers).
- `Blob`, `BlobPropertyBag`, `Url` removed from both crates' explicit `web-sys` feature lists.

## Version choice

`gloo 0.3` is used rather than `0.4` to remain compatible with the `js-sys 0.3.85` pin imposed by the workspace's pinned `iced` git dependency. `gloo-file 0.4` and `gloo-timers 0.4` both require `js-sys >= 0.3.91`, which conflicts with `iced_winit`'s exact `web-sys = "=0.3.85"` pin. The `0.3` and `0.4` APIs are identical; only the minimum dependency versions differ.