### PR TITLE
Reorganize developer docs

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,148 +1,42 @@
 # AGENTS.md
 
-This file provides guidance to AI coding agents when working with code in this repository.
+This file provides repository-specific guidance for AI coding agents.
 
-> **REQUIRED before any interaction with Git or GitHub** — including `git` commands, the `gh` CLI, GitHub MCP tools, or any other mechanism that reads or writes repository or pull-request state: read `.agents/rules/git-and-github.md`.
+> **REQUIRED before any interaction with Git or GitHub** — including `git`
+> commands, the `gh` CLI, GitHub MCP tools, or any other mechanism that reads or
+> writes repository or pull-request state: read
+> [`.agents/rules/git-and-github.md`](.agents/rules/git-and-github.md).
 
-## Project Overview
+## Shared Project Docs
 
-**Grow Your Own Fractal** — an interactive L-System (Lindenmayer system) visualizer in Rust. The browser-first app (`lsystem-web-app`) uses Leptos/DOM controls with a wgpu canvas that uses WebGPU with a WebGL2 fallback on browser wasm targets, backed by the toolkit-independent `lsystem-renderer` crate. The `lsystem-app` crate uses Iced for native desktop and retained wasm builds; its fractal viewport is an `iced::widget::shader` custom primitive backed by the shared wgpu line pipeline.
+Use the shared docs instead of duplicating long-lived project knowledge here:
 
-## Common Commands
+- [`README.md`](README.md) — user-facing overview, L-System alphabet, and TOML
+  config example.
+- [`CONTRIBUTING.md`](CONTRIBUTING.md) — contributor entry point.
+- [`docs/development.md`](docs/development.md) — setup, commands, verification,
+  CI, deploy, and repository layout.
+- [`docs/architecture.md`](docs/architecture.md) — crate boundaries, data flow,
+  rendering design, config model, exports, and key invariants.
 
