### PR TITLE
Add wgsl_to_wgpu build-time codegen for lsystem-renderer

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -530,6 +530,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e629a66d692cb9ff1a1c664e41771b3dcaf961985a9774c0eb0bd1b51cf60a48"
 
 [[package]]
+name = "case"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fd6c0e7b807d60291f42f33f58480c0bfafe28ed08286446f45e463728cf9c1c"
+
+[[package]]
 name = "cc"
 version = "1.2.63"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2423,6 +2429,7 @@ dependencies = [
  "png",
  "pollster",
  "wgpu",
+ "wgsl_to_wgpu",
 ]
 
 [[package]]
@@ -4938,6 +4945,23 @@ dependencies = [
  "log",
  "raw-window-handle",
  "web-sys",
+]
+
+[[package]]
+name = "wgsl_to_wgpu"
+version = "0.18.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b744c51f143c398cb2b197e60f77ec7bb54e7b9131be4894a166ff54cf417e4a"
+dependencies = [
+ "case",
+ "naga",
+ "pathdiff",
+ "prettyplease",
+ "proc-macro2",
+ "quote",
+ "syn",
+ "thiserror 2.0.18",
+ "wgpu-types",
 ]
 
 [[package]]

--- a/crates/lsystem-renderer/Cargo.toml
+++ b/crates/lsystem-renderer/Cargo.toml
@@ -16,10 +16,13 @@ lsystem-core.workspace = true
 bytemuck = { version = "1", features = ["derive"] }
 encase = "0.12"
 futures-channel = { version = "0.3", optional = true }
-glam = { workspace = true, features = ["encase"] }
+glam = { workspace = true, features = ["encase", "bytemuck"] }
 log.workspace = true
 png = { version = "0.18", optional = true }
 wgpu.workspace = true
+
+[build-dependencies]
+wgsl_to_wgpu = "0.18"
 
 [dev-dependencies]
 pollster = "0.4"

--- a/crates/lsystem-renderer/build.rs
+++ b/crates/lsystem-renderer/build.rs
@@ -1,0 +1,26 @@
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    let wgsl_file = "src/shader.wgsl";
+    println!("cargo:rerun-if-changed={wgsl_file}");
+
+    let wgsl_source = std::fs::read_to_string(wgsl_file)?;
+
+    let options = wgsl_to_wgpu::WriteOptions {
+        derive_bytemuck_vertex: true,
+        derive_encase_host_shareable: true,
+        matrix_vector_types: wgsl_to_wgpu::MatrixVectorTypes::Glam,
+        validate: Some(Default::default()),
+        ..Default::default()
+    };
+
+    let text =
+        wgsl_to_wgpu::create_shader_modules(&wgsl_source, options, wgsl_to_wgpu::demangle_identity)
+            .inspect_err(|error| error.emit_to_stderr_with_path(&wgsl_source, wgsl_file))
+            .map_err(|_| "failed to generate WGSL bindings")?;
+
+    let out_dir = std::env::var("OUT_DIR")?;
+    std::fs::write(
+        std::path::Path::new(&out_dir).join("shader_bindings.rs"),
+        text,
+    )?;
+    Ok(())
+}

--- a/crates/lsystem-renderer/src/lib.rs
+++ b/crates/lsystem-renderer/src/lib.rs
@@ -1,6 +1,10 @@
 #[cfg(feature = "png")]
 pub mod animation_export;
 pub mod camera;
+#[allow(dead_code, unused_imports, clippy::all)]
+mod generated_shader {
+    include!(concat!(env!("OUT_DIR"), "/shader_bindings.rs"));
+}
 pub mod line_renderer;
 pub mod lsystem_bridge;
 #[cfg(feature = "png")]

--- a/crates/lsystem-renderer/src/line_renderer.rs
+++ b/crates/lsystem-renderer/src/line_renderer.rs
@@ -3,10 +3,18 @@ use std::fmt::{Display, Formatter};
 use std::sync::Arc;
 
 use bytemuck::{Pod, Zeroable};
-use encase::{ShaderType, UniformBuffer};
+use encase::UniformBuffer;
 use lsystem_core::Dimensions;
 use wgpu::util::DeviceExt;
 
+pub use crate::generated_shader::{ColorParams, Mvp, Transform};
+
+use crate::generated_shader::{
+    self,
+    bind_groups::{
+        BindGroup0, BindGroup1, BindGroup2, BindGroupLayout0, BindGroupLayout1, BindGroupLayout2,
+    },
+};
 use crate::wgpu_util;
 
 /// Mirrors the `Segment2D` WGSL vertex input struct in `shader.wgsl`.
