### PR TITLE
Warn about unreachable L-system rules

### DIFF
--- a/crates/lsystem-app-model/src/editor_config.rs
+++ b/crates/lsystem-app-model/src/editor_config.rs
@@ -56,6 +56,11 @@ impl EditorGenerationConfig {
         has_stack_directives(&self.axiom, &self.rules)
     }
 
+    /// Returns the symbols of rules that are never reached during expansion.
+    pub fn unused_rules(&self) -> Vec<char> {
+        lsystem_core::unused_rules(&self.axiom, &self.rules)
+    }
+
     /// Resolves authored generation fields with defaults into a runtime `GenerationConfig`.
     ///
     /// Fills omitted `step` and `initial_heading` from `defaults`, and clamps
@@ -1915,6 +1920,39 @@ solid = "#00e680"
         let toml = test_toml(Dimensions::TwoD, "F[+F]F", 1, "25.0", "1.0", "0.0", "");
         let cfg = parse_config(&toml).unwrap();
         assert!(cfg.generation.has_stack_directives());
+    }
+
+    #[test]
+    fn unused_rules_empty_when_all_reachable() {
+        let toml = test_toml(
+            Dimensions::TwoD,
+            "F",
+            1,
+            "60.0",
+            "1.0",
+            "0.0",
+            "F = \"F-F++F-F\"",
+        );
+        let doc = ConfigDocument::try_from(ConfigSource::parse(&toml).unwrap()).unwrap();
+        assert_eq!(
+            doc.editor_config().generation.unused_rules(),
+            Vec::<char>::new()
+        );
+    }
+
+    #[test]
+    fn unused_rules_finds_symbol_never_referenced() {
+        let toml = test_toml(
+            Dimensions::TwoD,
+            "F",
+            1,
+            "60.0",
+            "1.0",
+            "0.0",
+            "F = \"F-F\"\nX = \"FF\"",
+        );
+        let doc = ConfigDocument::try_from(ConfigSource::parse(&toml).unwrap()).unwrap();
+        assert_eq!(doc.editor_config().generation.unused_rules(), vec!['X']);
     }
 
     #[test]

--- a/crates/lsystem-core/src/config.rs
+++ b/crates/lsystem-core/src/config.rs
@@ -2,6 +2,8 @@ use std::collections::BTreeMap;
 
 use thiserror::Error;
 
