### PR TITLE
Use wgpu buffer limits for caps

### DIFF
--- a/crates/lsystem-renderer/src/line_renderer.rs
+++ b/crates/lsystem-renderer/src/line_renderer.rs
@@ -59,25 +59,23 @@ impl Default for Mvp {
     }
 }
 
-const GUARANTEED_VERTEX_BUFFER_BYTES: u64 = 268_435_456;
-
-/// Maximum number of line segments that fit in a 256 MiB vertex buffer (wgpu's guaranteed limit).
+/// Maximum number of line segments that fit in the platform-selected wgpu max buffer size.
 /// Each 2D segment occupies one `Segment2D` instance record.
 const MAX_SEGMENTS_2D: u64 =
-    GUARANTEED_VERTEX_BUFFER_BYTES / std::mem::size_of::<Segment2D>() as u64;
+    wgpu_util::MAX_BUFFER_SIZE_BYTES / std::mem::size_of::<Segment2D>() as u64;
 
-/// Maximum number of topological-depth 2D line segments that fit in a 256 MiB vertex buffer.
+/// Maximum number of topological-depth 2D line segments that fit in the max buffer size.
 const MAX_DEPTH_SEGMENTS_2D: u64 =
-    GUARANTEED_VERTEX_BUFFER_BYTES / std::mem::size_of::<TopologicalDepthSegment2D>() as u64;
+    wgpu_util::MAX_BUFFER_SIZE_BYTES / std::mem::size_of::<TopologicalDepthSegment2D>() as u64;
 
-/// Maximum number of 3D line segments that fit in a 256 MiB vertex buffer.
+/// Maximum number of 3D line segments that fit in the platform-selected wgpu max buffer size.
 /// Each 3D segment occupies one `Segment3D` instance record.
 const MAX_SEGMENTS_3D: u64 =
-    GUARANTEED_VERTEX_BUFFER_BYTES / std::mem::size_of::<Segment3D>() as u64;
+    wgpu_util::MAX_BUFFER_SIZE_BYTES / std::mem::size_of::<Segment3D>() as u64;
 
-/// Maximum number of topological-depth 3D line segments that fit in a 256 MiB vertex buffer.
+/// Maximum number of topological-depth 3D line segments that fit in the max buffer size.
 const MAX_DEPTH_SEGMENTS_3D: u64 =
-    GUARANTEED_VERTEX_BUFFER_BYTES / std::mem::size_of::<TopologicalDepthSegment3D>() as u64;
+    wgpu_util::MAX_BUFFER_SIZE_BYTES / std::mem::size_of::<TopologicalDepthSegment3D>() as u64;
 
 /// Returns the segment cap appropriate for the given dimensions.
 pub fn max_segments_for(dimensions: Dimensions) -> u64 {
@@ -1008,15 +1006,27 @@ mod tests {
     }
 
     #[test]
+    fn segment_caps_use_platform_selected_max_buffer_size() {
+        assert_eq!(
+            max_segments_for(Dimensions::TwoD),
+            wgpu_util::MAX_BUFFER_SIZE_BYTES / std::mem::size_of::<Segment2D>() as u64
+        );
+        assert_eq!(
+            max_segments_for(Dimensions::ThreeD),
+            wgpu_util::MAX_BUFFER_SIZE_BYTES / std::mem::size_of::<Segment3D>() as u64
+        );
+    }
+
+    #[test]
     fn depth_gradient_segment_caps_use_depth_record_sizes() {
         assert_eq!(
             max_segments_for_line_color(Dimensions::TwoD, true),
-            GUARANTEED_VERTEX_BUFFER_BYTES
+            wgpu_util::MAX_BUFFER_SIZE_BYTES
                 / std::mem::size_of::<TopologicalDepthSegment2D>() as u64
         );
         assert_eq!(
             max_segments_for_line_color(Dimensions::ThreeD, true),
-            GUARANTEED_VERTEX_BUFFER_BYTES
+            wgpu_util::MAX_BUFFER_SIZE_BYTES
                 / std::mem::size_of::<TopologicalDepthSegment3D>() as u64
         );
         assert_eq!(

--- a/crates/lsystem-renderer/src/wgpu_util.rs
+++ b/crates/lsystem-renderer/src/wgpu_util.rs
@@ -5,7 +5,7 @@ use browser_wasm as platform;
 #[cfg(any(not(target_arch = "wasm32"), target_os = "emscripten"))]
 use non_browser_wasm as platform;
 
-pub(crate) use platform::new_instance;
+pub(crate) use platform::{MAX_BUFFER_SIZE_BYTES, new_instance};
 
 pub(crate) fn device_descriptor(
     label: &'static str,
@@ -20,6 +20,9 @@ pub(crate) fn device_descriptor(
 
 #[cfg(all(target_arch = "wasm32", not(target_os = "emscripten")))]
 mod browser_wasm {
+    pub(crate) const MAX_BUFFER_SIZE_BYTES: u64 =
+        wgpu::Limits::downlevel_webgl2_defaults().max_buffer_size;
+
     pub(crate) async fn new_instance() -> wgpu::Instance {
         let descriptor = wgpu::InstanceDescriptor::new_with_display_handle(Box::new(WebDisplay));
         wgpu::util::new_instance_with_webgpu_detection(descriptor).await
@@ -41,6 +44,8 @@ mod browser_wasm {
 
 #[cfg(any(not(target_arch = "wasm32"), target_os = "emscripten"))]
 mod non_browser_wasm {
+    pub(crate) const MAX_BUFFER_SIZE_BYTES: u64 = wgpu::Limits::defaults().max_buffer_size;
+
     pub(crate) async fn new_instance() -> wgpu::Instance {
         wgpu::Instance::new(wgpu::InstanceDescriptor::new_without_display_handle())
     }


### PR DESCRIPTION
## Summary
- Add platform-selected max buffer size constants to renderer wgpu utilities.
- Use those constants for line renderer segment caps instead of a hardcoded byte value.
- Keep device limit construction unchanged while covering the cap behavior with a unit test.