### PR TITLE
Add wall-clock and GPU timing diagnostics

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2385,6 +2385,7 @@ dependencies = [
  "rfd",
  "wasm-bindgen",
  "web-sys",
+ "web-time",
  "wgpu",
 ]
 
@@ -2431,6 +2432,7 @@ dependencies = [
  "console_error_panic_hook",
  "console_log",
  "gloo-file",
+ "gloo-timers",
  "js-sys",
  "leptos",
  "log",
@@ -2440,6 +2442,7 @@ dependencies = [
  "wasm-bindgen",
  "wasm-bindgen-futures",
  "web-sys",
+ "web-time",
  "wgpu",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,4 +30,5 @@ thiserror = "2"
 wasm-bindgen = "0.2"
 wasm-bindgen-futures = "0.4"
 web-sys = "0.3"
+web-time = "1"
 wgpu = { version = "29", features = ["webgl"] }

--- a/crates/lsystem-app/Cargo.toml
+++ b/crates/lsystem-app/Cargo.toml
@@ -12,6 +12,7 @@ lsystem-core = { workspace = true, features = ["svg"] }
 lsystem-app-model = { workspace = true }
 lsystem-renderer = { workspace = true, features = ["png"] }
 log.workspace = true
+web-time.workspace = true
 wgpu.workspace = true
 
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]

--- a/crates/lsystem-app/src/ui/fractal_canvas.rs
+++ b/crates/lsystem-app/src/ui/fractal_canvas.rs
@@ -18,6 +18,7 @@ use std::sync::{
     Arc,
     atomic::{AtomicU64, Ordering},
 };
+use web_time::Instant;
 
 use super::app_state::{FractalApp, Message};
 
@@ -338,6 +339,7 @@ pub(super) async fn build_scene(
     let mut camera = prev_camera;
     camera.reset_position();
     let colors = config.colors;
+    let started = Instant::now();
 
     match config.generation.dimensions {
         Dimensions::ThreeD => {
@@ -367,6 +369,8 @@ pub(super) async fn build_scene(
                     return SceneBuildResult::Cancelled;
                 }
 
+                log_generation_duration(started, segments_seen);
+
                 SceneBuildResult::Ready {
                     generation,
                     scene: Scene::from_depth_segment_data_3d(
@@ -395,6 +399,8 @@ pub(super) async fn build_scene(
                 if is_cancelled(generation, &current_generation) {
                     return SceneBuildResult::Cancelled;
                 }
+
+                log_generation_duration(started, segments_seen);
 
                 SceneBuildResult::Ready {
                     generation,
@@ -433,6 +439,8 @@ pub(super) async fn build_scene(
                     return SceneBuildResult::Cancelled;
                 }
 
+                log_generation_duration(started, segments_seen);
+
                 SceneBuildResult::Ready {
                     generation,
                     scene: Scene::from_depth_segment_data_2d(
@@ -462,6 +470,8 @@ pub(super) async fn build_scene(
                     return SceneBuildResult::Cancelled;
                 }
 
+                log_generation_duration(started, segments_seen);
+
                 SceneBuildResult::Ready {
                     generation,
                     scene: Scene::from_segment_data_2d(
@@ -474,6 +484,14 @@ pub(super) async fn build_scene(
             }
         }
     }
+}
+
+fn log_generation_duration(started: Instant, segment_count: usize) {
+    let elapsed = started.elapsed();
+    log::info!(
+        "generation_wall_ms={:.2} segments={segment_count}",
+        elapsed.as_secs_f64() * 1000.0,
+    );
 }
 
 fn is_cancelled(generation: u64, current_generation: &AtomicU64) -> bool {

--- a/crates/lsystem-web-app/Cargo.toml
+++ b/crates/lsystem-web-app/Cargo.toml
@@ -14,6 +14,7 @@ lsystem-renderer = { workspace = true, features = ["png"] }
 console_error_panic_hook.workspace = true
 console_log.workspace = true
 gloo-file = { workspace = true, features = ["futures"] }
+gloo-timers = { workspace = true, features = ["futures"] }
 js-sys.workspace = true
 leptos = { version = "0.8", features = ["csr"] }
 log.workspace = true
@@ -37,4 +38,5 @@ web-sys = { workspace = true, features = [
     "WheelEvent",
     "Window",
 ] }
+web-time.workspace = true
 wgpu.workspace = true

--- a/crates/lsystem-web-app/src/renderer.rs
+++ b/crates/lsystem-web-app/src/renderer.rs
@@ -1,4 +1,7 @@
 use std::sync::Arc;
+use std::sync::atomic::{AtomicBool, Ordering};
+
+use web_time::{Duration, Instant};
 
 use lsystem_core::{Config, Dimensions};
 use lsystem_renderer::camera::Camera;
@@ -125,6 +128,7 @@ impl CanvasRenderer {
     }
 
     fn rebuild_scene(&mut self, config: &Config) {
+        let started = Instant::now();
         match config.generation.dimensions {
             Dimensions::ThreeD => {
                 if config.generation.has_stack_directives() {
@@ -177,6 +181,13 @@ impl CanvasRenderer {
                 }
             }
         }
+
+        let elapsed = started.elapsed();
+        log::info!(
+            "generation_wall_ms={:.2} segments={}",
+            elapsed.as_secs_f64() * 1000.0,
+            self.scene.total_segments(),
+        );
 
         let colors = config.colors;
         self.color_params = color_params_from_config(
@@ -393,6 +404,8 @@ impl CanvasRenderer {
             reconfigure_after_present,
         } = frame;
 
+        let started = self.needs_upload.then(Instant::now);
+
         match &self.scene {
             ActiveScene::TwoD {
                 segments,
@@ -523,6 +536,35 @@ impl CanvasRenderer {
 
         self.gpu
             .end_frame(*frame, encoder, reconfigure_after_present);
+
+        if let Some(started) = started {
+            let segment_count = self.scene.total_segments();
+            let device = Arc::clone(&self.gpu.device);
+            let done = Arc::new(AtomicBool::new(false));
+            let done_for_callback = Arc::clone(&done);
+            // Registered synchronously, right after the submit it tracks, so no later
+            // submission can be folded into "previously submitted work" by the time a
+            // deferred async task gets around to registering it.
+            self.gpu.queue.on_submitted_work_done(move || {
+                done_for_callback.store(true, Ordering::Release);
+            });
+            wasm_bindgen_futures::spawn_local(async move {
+                if !await_submitted_work_done(&device, &done).await {
+                    log::warn!(
+                        "geometry_upload_frame_gpu_ms: gave up waiting for GPU completion \
+                         after {SUBMITTED_WORK_DONE_TIMEOUT:?}; segments={segment_count}"
+                    );
+                    return;
+                }
+                let elapsed = started.elapsed();
+                log::info!(
+                    "geometry_upload_frame_gpu_ms={:.2} segments={segment_count} \
+                     scope=\"submitted command buffer (upload + draw pass) GPU completion; \
+                     excludes present\"",
+                    elapsed.as_secs_f64() * 1000.0,
+                );
+            });
+        }
     }
 
     fn set_hue_offset_degrees(&mut self, offset: f32) {
@@ -553,6 +595,27 @@ impl CanvasRenderer {
             }
         }
     }
+}
+
+/// Bounds how long a `geometry_upload_frame_gpu_ms` wait can run. `Device::poll` with
+/// `PollType::Poll` cannot report device/context loss (its `Result` only ever carries
+/// `PollError::Timeout`/`WrongSubmissionIndex`, which don't apply here), so a dead device
+/// after, e.g., a lost WebGL context would otherwise spin this loop forever. This timeout
+/// is the only backstop against that.
+const SUBMITTED_WORK_DONE_TIMEOUT: Duration = Duration::from_secs(30);
+
+/// Polls `device` until `done` is set by an already-registered `on_submitted_work_done`
+/// callback, or `SUBMITTED_WORK_DONE_TIMEOUT` elapses. Returns `false` on timeout.
+async fn await_submitted_work_done(device: &wgpu::Device, done: &AtomicBool) -> bool {
+    let started = Instant::now();
+    while !done.load(Ordering::Acquire) {
+        if started.elapsed() > SUBMITTED_WORK_DONE_TIMEOUT {
+            return false;
+        }
+        let _ = device.poll(wgpu::PollType::Poll);
+        gloo_timers::future::TimeoutFuture::new(0).await;
+    }
+    true
 }
 
 fn sync_canvas_size(canvas: &web_sys::HtmlCanvasElement) -> (u32, u32, f32) {


### PR DESCRIPTION
## Summary

- Log `generation_wall_ms` for L-system generation (grammar expansion, turtle geometry, segment building) on both apps, on every scene rebuild.
- Log `geometry_upload_frame_gpu_ms` on the web app only, measuring actual GPU completion of an uploaded frame's command buffer (not just CPU enqueue time) via `wgpu::Queue::on_submitted_work_done`, gated on a real geometry upload so it doesn't fire on every animation frame.
- Native is excluded from the GPU-completion metric: Iced owns the actual `submit()` call internally (split across `FractalPrimitive::prepare()`/`draw()`), so this app has no reliable hook to measure GPU completion of a specific frame without invasively instrumenting Iced's render loop.
- The wait for GPU completion is bounded by a 30s timeout, since `Device::poll` cannot report device/context loss for non-blocking polls — without a backstop, a lost GPU context (e.g. during web surface recovery) would leave the wait spinning forever.
- Adds `web-time` (cross-platform `Instant`, used by both app crates) and `gloo-timers` (wasm polling delay, web app only) as dependencies.