@@ -41,18 +49,6 @@ pub struct TopologicalDepthSegment3D {
     pub start: [f32; 3],
     pub end: [f32; 3],
     pub topological_depth: u32,
-}
-
-#[derive(Copy, Clone, ShaderType)]
-pub struct Transform {
-    pub scale: glam::Vec2,
-    pub offset: glam::Vec2,
-}
-
-/// Column-major MVP matrix uniform.
-#[derive(Copy, Clone, ShaderType)]
-pub struct Mvp {
-    pub matrix: glam::Mat4,
 }
 
 impl Default for Mvp {
@@ -108,19 +104,6 @@ pub enum ColorMode {
     Gradient = 1,
     HueCycle = 2,
     DepthGradient = 3,
-}
-
-/// Per-frame color parameters written to the GPU as a WGSL uniform.
-#[derive(Copy, Clone, ShaderType)]
-pub struct ColorParams {
-    mode: u32,
-    pub total_segments: u32,
-    pub max_topological_depth: u32,
-    pub color_start: glam::Vec4,
-    pub color_end: glam::Vec4,
-    pub hue_start: f32,
-    pub saturation: f32,
-    pub value: f32,
 }
 
 impl Default for ColorParams {
@@ -306,7 +289,7 @@ fn create_line_pipeline(
         },
         fragment: Some(wgpu::FragmentState {
             module: shader,
-            entry_point: Some("fs_main"),
+            entry_point: Some(generated_shader::ENTRY_FS_MAIN),
             targets: &[Some(wgpu::ColorTargetState {
                 format: descriptor.format,
                 blend: Some(wgpu::BlendState::REPLACE),
@@ -330,8 +313,8 @@ pub struct LinePipeline2D {
     depth_pipeline: wgpu::RenderPipeline,
     uniform_buffer: wgpu::Buffer,
     color_params_buffer: wgpu::Buffer,
-    color_bind_group: wgpu::BindGroup,
-    transform_bind_group: wgpu::BindGroup,
+    color_bind_group: BindGroup0,
+    transform_bind_group: BindGroup1,
     segment_buffer: GrowableVertexBuffer,
     depth_segment_buffer: GrowableVertexBuffer,
     active_segment_buffer: ActiveSegmentBuffer,
@@ -360,51 +343,22 @@ impl LinePipeline2D {
             usage: wgpu::BufferUsages::UNIFORM | wgpu::BufferUsages::COPY_DST,
         });
 
-        let color_bgl = device.create_bind_group_layout(&wgpu::BindGroupLayoutDescriptor {
-            label: Some("lsystem_2d_color_bind_group_layout"),
-            entries: &[wgpu::BindGroupLayoutEntry {
-                binding: 0,
-                visibility: wgpu::ShaderStages::VERTEX,
-                ty: wgpu::BindingType::Buffer {
-                    ty: wgpu::BufferBindingType::Uniform,
-                    has_dynamic_offset: false,
-                    min_binding_size: wgpu::BufferSize::new(ColorParams::min_size().get()),
-                },
-                count: None,
-            }],
-        });
+        let color_bgl = BindGroup0::get_bind_group_layout(device);
+        let transform_bgl = BindGroup1::get_bind_group_layout(device);
 
-        let transform_bgl = device.create_bind_group_layout(&wgpu::BindGroupLayoutDescriptor {
-            label: Some("lsystem_2d_transform_bind_group_layout"),
-            entries: &[wgpu::BindGroupLayoutEntry {
-                binding: 0,
-                visibility: wgpu::ShaderStages::VERTEX,
-                ty: wgpu::BindingType::Buffer {
-                    ty: wgpu::BufferBindingType::Uniform,
-                    has_dynamic_offset: false,
-                    min_binding_size: wgpu::BufferSize::new(Transform::min_size().get()),
-                },
-                count: None,
-            }],
-        });
+        let color_bind_group = BindGroup0::from_bindings(
+            device,
+            BindGroupLayout0 {
+                color_params: color_params_buffer.as_entire_buffer_binding(),
+            },
+        );
 
-        let color_bind_group = device.create_bind_group(&wgpu::BindGroupDescriptor {
-            label: Some("lsystem_2d_color_bind_group"),
-            layout: &color_bgl,
-            entries: &[wgpu::BindGroupEntry {
-                binding: 0,
-                resource: color_params_buffer.as_entire_binding(),
-            }],
-        });
-
-        let transform_bind_group = device.create_bind_group(&wgpu::BindGroupDescriptor {
-            label: Some("lsystem_2d_transform_bind_group"),
-            layout: &transform_bgl,
-            entries: &[wgpu::BindGroupEntry {
-                binding: 0,
-                resource: uniform_buffer.as_entire_binding(),
-            }],
-        });
+        let transform_bind_group = BindGroup1::from_bindings(
+            device,
+            BindGroupLayout1 {
+                transform: uniform_buffer.as_entire_buffer_binding(),
+            },
+        );
 
         let pipeline_layout = device.create_pipeline_layout(&wgpu::PipelineLayoutDescriptor {
             label: Some("lsystem_2d_pipeline_layout"),
@@ -421,7 +375,7 @@ impl LinePipeline2D {
             LinePipelineDescriptor {
                 format,
                 label: "lsystem_2d_pipeline",
-                vertex_entry_point: "vs_main_2d",
+                vertex_entry_point: generated_shader::ENTRY_VS_MAIN_2D,
                 array_stride: std::mem::size_of::<Segment2D>() as wgpu::BufferAddress,
                 attributes: &normal_attrs,
             },
@@ -433,7 +387,7 @@ impl LinePipeline2D {
             LinePipelineDescriptor {
                 format,
                 label: "lsystem_2d_depth_pipeline",
-                vertex_entry_point: "vs_depth_main_2d",
+                vertex_entry_point: generated_shader::ENTRY_VS_DEPTH_MAIN_2D,
                 array_stride: std::mem::size_of::<TopologicalDepthSegment2D>()
                     as wgpu::BufferAddress,
                 attributes: &depth_attrs,
@@ -492,8 +446,10 @@ impl LinePipeline2D {
     }
 
     pub fn draw(&self, render_pass: &mut wgpu::RenderPass<'_>) {
-        let bind_groups: &[(u32, &wgpu::BindGroup)] =
-            &[(0, &self.color_bind_group), (1, &self.transform_bind_group)];
+        let bind_groups: &[(u32, &wgpu::BindGroup)] = &[
+            (0, self.color_bind_group.inner()),
+            (1, self.transform_bind_group.inner()),
+        ];
         match self.active_segment_buffer {
             ActiveSegmentBuffer::Normal => draw_line_list(
                 render_pass,
@@ -518,8 +474,8 @@ pub struct LinePipeline3D {
     depth_pipeline: wgpu::RenderPipeline,
     mvp_buffer: wgpu::Buffer,
     color_params_buffer: wgpu::Buffer,
-    color_bind_group: wgpu::BindGroup,
-    mvp_bind_group: wgpu::BindGroup,
+    color_bind_group: BindGroup0,
+    mvp_bind_group: BindGroup2,
     segment_buffer: GrowableVertexBuffer,
     depth_segment_buffer: GrowableVertexBuffer,
     active_segment_buffer: ActiveSegmentBuffer,
@@ -545,51 +501,22 @@ impl LinePipeline3D {
             usage: wgpu::BufferUsages::UNIFORM | wgpu::BufferUsages::COPY_DST,
         });
 
-        let color_bgl = device.create_bind_group_layout(&wgpu::BindGroupLayoutDescriptor {
-            label: Some("lsystem_3d_color_bind_group_layout"),
-            entries: &[wgpu::BindGroupLayoutEntry {
-                binding: 0,
-                visibility: wgpu::ShaderStages::VERTEX,
-                ty: wgpu::BindingType::Buffer {
-                    ty: wgpu::BufferBindingType::Uniform,
-                    has_dynamic_offset: false,
-                    min_binding_size: wgpu::BufferSize::new(ColorParams::min_size().get()),
-                },
-                count: None,
-            }],
-        });
+        let color_bgl = BindGroup0::get_bind_group_layout(device);
+        let mvp_bgl = BindGroup2::get_bind_group_layout(device);
 
-        let mvp_bgl = device.create_bind_group_layout(&wgpu::BindGroupLayoutDescriptor {
-            label: Some("lsystem_3d_mvp_bind_group_layout"),
-            entries: &[wgpu::BindGroupLayoutEntry {
-                binding: 0,
-                visibility: wgpu::ShaderStages::VERTEX,
-                ty: wgpu::BindingType::Buffer {
-                    ty: wgpu::BufferBindingType::Uniform,
-                    has_dynamic_offset: false,
-                    min_binding_size: wgpu::BufferSize::new(Mvp::min_size().get()),
-                },
-                count: None,
-            }],
-        });
+        let color_bind_group = BindGroup0::from_bindings(
+            device,
+            BindGroupLayout0 {
+                color_params: color_params_buffer.as_entire_buffer_binding(),
+            },
+        );
 
-        let color_bind_group = device.create_bind_group(&wgpu::BindGroupDescriptor {
-            label: Some("lsystem_3d_color_bind_group"),
-            layout: &color_bgl,
-            entries: &[wgpu::BindGroupEntry {
-                binding: 0,
-                resource: color_params_buffer.as_entire_binding(),
-            }],
-        });
-
-        let mvp_bind_group = device.create_bind_group(&wgpu::BindGroupDescriptor {
-            label: Some("lsystem_3d_mvp_bind_group"),
-            layout: &mvp_bgl,
-            entries: &[wgpu::BindGroupEntry {
-                binding: 0,
-                resource: mvp_buffer.as_entire_binding(),
-            }],
-        });
+        let mvp_bind_group = BindGroup2::from_bindings(
+            device,
+            BindGroupLayout2 {
+                mvp: mvp_buffer.as_entire_buffer_binding(),
+            },
+        );
 
         let pipeline_layout = device.create_pipeline_layout(&wgpu::PipelineLayoutDescriptor {
             label: Some("lsystem_3d_pipeline_layout"),
@@ -606,7 +533,7 @@ impl LinePipeline3D {
             LinePipelineDescriptor {
                 format,
                 label: "lsystem_3d_pipeline",
-                vertex_entry_point: "vs_main_3d",
+                vertex_entry_point: generated_shader::ENTRY_VS_MAIN_3D,
                 array_stride: std::mem::size_of::<Segment3D>() as wgpu::BufferAddress,
                 attributes: &normal_attrs,
             },
@@ -618,7 +545,7 @@ impl LinePipeline3D {
             LinePipelineDescriptor {
                 format,
                 label: "lsystem_3d_depth_pipeline",
-                vertex_entry_point: "vs_depth_main_3d",
+                vertex_entry_point: generated_shader::ENTRY_VS_DEPTH_MAIN_3D,
                 array_stride: std::mem::size_of::<TopologicalDepthSegment3D>()
                     as wgpu::BufferAddress,
                 attributes: &depth_attrs,
@@ -677,8 +604,10 @@ impl LinePipeline3D {
     }
 
     pub fn draw(&self, render_pass: &mut wgpu::RenderPass<'_>) {
-        let bind_groups: &[(u32, &wgpu::BindGroup)] =
-            &[(0, &self.color_bind_group), (2, &self.mvp_bind_group)];
+        let bind_groups: &[(u32, &wgpu::BindGroup)] = &[
+            (0, self.color_bind_group.inner()),
+            (2, self.mvp_bind_group.inner()),
+        ];
         match self.active_segment_buffer {
             ActiveSegmentBuffer::Normal => draw_line_list(
                 render_pass,
@@ -914,6 +843,8 @@ impl GpuContext {
 
 #[cfg(test)]
 mod tests {
+    use encase::ShaderType;
+
     use super::*;
 
     fn sample_params(mode: ColorMode, hue_start: f32) -> ColorParams {

--- a/crates/lsystem-renderer/src/shader.wgsl
+++ b/crates/lsystem-renderer/src/shader.wgsl
@@ -2,13 +2,11 @@ struct ColorParams {
     mode: u32,
     total_segments: u32,
     max_topological_depth: u32,
-    _pad1: u32,
     color_start: vec4<f32>,
     color_end: vec4<f32>,
     hue_start: f32,
     saturation: f32,
     value: f32,
-    _pad2: f32,
 }
 
 @group(0) @binding(0)

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -103,6 +103,18 @@ line colors use an externally tagged TOML shape (`solid`, `gradient`,
 `lsystem-renderer` owns the shared wgpu machinery used by both apps and by
 offscreen exports.
 
+- `build.rs` generates Rust bindings from `shader.wgsl` at build time via
+  `wgsl_to_wgpu`, validating `shader.wgsl` before compiling
+  `lsystem-renderer`'s Rust sources. `line_renderer.rs` sources its uniform
+  types (`ColorParams`, `Transform`, `Mvp`) and shader entry-point constants
+  from these generated bindings rather than hand-mirroring them, so most
+  field, binding, and entry-point renames in `shader.wgsl` now fail the Rust
+  build instead of only surfacing as a runtime wgpu validation error. Bind
+  group layouts and bind groups are built from the generated per-group
+  helpers, but pipeline layouts are still assembled by hand because the 2D
+  and 3D pipelines bind different, sparse subsets of the shader's three bind
+  groups. Vertex instance records (`Segment2D`/`Segment3D` and their
+  topological-depth variants) remain hand-mirrored.
 - `camera.rs` supports 2D pan/zoom and 3D orbit/elevation/roll/zoom.
 - `line_renderer.rs` defines GPU instance records, growable vertex buffers,
   2D/3D line pipelines, color uniforms, and surface frame handling.
@@ -117,9 +129,10 @@ Line rendering is instanced: one GPU record represents one segment, and the
 shader selects the start or end point from `vertex_index`. Buffers grow to the
 next power-of-two capacity and are reused through `Queue::write_buffer`.
 
-The 2D and 3D line pipelines are separate because their transform uniforms and
-shaders differ. They share the same color uniform model and segment-buffer
-strategy.
+The 2D and 3D line pipelines are separate because they use different vertex
+entry points, vertex-buffer layouts, and transform uniforms within the shared
+`shader.wgsl` module. They share the same color uniform model and
+segment-buffer strategy.
 
 ## Color And Depth
 
@@ -170,3 +183,8 @@ widget passes `wgpu` types (device, queue, render pass) to the custom primitive
 at the crate boundary; mismatched major versions produce a compile-time type
 error. Update those two dependencies together and verify native plus wasm
 builds.
+
+`lsystem-renderer`'s `wgsl_to_wgpu` build-dependency generates code against
+`naga`/`wgpu-types` types that must match the workspace `wgpu` major version.
+When updating `wgpu`, also check whether `wgsl_to_wgpu` needs a matching
+version bump.


### PR DESCRIPTION
## Summary

Addresses #134.

- Adds a `build.rs` to `lsystem-renderer` that generates and semantically validates Rust bindings from `shader.wgsl` via `wgsl_to_wgpu` (`create_shader_modules`, avoiding any `include_str!` path resolution against `OUT_DIR`). WGSL field, binding, and entry-point changes now fail the build instead of only surfacing as runtime wgpu validation errors.
- Adopts the generated bindings in `line_renderer.rs` where they're a direct fit:
  - `ColorParams`/`Transform`/`Mvp` are re-exported from the generated module instead of hand-mirrored; existing constructors and `Default` impls stay as inherent/trait impls on the generated types.
  - Vertex/fragment entry-point strings use the generated `ENTRY_*` constants instead of hardcoded literals.
  - Bind group layouts and bind groups use the generated per-group `BindGroup0/1/2` + `BindGroupLayout0/1/2` helpers instead of manual `wgpu::BindGroupLayoutDescriptor`/`BindGroupDescriptor` calls.
  - The generated `create_pipeline_layout()` bundles all three bind groups and doesn't fit either pipeline's sparse group usage (2D: groups 0,1; 3D: groups 0,2), so pipeline layouts are still built manually from the per-group layout helpers.
- Removes the explicit `_pad1`/`_pad2` fields from the WGSL `ColorParams` struct. WGSL's struct-layout algorithm already inserts the same implicit gaps (vec4 alignment forces `color_start` to offset 16 regardless; the struct's own 16-byte alignment rounds the final size to 64 regardless), so this is a no-op on the wire layout but lets the generated `ColorParams` binding match the handwritten Rust struct's field set exactly.
- Declares `glam`'s `bytemuck` feature explicitly on `lsystem-renderer`, since the generated vertex structs derive `bytemuck::Pod`/`Zeroable` and the crate was only building today via transitive feature unification from `lsystem-core`.

## Scope notes

`Segment2D`/`Segment3D` and their topological-depth variants are left handwritten: adopting the generated versions would change public field types (array to glam vector) across `lsystem-app`, `lsystem-web-app`, and `lsystem_bridge.rs`, which is a separate, more invasive decision left for a follow-up.

## Tradeoffs

- Generated bind group layouts use `min_binding_size: None` instead of the explicit `encase`-derived minimum size.
- Debug labels on generated layouts and bind groups are generic (e.g. `"BindGroup0"`) rather than the previous descriptive names.
- `ColorParams::mode` becomes a public field rather than private-with-helpers, though nothing currently reads or writes it outside `line_renderer.rs`.