### PR TITLE
Fix PNG export hanging in browser apps

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2416,6 +2416,7 @@ dependencies = [
  "encase",
  "futures-channel",
  "glam 0.33.0",
+ "gloo-timers",
  "log",
  "lsystem-core",
  "png",

--- a/crates/lsystem-renderer/Cargo.toml
+++ b/crates/lsystem-renderer/Cargo.toml
@@ -6,7 +6,10 @@ license.workspace = true
 
 [features]
 default = []
-png = ["dep:futures-channel", "dep:png"]
+png = ["dep:futures-channel", "dep:png", "dep:gloo-timers"]
+
+[target.'cfg(target_arch = "wasm32")'.dependencies]
+gloo-timers = { workspace = true, features = ["futures"], optional = true }
 
 [dependencies]
 lsystem-core.workspace = true

--- a/crates/lsystem-renderer/src/png_export.rs
+++ b/crates/lsystem-renderer/src/png_export.rs
@@ -268,19 +268,44 @@ async fn finish_render(
         .map_async(wgpu::MapMode::Read, move |result| {
             let _ = sender.send(result);
         });
-    // Native needs polling to drive the map_async callback. On browser WebGPU this is a no-op;
-    // callback completion is driven by the browser event loop.
-    device
-        .poll(wgpu::PollType::Wait {
-            submission_index: None,
-            timeout: None,
-        })
-        .map_err(PngExportError::Poll)?;
-
-    receiver
-        .await
-        .map_err(|_| PngExportError::MapChannelClosed)?
-        .map_err(PngExportError::Map)?;
+    // Native: block the thread until the map_async callback fires.
+    #[cfg(not(target_arch = "wasm32"))]
+    {
+        device
+            .poll(wgpu::PollType::Wait {
+                submission_index: None,
+                timeout: None,
+            })
+            .map_err(PngExportError::Poll)?;
+        receiver
+            .await
+            .map_err(|_| PngExportError::MapChannelClosed)?
+            .map_err(PngExportError::Map)?;
+    }
+    // Wasm: device.poll(Wait) is not supported. On the WebGPU backend, poll()
+    // is a no-op — the browser resolves the mapAsync promise automatically via
+    // its own event loop. On the WebGL2 fallback, poll(Poll) additionally fires
+    // pending wgpu callbacks. In both cases, yielding to the macrotask queue
+    // via setTimeout(0) is what allows the browser to advance GPU work.
+    #[cfg(target_arch = "wasm32")]
+    {
+        let mut receiver = receiver;
+        loop {
+            let _ = device.poll(wgpu::PollType::Poll);
+            match receiver.try_recv() {
+                Ok(Some(result)) => {
+                    result.map_err(PngExportError::Map)?;
+                    break;
+                }
+                Ok(None) => {
+                    // Yield to the macrotask queue (setTimeout 0) so the browser
+                    // can advance GPU work and resolve the WebGPU mapAsync promise.
+                    gloo_timers::future::TimeoutFuture::new(0).await;
+                }
+                Err(_) => return Err(PngExportError::MapChannelClosed),
+            }
+        }
+    }
     let rgba = {
         let mapped = readback.slice(..).get_mapped_range();
         readback_layout.strip_padding(&mapped)


### PR DESCRIPTION
## What changed

- `lsystem-renderer/src/png_export.rs`: replaced the unconditional `device.poll(Wait)` + `receiver.await` with a `#[cfg]`-split readback path
- `lsystem-renderer/Cargo.toml`: added `gloo-timers` (futures feature) as a wasm32-only optional dependency, activated by the existing `png` feature

## Why

`device.poll(PollType::Wait)` is not supported on wasm. The browser cannot honor a blocking wait and returns `PollError::Timeout` immediately, so PNG export always failed on the first attempt (the export only completed if another GPU action happened to tick the wgpu device afterward).

## How it works now

**Native path** (unchanged): `device.poll(Wait)` blocks the thread until the `map_async` callback fires, then `receiver.await` drains the oneshot channel.

**Wasm path** (new): a loop alternates between two operations until `receiver.try_recv()` returns a value:

1. `device.poll(Poll)` — on the WebGL2 fallback backend this fires any pending wgpu callbacks synchronously; on the WebGPU backend `poll()` is a no-op (the browser resolves `mapAsync` automatically via its event loop)
2. `gloo_timers::future::TimeoutFuture::new(0).await` — yields to the JS macrotask queue via `setTimeout(0)`, giving the browser a scheduling boundary to advance GPU work on both backends

A microtask yield (`Promise.resolve()`) is insufficient here — GPU work requires a macrotask boundary to progress.