+use crate::grammar;
+
 #[derive(Debug, Error)]
 pub enum ConfigError {
     #[error("rule key {key:?} must be a single ASCII letter")]
@@ -208,6 +210,11 @@ impl GenerationConfig {
     /// Only `[` needs checking; bracket balance is validated, so `]` cannot appear alone.
     pub fn has_stack_directives(&self) -> bool {
         has_stack_directives(&self.axiom, &self.rules)
+    }
+
+    /// Returns the symbols of rules that are never reached during expansion.
+    pub fn unused_rules(&self) -> Vec<char> {
+        grammar::unused_rules(&self.axiom, &self.rules)
     }
 }
 

--- a/crates/lsystem-core/src/grammar.rs
+++ b/crates/lsystem-core/src/grammar.rs
@@ -1,4 +1,4 @@
-use std::collections::BTreeMap;
+use std::collections::{BTreeMap, BTreeSet};
 
 pub(crate) struct ExpandIter<'a> {
     stack: Vec<(std::str::Chars<'a>, u32)>,
@@ -84,6 +84,28 @@ pub fn max_safe_iterations(axiom: &str, rules: &BTreeMap<char, String>, max_segm
     HARD_MAX
 }
 
+/// Returns the rule symbols that are never reached during expansion of `axiom`.
+///
+/// A rule is reachable if its symbol appears in `axiom`, or in the RHS of any
+/// other reachable rule. Unreachable rules are dead: `expand` never invokes them,
+/// no matter the iteration count.
+pub fn unused_rules(axiom: &str, rules: &BTreeMap<char, String>) -> Vec<char> {
+    let mut reachable = BTreeSet::new();
+    let mut stack: Vec<char> = axiom.chars().collect();
+    while let Some(c) = stack.pop() {
+        if reachable.insert(c)
+            && let Some(rhs) = rules.get(&c)
+        {
+            stack.extend(rhs.chars());
+        }
+    }
+    rules
+        .keys()
+        .filter(|k| !reachable.contains(k))
+        .copied()
+        .collect()
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -164,5 +186,33 @@ mod tests {
             [('A', "aA".to_string()), ('B', "Bb".to_string())].into();
         let result: String = expand("AB", &rules, 2).collect();
         assert_eq!(result, "aaABbb");
+    }
+
+    #[test]
+    fn unused_rules_empty_when_all_reachable() {
+        let rules = koch_rules();
+        assert_eq!(unused_rules("F++F++F", &rules), Vec::<char>::new());
+    }
+
+    #[test]
+    fn unused_rules_finds_symbol_never_referenced() {
+        // 'X' has a rule but never appears in the axiom or any reachable RHS.
+        let rules: BTreeMap<char, String> =
+            [('F', "F-F".to_string()), ('X', "FF".to_string())].into();
+        assert_eq!(unused_rules("F", &rules), vec!['X']);
+    }
+
+    #[test]
+    fn unused_rules_finds_self_referencing_cycle_disconnected_from_axiom() {
+        // 'X' only ever refers to itself; it's never reachable from the axiom.
+        let rules: BTreeMap<char, String> =
+            [('F', "F-F".to_string()), ('X', "XX".to_string())].into();
+        assert_eq!(unused_rules("F", &rules), vec!['X']);
+    }
+
+    #[test]
+    fn unused_rules_empty_for_no_rules() {
+        let rules: BTreeMap<char, String> = BTreeMap::new();
+        assert_eq!(unused_rules("F", &rules), Vec::<char>::new());
     }
 }

--- a/crates/lsystem-core/src/lib.rs
+++ b/crates/lsystem-core/src/lib.rs
@@ -10,7 +10,7 @@ pub use alphabet::{contains_3d_symbols, validate_bracket_balance, validate_symbo
 pub use config::{
     ColorConfig, Config, ConfigError, Dimensions, GenerationConfig, LineColorConfig, Rgb, RgbError,
 };
-pub use grammar::max_safe_iterations;
+pub use grammar::{max_safe_iterations, unused_rules};
 
 use glam::{Vec2, Vec3};
 

--- a/crates/lsystem-web-app/src/app.rs
+++ b/crates/lsystem-web-app/src/app.rs
@@ -65,6 +65,8 @@ pub(crate) fn App() -> impl IntoView {
     let editor_generation_config = Memo::new(move |_| {
         config_workspace.with(|ws| ws.selected().editor_config().generation.clone())
     });
+    let unused_rule_symbols =
+        Memo::new(move |_| editor_generation_config.with(|generation| generation.unused_rules()));
     let max_iterations =
         Memo::new(move |_| editor_generation_config.with(max_iterations_for_editor_config));
     let generation_config = Memo::new(move |_| {
@@ -952,6 +954,17 @@ pub(crate) fn App() -> impl IntoView {
                     {move || grammar_error.get().map(|msg| view! {
                         <span class="inline-status error">{msg}</span>
                     })}
+                    {move || {
+                        let unused = unused_rule_symbols.get();
+                        (!unused.is_empty()).then(|| {
+                            let symbols = unused.iter().map(|c| c.to_string()).collect::<Vec<_>>().join(", ");
+                            view! {
+                                <span class="inline-status warning">
+                                    {format!("Unused rules: {symbols} (never used during expansion)")}
+                                </span>
+                            }
+                        })
+                    }}
 
                     <hr class="section-divider" />
 


### PR DESCRIPTION
## Summary

- Add `lsystem_core::grammar::unused_rules(axiom, rules)`, which finds rule
  symbols never reached during expansion (reachability search from the
  axiom through rule replacement strings). Exposed as
  `GenerationConfig::unused_rules()`, mirroring the existing
  `has_stack_directives()` pattern.
- Add `EditorGenerationConfig::unused_rules()` in `lsystem-app-model`,
  delegating to the new core function.
- Surface a non-blocking `inline-status warning` in the web app's Grammar
  section listing any unused rule symbols (e.g. `Unused rules: X, Y (never used
  during expansion)`), derived from the applied grammar so it updates on
  Apply, the same cadence as the existing grammar error message.