-```bash
-# Build & run
-cargo run -p lsystem-app          # native desktop Iced app
-trunk serve --config crates/lsystem-web-app/Trunk.toml    # browser app at localhost:8081
-trunk build --release --config crates/lsystem-web-app/Trunk.toml  # browser release → crates/lsystem-web-app/dist/
-trunk serve --config crates/lsystem-app/Trunk.toml    # Iced web app at localhost:8080
+Read the relevant shared docs before making changes in that area. For example,
+read `docs/architecture.md` before changing crate boundaries or render/config
+data flow, and read `docs/development.md` before changing commands, CI, deploy,
+or tooling.
 
-# Verification (all run in CI)
-cargo fmt --check --all
-cargo clippy --workspace --all-targets -- -D warnings
-cargo clippy --workspace --all-features --all-targets -- -D warnings
-cargo test --workspace --all-features --all-targets
-RUSTDOCFLAGS="-D warnings" cargo doc --no-deps --workspace --all-features
-cargo clippy --target wasm32-unknown-unknown --workspace -- -D warnings
-cargo clippy --target wasm32-unknown-unknown --workspace --all-features -- -D warnings
-trunk build --release --config crates/lsystem-app/Trunk.toml
-trunk build --release --config crates/lsystem-web-app/Trunk.toml
+## Agent Rules
 
-# Run a single test
-cargo test -p lsystem-core config::tests::test_name
-
-# Run SVG export tests (svg feature must be enabled explicitly)
-cargo test -p lsystem-core --features svg svg_export
-```
-
-`trunk` is managed by mise; run `mise install` to get the pinned version from `mise.toml`. `trunk` may fail to launch when `NO_COLOR=1` is present in the environment; use `NO_COLOR=true` or `NO_COLOR=false` as a workaround.
-
-## Supplemental Rules
-
-When making code changes, check whether `README.md`, `CONTRIBUTING.md`, and/or `AGENTS.md` need updates for the changed behavior, commands, architecture, or workflow. Update them in the same change when applicable.
-
-Successful CI runs on `main` trigger `.github/workflows/deploy.yml`, which deploys the Leptos browser app from `crates/lsystem-web-app/dist/` to GitHub Pages.
-
-## Architecture
-
-Five-crate workspace under `crates/`:
-
-### `lsystem-core` — pure library, zero rendering deps
-
-| Module | Role |
-|--------|------|
-| `config.rs` | Runtime config types: `Rgb` + `RgbError` (validated hex color), `ConfigError` (domain validation errors), `Dimensions` (2D/3D enum), `Config`, `GenerationConfig`, `ColorConfig`, `LineColorConfig`. `LineColorConfig::needs_topological_depth()` and `GenerationConfig::has_stack_directives()` are the render/export boundary predicates that determine which geometry and GPU mode to use. No TOML or serde deps; pure Rust data types consumed by the renderer and exporter. |
-| `alphabet.rs` | Reserved symbols (`F f + - \| [ ]` for 2D; additionally `& ^ / \` for 3D), character set validation per `dimensions`; `contains_3d_symbols(s: &str) -> bool` re-exported from `lsystem-core` |
-| `grammar.rs` | `expand(axiom, rules, iterations)` → lazy `ExpandIter` char iterator; `expand_owned` → `OwnedExpandIter` (same logic, owns its data via `Vec<char>` so callers need no lifetime) |
-| `turtle/mod.rs` | Declares `turtle2d` and `turtle3d` submodules |
-| `turtle/turtle2d.rs` | `Segments2D<I>` — pull iterator over `[Vec2; 2]` segments; owns position, heading, and bracket stack; yields one segment per `'F'` without collecting |
-| `turtle/turtle3d.rs` | `Segments3D<I>` — pull iterator over `[Vec3; 2]` segments; uses `glam::Quat` orientation (heading = `orientation * Vec3::X`); dispatches `& ^ / \` pitch/roll symbols in addition to the 2D set |
-| `svg_export.rs` | `export_svg(config) -> String` — generates an SVG string; gated behind the `svg` Cargo feature |
-| `lib.rs` | Public API: `generate(generation_config) -> impl Iterator<Item = [Vec2; 2]>`, `generate_3d(generation_config) -> impl Iterator<Item = [Vec3; 2]>`, `generate_with_topological_depth(generation_config) -> impl Iterator<Item = Segment2DWithTopologicalDepth>`, and `generate_3d_with_topological_depth(generation_config) -> impl Iterator<Item = Segment3DWithTopologicalDepth>`; re-exports `contains_3d_symbols`, `validate_symbols`, `validate_bracket_balance`, `Config`, `ConfigError`, `ColorConfig`, `Dimensions`, `GenerationConfig`, `LineColorConfig`, `Rgb`, and `RgbError`; exposes `svg_export` when the `svg` feature is enabled |
-
-Data flow (2D): `GenerationConfig` → `OwnedExpandIter` → `Segments2D` → streaming `[Vec2; 2]` segments.
-Data flow (3D): `GenerationConfig` → `OwnedExpandIter` → `Segments3D` → streaming `[Vec3; 2]` segments.
-Config data flow (app-model): `ConfigSource::parse` → `RawConfig` → `EditorConfig` → resolved `Config` → `GenerationConfig`.
-
-### `lsystem-app-model` — toolkit-independent application model
-
-Depends on `lsystem-core`. Renderer-free and toolkit-free; must not depend on `iced`, `leptos`, `web-sys`, `wasm-bindgen`, `wgpu`, or `lsystem-renderer`.
-
-| Module | Role |
-|--------|------|
-| `config_defaults.rs` | `ConfigDefaults`, `TurtleDefaults`, `ColorDefaults`, `LineColorDefaults`, `GradientDefaults`, `HueCycleDefaults` — parsed from embedded `defaults.toml` via `ConfigDefaults::embedded()` (cached via `OnceLock`). `LineColorDefaults` has no `default` field; omitting `colors.line` always resolves to `LineColorConfig::Solid(defaults.line.solid)`. `ParseConfigError` — error type covering TOML parse errors (`TomlParse`, `TomlDeserialize`) and domain validation failures (`Validation(ConfigError)`). Shared helpers `validate_step` and `validate_initial_heading` used by both defaults and editor-config paths. |
-| `editor_config.rs` | TOML config pipeline: `ConfigSource` wraps a `toml_edit::DocumentMut` (format-preserving, parse-only); strict `RawConfig` validates into `EditorConfig` that preserves defaultable authored fields as `Option`s; `EditorConfig::resolve(ConfigDefaults::embedded(), max_iterations)` produces the fully resolved runtime `Config`; `ConfigDocument` stores the source and validated editor config, but no cached runtime `Config`. Validates symbols, rules, step/angle finiteness, bracket balance, optional authored background color, externally tagged line colors (`solid`, `gradient`, `hue_cycle`) including optional `gradient.topological_depth`, and hex color strings. Render/export callers resolve runtime `Config` values at their boundaries. |
-| `config_workspace.rs` | Shared session config workspace; tracks optional draft TOML, a last-applied `ConfigDocument`, and an optional bundled default document per entry; exposes indexed copy/apply/revert/reset operations while each UI owns selection; exposes `editor_config()` for source-presence/editor state while render/export callers resolve or assemble runtime `Config` values at their boundaries |
-| `presets.rs` | `load_presets() -> Vec<(String, String)>` — embeds the `presets/` directory at compile time via `include_dir!` and returns sorted `(label, TOML text)` pairs; replaces identical helpers that previously lived in each GUI crate |
-| `color.rs` | `LineColorMode` — unified enum with `ALL`, `Display`, `from_key`/`key`, `from_line_color`, and `from_editor_line_color`; `line_color_for_controls` resolves authored/default values without runtime-only normalization; `selected_line_color_mode` returns the picker mode for authored or default color state; `ColorControlMemory` — per-mode `Rgb` slot store for UI color picker memory, initialized from editor color state plus defaults |
-| `animation.rs` | `HueRotation` (no `phase_degrees` field), `HueRotationDirection` (with `ALL`, `Display`, `sign`), speed constants, and `advance_hue_rotation_phase_degrees(phase, speed, dt, direction) -> f32` free function; phase accumulator stored separately by each GUI |
-| `util.rs` | `sanitize_filename` — pure filename utility with no toolkit dependencies |
-
-### `lsystem-renderer` — toolkit-independent wgpu renderer
-
-Depends on `lsystem-core` and `wgpu`.
-
-| File | Role |
-|------|------|
-| `camera.rs` | Shared `Camera` — 2D pan/zoom state and 3D orbit (azimuth, elevation, roll, zoom) state; `compute_transform` for 2D, `compute_mvp_3d` for perspective 3D; `reset()` resets all state, `reset_position()` preserves rotation for scene rebuilds |
-| `line_renderer.rs` | `Segment2D`/`Segment3D` GPU instance types plus `TopologicalDepthSegment2D`/`TopologicalDepthSegment3D` for depth-aware rendering. `GrowableVertexBuffer` — grows to next power-of-two capacity on demand and counts segment instances. Vertex instance buffers remain `bytemuck`-cast records, while `Transform`, `Mvp`, and `ColorParams` uniform writes use `encase::ShaderType` WGSL layout serialization. `LinePipeline2D` — 2D `Transform` uniform + `LinePipeline3D` — `Mvp` (64-byte MVP matrix) uniform; both own normal and topological-depth render pipelines that each serve all color modes, and share a private `draw_line_list()` helper using `draw(0..2, 0..segment_count)`. `write_color_params()` updates only the color uniform without re-uploading segment data. `GpuContext`, `GpuInitError`, `FrameOutcome`, `SurfaceFrame`. Dimension and stack-directive-aware segment-count caps keep normal and depth segment buffers within wgpu's guaranteed 256 MiB vertex-buffer limit. |
-| `lsystem_bridge.rs` | L-system→GPU adapters. `geometry_to_segments()` for 2D (`SegmentData`), `geometry_to_segments_3d()` for 3D (`SegmentData3D`), and topological-depth variants that preserve per-segment depth and compute `max_topological_depth`. `color_params_from_config(line, total_segments, max_topological_depth, has_depth_geometry)` maps `LineColorConfig` to the `ColorParams` GPU uniform; selects `DepthGradient` mode only when both `topological_depth` is set in config AND `has_depth_geometry` is true (i.e., depth geometry was actually uploaded), otherwise falls back to traversal-order gradient. |
-| `offscreen.rs` | Private module (under the `png` feature) with GPU plumbing shared by PNG and APNG export: `ExportScene` (one enum-backed type pairing the 2D or 3D line pipeline with bounds of the matching dimensionality, plus resolved `ColorParams`; exposes `write_camera` and `write_color_params`) and `RenderTarget` (offscreen texture + readback buffer + `ReadbackLayout`; `render_frame` returns tightly packed RGBA) |
-| `png_export.rs` | Public PNG export surface; gated behind the `png` Cargo feature. `render_png` (caller-supplied device) / `render_png_standalone` (creates its own device) → `PngExport { width, height, bytes }`; shared `ExportError` used by both PNG and APNG paths; public `MIN_DIMENSION`/`MAX_DIMENSION` width/height limits consumed by both UIs |
-| `animation_export.rs` | Public APNG animation export surface; gated behind the `png` Cargo feature. `AnimationParams` (with `MAX_FRAMES` and `validate()`), `AnimationExportError` (animation-specific variants + `Export(ExportError)`); `render_animation` / `render_animation_standalone` → `PngExport`; geometry uploaded once via `offscreen::ExportScene`, only uniforms change per frame |
-| `wgpu_util.rs` | Shared wgpu instance/device descriptor and uncaptured-error logging helpers; browser wasm creates an instance with a web display handle so wgpu can use WebGPU or fall back to WebGL2, while native and Emscripten use the normal non-web instance path |
-| `shader.wgsl` | 2D vertex shader: applies `Transform` (scale + offset), computes per-segment color from `ColorParams`; topology `LineList` |
-| `shader3d.wgsl` | 3D vertex shader: applies `Mvp` matrix for perspective projection, same per-segment color logic as `shader.wgsl` |
-
-### `lsystem-app` — entry points and Iced UI
-
-Depends on `lsystem-core`, `lsystem-app-model`, `lsystem-renderer`, `iced`, and browser/native export support crates.
-
-| File | Role |
-|------|------|
-| `main.rs` | Thin native entry that calls `lib.rs::run_native()` |
-| `lib.rs` | Module declarations; `run_native()` starts the Iced app on desktop; `#[wasm_bindgen(start)] start()` starts the same Iced app on web |
-| `ui.rs` | Iced UI module shell and shared UI constants |
-| `ui/app_state.rs` | `FractalApp` state/update/view, preset/config controls, async geometry generation, stale-generation cancellation, exports, and pan/zoom messages |
-| `ui/controls.rs` | Iced control panel widgets; hides SVG export and shows auto-rotate controls for 3D scenes |
-| `ui/fractal_canvas.rs` | `iced::widget::shader` integration; `Scene` holds either 2D or 3D geometry plus camera; mouse drag orbits in 3D, pans in 2D; GPU upload-by-scene-revision |
-| `export.rs` | Native/browser SVG and PNG export helpers; PNG export creates an offscreen wgpu device instead of borrowing Iced's renderer device |
-
-### `lsystem-web-app` — browser-first Leptos UI
-
-Depends on `lsystem-core`, `lsystem-app-model`, `lsystem-renderer`, `leptos`, and browser `web-sys`/`wasm-bindgen` APIs.
-
-| File | Role |
-|------|------|
-| `lib.rs` | Leptos CSR entry point |
-| `app.rs` | DOM controls for presets, TOML, overrides, viewport input, export buttons, and GPU rendering error display |
-| `presets.rs` | Effective-config helpers (`max_iterations_for_editor_config`); preset loading delegated to `lsystem_app_model::load_presets` |
-| `export.rs` | Browser SVG/PNG download helpers |
-| `renderer.rs` | `CanvasRenderer` — owns `GpuContext`, `LinePipeline2D`, `LinePipeline3D`, `Camera`, and an `ActiveScene` enum (2D or 3D); dispatches drag to pan (2D) or orbit (3D); handles canvas resize, zoom, orbit, roll, auto-rotate, reset, and surface-loss recovery |
-| `index.html` | Trunk entry that mounts the Leptos app |
-| `Trunk.toml` | Browser app build config, served locally on `127.0.0.1:8081` |
-
-### `presets/`
-
-Bundled TOML L-System definitions. New fractals are added here; they are embedded at compile time via `include_dir!` in `lsystem-app-model` (via `load_presets()`) and auto-discovered — no registration step needed.
-
-## Key Design Decisions
-
-- **Streaming segment pipeline**: `generate()` returns a lazy `impl Iterator<Item = [Vec2; 2]>` — no intermediate `Vec<[Vec2; 2]>` is ever allocated. `OwnedExpandIter` (in `grammar.rs`) owns the axiom and rules as `Vec<char>` so the iterator carries no lifetime. `Segments2D` (in `turtle/turtle2d.rs`) yields one segment per `'F'` symbol, holding only position, heading, and a bracket stack. `geometry_to_segments` streams the iterator directly into the GPU segment instance buffer, so peak memory is one `Vec<Segment2D>` rather than a segment vec plus a vertex vec simultaneously.
-- **Lazy expansion**: `ExpandIter` / `OwnedExpandIter` avoid materializing the full rewritten string, keeping memory bounded for high-iteration fractals.
-- **Dual target from day one**: `lsystem-core` has no platform-specific deps so it compiles for both native and `wasm32-unknown-unknown` without feature flags.
-- **Iced/wgpu version coupling**: the workspace `wgpu` dependency is pinned to version 29 and Iced is pinned to a specific upstream git revision that uses the same wgpu major version. Do not independently bump `wgpu` or the Iced git revision; update them in lockstep and verify native + wasm builds.
-- **3D turtle uses quaternion orientation**: `Segments3D<I>` stores a `glam::Quat` orientation instead of a scalar heading angle. Heading = `orientation * Vec3::X`; left = `* Vec3::Y`; up = `* Vec3::Z`. Each rotation symbol applies `orientation *= Quat::from_rotation_*(angle)` in local space, so rotations compose correctly regardless of prior orientation.
-- **Whitespace in axiom/rules is stripped**: whitespace inside `axiom` and rule RHS strings is removed before validation and expansion, allowing multi-line formatting in TOML configs.
-- **Config parse/validate/resolve**: `ConfigSource` and `ConfigDocument` live in `lsystem-app-model/src/editor_config.rs`; `ConfigDefaults` and `ParseConfigError` live in `lsystem-app-model/src/config_defaults.rs`. `ConfigSource` (a `toml_edit::DocumentMut` wrapper) is the output of `ConfigSource::parse`; it is format-preserving but carries no validity guarantee. `TryFrom<ConfigSource> for ConfigDocument` deserializes strict `RawConfig`, validates it into `EditorConfig`, and stores the source plus validated editor config. Holding a `ConfigDocument` is a runtime invariant that `editor_config()` returns the validated config-as-authored; it does not cache or expose a resolved runtime `Config`. Config parsing accepts nested v2 field paths, explicit tables, dotted keys, and implicit parent tables; canonical TOML uses explicit `[metadata]`, `[l-system]`, `[l-system.rules]`, and `[colors]` tables, plus a line-color entry such as `colors.line.solid = "#rrggbb"`, `[colors.line.gradient]`, or `[colors.line.hue_cycle]`. `colors.background`, `colors.line`, `l-system.step`, `l-system.initial_heading`, and line-mode parameters may be omitted in `EditorConfig`; resolved `Config` fills them from `defaults.toml` (embedded in `lsystem-app-model`), whose strict `RawDefaults -> ConfigDefaults` validation uses `#[serde(deny_unknown_fields)]` and the same finite turtle/RGB validation paths. Render/export callers resolve or assemble runtime `Config` values at render/export boundaries and read `Config.colors.background` and `Config.colors.line` there.
-- **Session config workspace**: `ConfigWorkspace` (in `lsystem-app-model`) is the shared source of config entry state for both UIs, while each client owns its selected entry index. Each entry stores only an optional dirty draft, a last-applied `ConfigDocument`, and an optional bundled default document; names, applied text, editor/source-presence state, and resolved `Config` values are derived from those on demand. Indexed Copy creates a renamed custom copy that preserves dirty draft text separately from the last-applied document and returns the new entry index, failed Apply keeps the current rendered scene, Revert drops the dirty draft, Reset restores bundled defaults for preset entries when the last-applied document differs from the default, custom entries have no bundled default, clean iteration/angle/background/line color changes update the entry's last-applied TOML through validated `ConfigEntry` setters, and dirty drafts disable config-affecting controls until Apply/Revert.
-- **Line color modes**: `LineColorConfig` supports solid RGB, gradient, and hue-cycle. The gradient mode also has a `topological_depth` boolean; when enabled, gradient interpolation uses turtle topological depth instead of traversal order. TOML uses an externally tagged shape: omitted `colors.line` always resolves to `LineColorConfig::Solid(defaults.line.solid)` — this is a deliberate choice, since any non-solid default would make it impossible to reach solid mode via omission (the externally-tagged shape means `colors.line.solid` selects solid explicitly, but there would be no way to get solid by omission if the default were non-solid). `colors.line.solid = "#rrggbb"` selects solid, `[colors.line.gradient]` may set optional `start`, `end`, and `topological_depth`, and `[colors.line.hue_cycle]` may set optional `initial`. `EditorLineColorConfig` preserves omitted mode parameters as `None`; resolved `LineColorConfig` contains concrete values. Color fields are validated `Rgb` values; TOML uses `"#rrggbb"` hex strings; `HueCycle { initial }` is converted to HSV in `color_params_from_config` when building the GPU uniform. Both UIs also expose transient hue rotation for hue-cycle mode; it advances a phase value and writes an adjusted `hue_start` color uniform, without changing TOML, presets, geometry, exports, or the config schema. The rotation state is preserved but ignored while another line color mode is active. Topological-depth gradient uses turtle topological depth: the first drawn `F` segment is depth 0, each drawn `F` increments depth, `f` does not, and bracket stack push/pop restores depth with turtle position and orientation. Topological-depth geometry (`TopologicalDepthSegment2D`/`3D`) is generated when `GenerationConfig::has_stack_directives()` is true — i.e., the axiom or any rule RHS contains `[` — independent of the active color mode. The GPU mode is resolved at the render/export boundary: `color_params_from_config` uses `DepthGradient` mode only when `LineColorConfig::needs_topological_depth() && has_depth_geometry`; a bracketless grammar uploads plain geometry, so `has_depth_geometry` is false and `color_params_from_config` falls back to traversal-order gradient even if `topological_depth` is authored. Render and export paths read `config.colors` directly; export paths therefore avoid depth-segment allocation when the resolved color does not need it, while interactive scene builders may still keep depth geometry for bracketed grammars so later color-only changes do not rebuild geometry. The editor config and the UI color-mode picker preserve the authored active mode; correct depth geometry activates as soon as the fractal gains a stack directive. Color-mode changes, the topological-depth checkbox, and hue rotation never trigger geometry recomputation; both pipelines handle all color modes by dispatching on `color_params.mode` in the vertex shader.
-- **Fractal lives in an Iced shader widget**: `lsystem-app` renders the fractal through `iced::widget::shader`. Iced owns the window, surface, event loop, and render pass; the custom primitive owns only the fractal GPU pipeline state.
-- **Async scene generation**: `FractalApp` schedules geometry generation with `Task::perform` when presets, TOML, iterations, or angle change. Each request gets a monotonic generation token; stale results are ignored, so rapid slider changes do not block the UI with outdated work.
-- **Scene-revision uploads**: `FractalApp::schedule_scene_generation()` increments a monotonic generation token whenever geometry is requested. Completed scene builds store that token as `Scene::geometry_revision`; color-only changes increment `Scene::color_revision` independently. The Iced shader pipeline re-uploads segment instances and color params when `geometry_revision` changes, writes only the color params uniform when `color_revision` changes, and skips both when neither changes. Camera transforms are always written during prepare.
-- **Reusable segment instance buffer**: `GrowableVertexBuffer` grows the GPU vertex buffer to the next power-of-two capacity when needed and otherwise updates it with `Queue::write_buffer`. Both `LinePipeline2D` and `LinePipeline3D` use it via a generic `upload<V: Pod>` method. Line rendering is instanced: one GPU record per segment, shader `vertex_index` selects start/end, and `instance_index` drives traversal gradient and hue-cycle colors.
-- **2D/3D pipeline split**: `LinePipeline2D` and `LinePipeline3D` are separate structs with different uniform types (`Transform` vs `Mvp`) and different shaders, but share `GrowableVertexBuffer` and a private `draw_line_list()` helper to avoid duplication. `lsystem-web-app`'s `CanvasRenderer` owns both pipelines and keeps both always-initialized; `lsystem-app`'s `Scene` holds an enum that selects the active pipeline at draw time.
-- **DOM browser UI with GPU canvas**: `lsystem-web-app` owns browser UI state in Leptos signals and renders the fractal into a dedicated `<canvas>`. It creates a wgpu surface from `web_sys::HtmlCanvasElement`, reuses `LinePipeline`, and drives rendering from explicit DOM events instead of a continuous repaint loop. On browser wasm targets, `wgpu_util` creates the instance with a web display handle and WebGPU detection so wgpu can use WebGPU when available and fall back to WebGL2 otherwise.
-- **Surface acquisition recovery**: `GpuContext::begin_frame` retries `CurrentSurfaceTexture::Outdated` once after reconfiguring the surface. Timeout and occlusion are quiet skip reasons, validation/repeated-outdated are explicit skip reasons, and true surface loss is reported to callers. The Leptos web renderer rebuilds `GpuContext` and `LinePipeline` after surface loss while preserving CPU-side scene/camera/color state and marking geometry for reupload.
-- **SVG export is 2D-only**: SVG export is a `lsystem-core` Cargo feature (`svg`). `export_svg(config) -> String` collects 2D segments, computes a padded bounding box, and builds SVG XML. For gradients with `topological_depth = true`, it collects topological-depth segments and colors by depth normalized to the maximum emitted topological depth so SVG matches canvas rendering. The Y-axis flip is handled by a `<g transform="matrix(1 0 0 -1 0 0)">` group. Both apps hide the SVG export button when `config.dimensions == 3`.
-- **Strict CI**: `clippy -D warnings` and `cargo fmt --check` must pass. A single Clippy job lints native default/all-features builds (with `--all-targets`) and `wasm32-unknown-unknown` default/all-features builds. CI also tests the workspace with all features/all targets, builds rustdoc with `RUSTDOCFLAGS=-D warnings`, and builds both Trunk web apps. Toolchain channel/components/targets come from `rust-toolchain.toml`; rustup auto-installs them on first cargo invocation. GitHub Pages deploys the Leptos browser app.
+- Keep `AGENTS.md` focused on agent-only workflow. Put durable architecture,
+  setup, and contributor information in `docs/` or `CONTRIBUTING.md`.
+- When changing behavior, commands, architecture, config format, deploy
+  workflow, or contributor workflow, update the relevant docs in the same
+  change.
+- The primary browser app is `lsystem-web-app`; `lsystem-app` provides the
+  native Iced app and retained Iced web build.
+- Preserve crate boundaries from `docs/architecture.md`. In particular,
+  `lsystem-core` stays free of rendering/TOML/UI/platform dependencies, and
+  `lsystem-app-model` stays toolkit- and renderer-independent.
+- `wgpu` and the pinned Iced git revision are coupled. Do not update either one
+  independently; update and verify them together.
+- Prefer focused verification while iterating, then run the relevant checks from
+  `docs/development.md` before claiming a code change is complete.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,25 +1,23 @@
 # Contributing
 
-Thanks for helping improve Grow Your Own Fractal. This guide covers local
-setup, build commands, verification, CI, and the workspace layout.
+Thanks for helping improve Grow Your Own Fractal.
 
-## Prerequisites
+## Start Here
 
-| Tool | Purpose |
-|------|---------|
-| [Rust](https://rustup.rs/) stable | compiler (version pinned in `rust-toolchain.toml`) |
-| [mise](https://mise.jdx.dev/) | installs pinned tools, including `trunk` from `mise.toml` |
-| Modern browser | WebGPU support, or WebGL2 for the fallback renderer |
+- For local setup, build commands, tests, CI, deploy behavior, and repository
+  layout, see [`docs/development.md`](docs/development.md).
+- For crate responsibilities, data flow, rendering design, and important
+  invariants, see [`docs/architecture.md`](docs/architecture.md).
+- For user-facing L-System syntax and TOML examples, see [`README.md`](README.md).
+
+## Quick Setup
+
+Install the Rust toolchain from [`rust-toolchain.toml`](rust-toolchain.toml) and
+the pinned `trunk` version from [`mise.toml`](mise.toml):
 
 ```sh
 mise install
 ```
-
-The Iced dependency is pinned to a specific upstream git revision in the
-workspace manifest so the Iced renderer and the shared `wgpu` dependency stay on
-the same major version. Update them together.
-
-## Building
 
 Run the native Iced app:
 
@@ -27,107 +25,19 @@ Run the native Iced app:
 cargo run -p lsystem-app
 ```
 
-Run the browser-first Leptos app locally:
+Run the browser-first Leptos app:
 
 ```sh
 trunk serve --config crates/lsystem-web-app/Trunk.toml
 ```
 
-This serves the Leptos/DOM app at <http://127.0.0.1:8081/>.
-
-Build the browser-first Leptos app for release:
-
-```sh
-trunk build --release --config crates/lsystem-web-app/Trunk.toml
-```
-
-The release output is written to `crates/lsystem-web-app/dist/`.
-
-Run or build the retained Iced web app:
-
-```sh
-trunk serve --config crates/lsystem-app/Trunk.toml
-trunk build --release --config crates/lsystem-app/Trunk.toml
-```
-
-## Testing
-
-Run the workspace test suite:
-
-```sh
-cargo test --workspace --all-features --all-targets
-```
-
-Run a single core test:
-
-```sh
-cargo test -p lsystem-core config::tests::test_name
-```
-
-Run SVG export tests:
-
-```sh
-cargo test -p lsystem-core --features svg svg_export
-```
+The Leptos app serves on <http://127.0.0.1:8081/>.
 
 ## Before Submitting
 
-Run the same checks CI runs when the change affects code, build config, docs
-that rustdoc consumes, or web app behavior:
+Use the smallest relevant command while iterating, then run the affected checks
+from [`docs/development.md`](docs/development.md#full-verification) before
+submitting code changes.
 
-```sh
-cargo fmt --check --all
-cargo clippy --workspace --all-targets -- -D warnings
-cargo clippy --workspace --all-features --all-targets -- -D warnings
-cargo test --workspace --all-features --all-targets
-RUSTDOCFLAGS="-D warnings" cargo doc --no-deps --workspace --all-features
-cargo clippy --target wasm32-unknown-unknown --workspace -- -D warnings
-cargo clippy --target wasm32-unknown-unknown --workspace --all-features -- -D warnings
-trunk build --release --config crates/lsystem-app/Trunk.toml
-trunk build --release --config crates/lsystem-web-app/Trunk.toml
-```
-
-## Project Structure
-
-```text
-Cargo.toml                  workspace manifest
-rust-toolchain.toml         pins stable Rust + wasm32 target + components
-mise.toml                   pins trunk version (read by CI and local dev)
-.github/workflows/ci.yml    fmt, clippy, test, docs, trunk-build
-.github/workflows/deploy.yml deploys the Leptos web app to GitHub Pages
-
-crates/
-  lsystem-core/             L-system grammar expansion, turtle geometry, SVG export; runtime config types (no TOML/serde deps)
-  lsystem-renderer/         toolkit-independent wgpu camera, line rendering, and PNG/APNG export
-  lsystem-app-model/        toolkit-free shared app model (TOML config parsing/validation/defaults, config workspace, presets, color, animation, utilities)
-  lsystem-app/              Iced native app and retained Iced web app
-  lsystem-web-app/          browser-first Leptos app with DOM controls and GPU canvas
-
-crates/lsystem-app/index.html         Iced web Trunk entry
-crates/lsystem-app/Trunk.toml         Iced web Trunk config
-crates/lsystem-web-app/index.html     Leptos web Trunk entry
-crates/lsystem-web-app/Trunk.toml     Leptos web Trunk config
-
-presets/                    bundled TOML L-System definitions
-```
-
-## Continuous Integration
-
-Every push and pull request to `main` runs these jobs:
-
-| Job | Commands |
-|-----|----------|
-| fmt | `cargo fmt --check --all` |
-| clippy | `cargo clippy --workspace --all-targets -- -D warnings`; `cargo clippy --workspace --all-features --all-targets -- -D warnings`; `cargo clippy --target wasm32-unknown-unknown --workspace -- -D warnings`; `cargo clippy --target wasm32-unknown-unknown --workspace --all-features -- -D warnings` |
-| test | `cargo test --workspace --all-features --all-targets` |
-| docs | `RUSTDOCFLAGS="-D warnings" cargo doc --no-deps --workspace --all-features` |
-| trunk-build | release builds for `crates/lsystem-app/Trunk.toml` and `crates/lsystem-web-app/Trunk.toml` |
-
-Successful CI runs on `main` trigger the deploy workflow, which builds
-`crates/lsystem-web-app` with the repository GitHub Pages public URL and deploys
-`crates/lsystem-web-app/dist/`.
-
-## Documentation
-
-When changing behavior, commands, architecture, or workflow, update `README.md`,
-`CONTRIBUTING.md`, or `AGENTS.md` in the same change when applicable.
+When changing behavior, commands, architecture, config format, deploy workflow,
+or contributor workflow, update the relevant documentation in the same change.

--- a/README.md
+++ b/README.md
@@ -141,24 +141,13 @@ you can break long rules across lines for readability.
 
 ## Bundled presets
 
-| File | Name | Description |
-|------|------|-------------|
-| `presets/box_fractal.toml` | Box Fractal | Square-grid fractal built by replacing each edge with a five-segment box pattern. |
-| `presets/dragon_curve.toml` | Harter-Heighway Dragon | Self-similar curve obtained by repeatedly folding a strip of paper in half. |
-| `presets/gosper_curve.toml` | Gosper Curve | Space-filling curve that tiles the plane with hexagonal regions; also known as the flowsnake. |
-| `presets/hilbert_curve.toml` | Hilbert Curve | Space-filling curve that maps a line continuously to a 2D square while preserving locality. |
-| `presets/hilbert_curve_3d.toml` | 3D Hilbert Curve | Three-dimensional Hilbert-style space-filling curve using pitch and roll turns. |
-| `presets/koch_snowflake.toml` | Koch Snowflake | Classic fractal snowflake built by iteratively replacing each edge with a triangular bump. |
-| `presets/levy_c_curve.toml` | Lévy C Curve | Self-similar curve formed by recursively replacing a segment with two right-angled turns. |
-| `presets/peano_curve.toml` | Peano Curve | First known space-filling curve; fills a square with a continuous self-similar path. |
-| `presets/plant_a.toml` | Plant A | Branching plant-like structure modelled with push/pop brackets for recursive branching. |
-| `presets/sierpinski_arrowhead_curve.toml` | Sierpiński Arrowhead Curve | Continuous self-similar curve that traces a Sierpiński triangle with alternating arrowhead turns. |
-| `presets/sierpinski_curve.toml` | Sierpiński Curve | Space-filling curve traced along the boundary of a Sierpiński triangle. |
-| `presets/sierpinski_triangle.toml` | Sierpiński Triangle | Self-similar triangle subdivided into progressively smaller triangular holes. |
-| `presets/snowflake.toml` | Snowflake | Branching snowflake pattern with six-fold symmetry and recursive side branches. |
-| `presets/plant_3d.toml` | 3D Plant | Branching 3D plant using pitch symbols to spread branches in all directions. |
-| `presets/ternary_tree_3d.toml` | 3D Ternary Tree | Branching tree that splits into three pitched branches at each recursive step. |
-| `presets/tree_3d.toml` | 3D Tree | Symmetric 3D tree that combines yaw, pitch, and roll for multi-directional branching. |
+Bundled L-System definitions live in [`presets/`](presets/). They are embedded
+in both apps at compile time.
+
+## Development
+
+For local setup, build commands, tests, CI, and architecture notes, see
+[`CONTRIBUTING.md`](CONTRIBUTING.md).
 
 ## License
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -1,0 +1,170 @@
+# Architecture
+
+Grow Your Own Fractal is a Rust workspace for generating, editing, rendering,
+and exporting 2D and 3D L-System fractals. The core model is toolkit-agnostic:
+grammar expansion and turtle geometry live in `lsystem-core`, shared
+application state lives in `lsystem-app-model`, and GPU rendering/export support
+lives in `lsystem-renderer`. The native/Iced and browser-first/Leptos apps are
+thin UI layers over those shared crates.
+
+## Workspace Crates
+
+| Crate | Role |
+|-------|------|
+| `lsystem-core` | Pure L-System library: runtime config types, symbol validation, lazy grammar expansion, 2D/3D turtle geometry, and SVG export behind the `svg` feature. It has no rendering, TOML, serde, UI, or platform dependencies. |
+| `lsystem-app-model` | Toolkit-independent app model: TOML parsing/validation/default resolution, session config workspace, embedded presets, color-control helpers, hue rotation state, and filename utilities. It must not depend on `iced`, `leptos`, `web-sys`, `wasm-bindgen`, `wgpu`, or `lsystem-renderer`. |
+| `lsystem-renderer` | Toolkit-independent wgpu layer: camera math, line pipelines, L-System-to-GPU adapters, browser/native wgpu setup, and PNG/APNG export behind the `png` feature. |
+| `lsystem-app` | Iced native app and retained Iced web app. The fractal viewport is an `iced::widget::shader` primitive backed by `lsystem-renderer`. |
+| `lsystem-web-app` | Browser-first Leptos app with DOM controls and a dedicated wgpu canvas. It is the primary web app deployed at the GitHub Pages root. |
+
+Bundled fractals live in [`presets/`](../presets/). They are embedded at compile
+time by `lsystem-app-model::load_presets`; adding a TOML file there is enough to
+make it available to both UIs.
+
+## Data Flow
+
+Runtime generation starts from a resolved `GenerationConfig`.
+
+```text
+GenerationConfig
+  -> OwnedExpandIter
+  -> Segments2D / Segments3D
+  -> renderer bridge segment records
+  -> wgpu instance buffer
+```
+
+The expansion and turtle layers are streaming iterators. They do not build the
+full expanded string or an intermediate vertex list before yielding geometry.
+The renderer bridge collects only the GPU instance records needed for upload.
+Do not introduce another collection of expanded symbols, raw geometry, or
+vertices; the renderer bridge's segment-instance `Vec` is the intentional
+collection point before GPU upload. Adding another large collection breaks the
+memory-bounded property for high iteration counts.
+
+Config editing has a separate parse/validate/resolve pipeline.
+
+```text
+ConfigSource::parse
+  -> RawConfig
+  -> EditorConfig
+  -> ConfigDocument
+  -> EditorConfig::resolve(defaults, max_iterations)
+  -> Config / GenerationConfig
+```
+
+`ConfigSource` preserves TOML formatting but is only parse-valid.
+`ConfigDocument` is the invariant that the authored config is valid. Runtime
+rendering and export paths resolve a concrete `Config` at their boundary rather
+than caching resolved values inside the editor document.
+
+## Core Model
+
+`lsystem-core` owns the grammar and turtle semantics:
+
+- `alphabet.rs` validates reserved symbols for 2D and 3D.
+- `grammar.rs` provides lazy borrowed and owned expansion iterators.
+- `turtle/turtle2d.rs` yields 2D line segments from expanded symbols.
+- `turtle/turtle3d.rs` yields 3D line segments using quaternion orientation.
+- `config.rs` defines validated runtime config and color types.
+- `svg_export.rs` exports resolved 2D configs when the `svg` feature is enabled.
+
+3D turtle orientation is stored as a `glam::Quat`. Heading, left, and up vectors
+are derived from that orientation, and pitch/roll/yaw symbols compose in local
+space. This avoids the accumulation and ordering problems that come from
+tracking heading as a single scalar angle.
+
+Whitespace inside `axiom` and rule right-hand-side strings is stripped before
+validation and expansion. This keeps long TOML rules readable without changing
+the generated grammar.
+
+## App Model
+
+`lsystem-app-model` is the shared state and config boundary for both UIs.
+
+- `config_defaults.rs` parses embedded `defaults.toml` and validates default
+  turtle/color values with the same domain checks as authored configs.
+- `editor_config.rs` parses strict TOML, validates symbols and value domains,
+  preserves optional authored fields, and resolves defaults at runtime
+  boundaries.
+- `config_workspace.rs` tracks preset/custom entries, dirty drafts,
+  last-applied documents, copy/apply/revert/reset operations, and derived names.
+- `presets.rs` embeds and sorts the `presets/` directory.
+- `color.rs` centralizes line-color mode selection and per-mode picker memory.
+- `animation.rs` contains hue-rotation state and phase advancement.
+
+Omitting `colors.line` deliberately resolves to a solid default color. Because
+line colors use an externally tagged TOML shape (`solid`, `gradient`,
+`hue_cycle`), a non-solid default would make solid mode unreachable by omission.
+
+## Rendering
+
+`lsystem-renderer` owns the shared wgpu machinery used by both apps and by
+offscreen exports.
+
+- `camera.rs` supports 2D pan/zoom and 3D orbit/elevation/roll/zoom.
+- `line_renderer.rs` defines GPU instance records, growable vertex buffers,
+  2D/3D line pipelines, color uniforms, and surface frame handling.
+- `lsystem_bridge.rs` converts core geometry iterators into GPU segment data and
+  maps `LineColorConfig` into shader color parameters.
+- `offscreen.rs`, `png_export.rs`, and `animation_export.rs` render PNG/APNG
+  output with an offscreen target behind the `png` feature.
+- `wgpu_util.rs` centralizes instance/device setup and error logging for native
+  and browser targets.
+
+Line rendering is instanced: one GPU record represents one segment, and the
+shader selects the start or end point from `vertex_index`. Buffers grow to the
+next power-of-two capacity and are reused through `Queue::write_buffer`.
+
+The 2D and 3D line pipelines are separate because their transform uniforms and
+shaders differ. They share the same color uniform model and segment-buffer
+strategy.
+
+## Color And Depth
+
+Line colors support solid RGB, traversal-order gradient, topological-depth
+gradient, and hue-cycle modes. Topological-depth gradient uses turtle branch
+depth: drawn `F` segments advance depth, `f` does not, and bracket push/pop
+restores depth along with turtle state.
+
+Depth-aware geometry is generated only when the grammar has stack directives.
+At the render/export boundary, `color_params_from_config` selects
+topological-depth shader mode only when the config asks for it and depth
+geometry is actually available. Bracketless grammars therefore fall back to
+traversal-order gradient even if `topological_depth = true` is authored.
+
+Hue rotation is transient UI state. It changes the color uniform for hue-cycle
+rendering, but it does not mutate TOML, presets, geometry, exports, or the config
+schema.
+
+## App Layers
+
+`lsystem-app` uses Iced for native desktop and retained-mode wasm builds. Iced
+owns the window, surface, event loop, and render pass; the fractal shader widget
+owns only the fractal GPU pipeline state. Geometry generation is asynchronous
+and tokenized so stale generation results can be ignored after rapid input
+changes. Geometry and color revisions let the shader upload segment data only
+when geometry changes and update only color uniforms for color-only edits.
+
+`lsystem-web-app` uses Leptos for DOM controls and renders into a dedicated
+canvas. The renderer owns both 2D and 3D pipelines, handles resize/zoom/orbit/
+roll/auto-rotate/reset operations, and rebuilds GPU state after surface loss
+while preserving CPU-side scene, camera, and color state.
+
+## Export Behavior
+
+SVG export is 2D-only and lives in `lsystem-core` behind the `svg` feature. Both
+apps hide SVG export when `dimensions = "3D"`.
+
+PNG and APNG export live in `lsystem-renderer` behind the `png` feature. APNG
+uploads geometry once and changes uniforms per frame. Browser and native UI
+layers use app-specific download/file plumbing around the shared renderer export
+APIs.
+
+## Dependency Coupling
+
+The workspace `wgpu` dependency is pinned to major version 29. Iced is pinned to
+an upstream git revision that uses the same wgpu major version. Iced's shader
+widget passes `wgpu` types (device, queue, render pass) to the custom primitive
+at the crate boundary; mismatched major versions produce a compile-time type
+error. Update those two dependencies together and verify native plus wasm
+builds.

--- a/docs/development.md
+++ b/docs/development.md
@@ -1,0 +1,147 @@
+# Development
+
+This document covers local setup, build commands, verification, CI, and deploy
+behavior. The system design lives in [`architecture.md`](architecture.md).
+
+## Prerequisites
+
+| Tool | Purpose |
+|------|---------|
+| [Rust](https://rustup.rs/) stable | Compiler and Cargo. The channel, components, and wasm target are pinned in `rust-toolchain.toml`. |
+| [mise](https://mise.jdx.dev/) | Installs pinned development tools, including `trunk` from `mise.toml`. |
+| Modern browser | Runs the browser apps with WebGPU or the WebGL2 fallback renderer. |
+
+Install pinned tools:
+
+```sh
+mise install
+```
+
+`trunk` may fail to launch when `NO_COLOR=1` is present in the environment. Use
+`NO_COLOR=true` or `NO_COLOR=false` as a workaround.
+
+## Build And Run
+
+Run the native Iced app:
+
+```sh
+cargo run -p lsystem-app
+```
+
+Run the browser-first Leptos app locally:
+
+```sh
+trunk serve --config crates/lsystem-web-app/Trunk.toml
+```
+
+The Leptos app serves on <http://127.0.0.1:8081/>.
+
+Build the browser-first Leptos app for release:
+
+```sh
+trunk build --release --config crates/lsystem-web-app/Trunk.toml
+```
+
+The release output is written to `crates/lsystem-web-app/dist/`.
+
+Run or build the retained Iced web app:
+
+```sh
+trunk serve --config crates/lsystem-app/Trunk.toml
+trunk build --release --config crates/lsystem-app/Trunk.toml
+```
+
+The Iced web app serves on <http://127.0.0.1:8080/>.
+
+## Testing
+
+Run the workspace test suite:
+
+```sh
+cargo test --workspace --all-features --all-targets
+```
+
+Run a single core test:
+
+```sh
+cargo test -p lsystem-core config::tests::test_name
+```
+
+Run SVG export tests:
+
+```sh
+cargo test -p lsystem-core --features svg svg_export
+```
+
+## Full Verification
+
+Run the same checks CI runs when a change affects code, build configuration,
+rustdoc, or web app behavior:
+
+```sh
+cargo fmt --check --all
+cargo clippy --workspace --all-targets -- -D warnings
+cargo clippy --workspace --all-features --all-targets -- -D warnings
+cargo test --workspace --all-features --all-targets
+RUSTDOCFLAGS="-D warnings" cargo doc --no-deps --workspace --all-features
+cargo clippy --target wasm32-unknown-unknown --workspace -- -D warnings
+cargo clippy --target wasm32-unknown-unknown --workspace --all-features -- -D warnings
+trunk build --release --config crates/lsystem-app/Trunk.toml
+trunk build --release --config crates/lsystem-web-app/Trunk.toml
+```
+
+For documentation-only changes that do not affect rustdoc or build scripts,
+spellcheck/link review may be enough. For code changes, prefer the smallest
+relevant command while iterating, then run the full affected verification before
+submitting.
+
+## Continuous Integration
+
+Every push and pull request to `main` runs:
+
+| Job | Commands |
+|-----|----------|
+| Format | `cargo fmt --check --all` |
+| Clippy | Native default/all-features clippy with `--all-targets`, plus wasm default/all-features clippy. All use `-D warnings`. |
+| Test | `cargo test --workspace --all-features --all-targets` with Mesa Vulkan drivers installed for GPU-related tests. |
+| Docs | `RUSTDOCFLAGS="-D warnings" cargo doc --no-deps --workspace --all-features` |
+| Trunk Build | Release builds for `crates/lsystem-app/Trunk.toml` and `crates/lsystem-web-app/Trunk.toml`. |
+
+## Deploy
+
+Successful CI runs on `main` trigger `.github/workflows/deploy.yml`. The deploy
+workflow builds both web apps and publishes them to GitHub Pages:
+
+- `lsystem-web-app` is deployed at the site root.
+- `lsystem-app` is deployed under `/iced/`.
+
+## Project Structure
+
+```text
+Cargo.toml                  workspace manifest
+rust-toolchain.toml         pins stable Rust, wasm target, and components
+mise.toml                   pins trunk version for local development and CI
+.github/workflows/ci.yml    fmt, clippy, test, docs, and trunk builds
+.github/workflows/deploy.yml deploys both web apps to GitHub Pages
+
+crates/
+  lsystem-core/             grammar expansion, turtle geometry, runtime config, SVG export
+  lsystem-app-model/        shared TOML config model, defaults, presets, colors, animation, utilities
+  lsystem-renderer/         shared wgpu camera, line rendering, and PNG/APNG export
+  lsystem-app/              Iced native app and retained Iced web app
+  lsystem-web-app/          browser-first Leptos app with DOM controls and GPU canvas
+
+presets/                    bundled TOML L-System definitions
+docs/                       shared developer and architecture documentation
+```
+
+## Documentation Updates
+
+When changing behavior, commands, architecture, config format, deploy workflow,
+or contributor workflow, update the relevant docs in the same change:
+
+- `README.md` for user-facing product, alphabet, or config-format information.
+- `CONTRIBUTING.md` for contributor entry-point changes.
+- `AGENTS.md` for agent-only workflow rules.
+- `docs/architecture.md` for design, boundaries, or invariants.
+- `docs/development.md` for commands, setup, CI, deploy, or repository layout.


### PR DESCRIPTION
## Summary
- Move shared architecture notes into docs/architecture.md so humans and agents use the same design reference.
- Move setup, verification, CI, deploy, and repository layout details into docs/development.md.
- Keep README focused on user-facing syntax and replace the long preset table with a link to presets/.