### PR TITLE
Compute fractal bounds on GPU

### DIFF
--- a/crates/lsystem-app/src/ui/fractal_canvas.rs
+++ b/crates/lsystem-app/src/ui/fractal_canvas.rs
@@ -3,6 +3,7 @@ use iced::widget::{container, shader};
 use iced::{Background, Color, Element, Event, Length, Point, Rectangle, Size, Theme};
 use lsystem_app_model::ConfigDefaults;
 use lsystem_core::{ColorConfig, Config, Dimensions};
+use lsystem_renderer::bounds_compute;
 use lsystem_renderer::camera::Camera;
 use lsystem_renderer::line_renderer::{
     ColorParams, LinePipeline2D, LinePipeline3D, Segment2D, Segment3D, TopologicalDepthSegment2D,
@@ -91,13 +92,14 @@ impl Scene {
     fn from_segment_data_2d(
         colors: &ColorConfig,
         data: SegmentData,
+        bounds: bounds_compute::Bounds2D,
         camera: Camera,
         revision: u64,
     ) -> Self {
         let geometry = SceneGeometry::TwoD {
             segments: Arc::new(data.segments),
-            bounds_min: data.bounds_min,
-            bounds_max: data.bounds_max,
+            bounds_min: bounds.0,
+            bounds_max: bounds.1,
         };
         Self {
             color_params: color_params_from_config(&colors.line, geometry.total_segments(), None),
@@ -113,13 +115,14 @@ impl Scene {
     fn from_segment_data_3d(
         colors: &ColorConfig,
         data: SegmentData3D,
+        bounds: bounds_compute::Bounds3D,
         camera: Camera,
         revision: u64,
     ) -> Self {
         let geometry = SceneGeometry::ThreeD {
             segments: Arc::new(data.segments),
-            bounds_min: data.bounds_min,
-            bounds_max: data.bounds_max,
+            bounds_min: bounds.0,
+            bounds_max: bounds.1,
         };
         Self {
             color_params: color_params_from_config(&colors.line, geometry.total_segments(), None),
@@ -135,14 +138,15 @@ impl Scene {
     fn from_depth_segment_data_2d(
         colors: &ColorConfig,
         data: TopologicalDepthSegmentData,
+        bounds: bounds_compute::Bounds2D,
         camera: Camera,
         revision: u64,
     ) -> Self {
         let max_topological_depth = data.max_topological_depth();
         let geometry = SceneGeometry::TwoDWithTopologicalDepth {
             segments: Arc::new(data.segments),
-            bounds_min: data.bounds_min,
-            bounds_max: data.bounds_max,
+            bounds_min: bounds.0,
+            bounds_max: bounds.1,
             max_topological_depth,
         };
         Self {
@@ -163,14 +167,15 @@ impl Scene {
     fn from_depth_segment_data_3d(
         colors: &ColorConfig,
         data: TopologicalDepthSegmentData3D,
+        bounds: bounds_compute::Bounds3D,
         camera: Camera,
         revision: u64,
     ) -> Self {
         let max_topological_depth = data.max_topological_depth();
         let geometry = SceneGeometry::ThreeDWithTopologicalDepth {
             segments: Arc::new(data.segments),
-            bounds_min: data.bounds_min,
-            bounds_max: data.bounds_max,
+            bounds_min: bounds.0,
+            bounds_max: bounds.1,
             max_topological_depth,
         };
         Self {
@@ -370,14 +375,17 @@ pub(super) async fn build_scene(
                 }
 
                 log_generation_duration(started, segments_seen);
+                let data = builder.finish();
+                let bounds =
+                    bounds_compute::standalone_depth_segment_bounds_3d(&data.segments).await;
+                if is_cancelled(generation, &current_generation) {
+                    return SceneBuildResult::Cancelled;
+                }
 
                 SceneBuildResult::Ready {
                     generation,
                     scene: Scene::from_depth_segment_data_3d(
-                        &colors,
-                        builder.finish(),
-                        camera,
-                        generation,
+                        &colors, data, bounds, camera, generation,
                     ),
                 }
             } else {
@@ -401,15 +409,15 @@ pub(super) async fn build_scene(
                 }
 
                 log_generation_duration(started, segments_seen);
+                let data = builder.finish();
+                let bounds = bounds_compute::standalone_segment_bounds_3d(&data.segments).await;
+                if is_cancelled(generation, &current_generation) {
+                    return SceneBuildResult::Cancelled;
+                }
 
                 SceneBuildResult::Ready {
                     generation,
-                    scene: Scene::from_segment_data_3d(
-                        &colors,
-                        builder.finish(),
-                        camera,
-                        generation,
-                    ),
+                    scene: Scene::from_segment_data_3d(&colors, data, bounds, camera, generation),
                 }
             }
         }
@@ -440,14 +448,17 @@ pub(super) async fn build_scene(
                 }
 
                 log_generation_duration(started, segments_seen);
+                let data = builder.finish();
+                let bounds =
+                    bounds_compute::standalone_depth_segment_bounds_2d(&data.segments).await;
+                if is_cancelled(generation, &current_generation) {
+                    return SceneBuildResult::Cancelled;
+                }
 
                 SceneBuildResult::Ready {
                     generation,
                     scene: Scene::from_depth_segment_data_2d(
-                        &colors,
-                        builder.finish(),
-                        camera,
-                        generation,
+                        &colors, data, bounds, camera, generation,
                     ),
                 }
             } else {
@@ -471,15 +482,15 @@ pub(super) async fn build_scene(
                 }
 
                 log_generation_duration(started, segments_seen);
+                let data = builder.finish();
+                let bounds = bounds_compute::standalone_segment_bounds_2d(&data.segments).await;
+                if is_cancelled(generation, &current_generation) {
+                    return SceneBuildResult::Cancelled;
+                }
 
                 SceneBuildResult::Ready {
                     generation,
-                    scene: Scene::from_segment_data_2d(
-                        &colors,
-                        builder.finish(),
-                        camera,
-                        generation,
-                    ),
+                    scene: Scene::from_segment_data_2d(&colors, data, bounds, camera, generation),
                 }
             }
         }

--- a/crates/lsystem-renderer/Cargo.toml
+++ b/crates/lsystem-renderer/Cargo.toml
@@ -6,16 +6,16 @@ license.workspace = true
 
 [features]
 default = []
-png = ["dep:futures-channel", "dep:png", "dep:gloo-timers"]
+png = ["dep:png"]
 
 [target.'cfg(target_arch = "wasm32")'.dependencies]
-gloo-timers = { workspace = true, features = ["futures"], optional = true }
+gloo-timers = { workspace = true, features = ["futures"] }
 
 [dependencies]
 lsystem-core.workspace = true
 bytemuck = { version = "1", features = ["derive"] }
 encase = "0.12"
-futures-channel = { version = "0.3", optional = true }
+futures-channel = "0.3"
 glam = { workspace = true, features = ["encase", "bytemuck"] }
 log.workspace = true
 png = { version = "0.18", optional = true }

--- a/crates/lsystem-renderer/build.rs
+++ b/crates/lsystem-renderer/build.rs
@@ -1,8 +1,11 @@
 fn main() -> Result<(), Box<dyn std::error::Error>> {
     let wgsl_file = "src/shader.wgsl";
     println!("cargo:rerun-if-changed={wgsl_file}");
+    let bounds_wgsl_file = "src/bounds_compute.wgsl";
+    println!("cargo:rerun-if-changed={bounds_wgsl_file}");
 
     let wgsl_source = std::fs::read_to_string(wgsl_file)?;
+    let bounds_wgsl_source = std::fs::read_to_string(bounds_wgsl_file)?;
 
     let options = wgsl_to_wgpu::WriteOptions {
         derive_bytemuck_vertex: true,
@@ -16,6 +19,14 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
         wgsl_to_wgpu::create_shader_modules(&wgsl_source, options, wgsl_to_wgpu::demangle_identity)
             .inspect_err(|error| error.emit_to_stderr_with_path(&wgsl_source, wgsl_file))
             .map_err(|_| "failed to generate WGSL bindings")?;
+
+    wgsl_to_wgpu::create_shader_modules(
+        &bounds_wgsl_source,
+        options,
+        wgsl_to_wgpu::demangle_identity,
+    )
+    .inspect_err(|error| error.emit_to_stderr_with_path(&bounds_wgsl_source, bounds_wgsl_file))
+    .map_err(|_| "failed to validate bounds WGSL")?;
 
     let out_dir = std::env::var("OUT_DIR")?;
     std::fs::write(

--- a/crates/lsystem-renderer/src/animation_export.rs
+++ b/crates/lsystem-renderer/src/animation_export.rs
@@ -3,6 +3,7 @@ use std::fmt::{Display, Formatter};
 
 use lsystem_core::Config;
 
+use crate::bounds_compute::BoundsComputeSupport;
 use crate::camera::Camera;
 use crate::offscreen::{ExportScene, RenderTarget, validate_height, validate_width};
 use crate::png_export::{ExportError, PngExport};
@@ -103,6 +104,7 @@ impl From<ExportError> for AnimationExportError {
 pub async fn render_animation(
     device: &wgpu::Device,
     queue: &wgpu::Queue,
+    bounds_support: BoundsComputeSupport,
     config: &Config,
     width: u32,
     height: u32,
@@ -114,7 +116,9 @@ pub async fn render_animation(
     validate_width(width)?;
     validate_height(height)?;
 
-    let scene = ExportScene::new(device, queue, config);
+    let scene = ExportScene::new(device, queue, bounds_support, config)
+        .await
+        .map_err(ExportError::from)?;
     let target = RenderTarget::new(device, width, height);
     let background = config.colors.background.to_array();
     let base_color = scene.color_params();
@@ -176,13 +180,14 @@ pub async fn render_animation_standalone(
     params.validate()?;
     validate_width(width)?;
     validate_height(height)?;
-    let (device, queue) =
+    let (device, queue, bounds_support) =
         wgpu_util::create_headless_device("animation_export_device", "animation export")
             .await
             .map_err(ExportError::from)?;
     render_animation(
         &device,
         &queue,
+        bounds_support,
         config,
         width,
         height,

--- a/crates/lsystem-renderer/src/bounds_compute.rs
+++ b/crates/lsystem-renderer/src/bounds_compute.rs
@@ -1,0 +1,652 @@
+use wgpu::util::DeviceExt;
+
+use crate::line_renderer::{
+    Segment2D, Segment3D, TopologicalDepthSegment2D, TopologicalDepthSegment3D,
+    UploadedSegmentBuffer,
+};
+use crate::readback::{ReadbackError, map_read_buffer};
+
+const WORKGROUP_SIZE: u32 = 64;
+const BOUNDS_3D_WORDS: usize = 6;
+const DIMENSIONS_2D: u32 = 2;
+const DIMENSIONS_3D: u32 = 3;
+
+#[repr(C)]
+#[derive(Clone, Copy, bytemuck::Pod, bytemuck::Zeroable)]
+struct BoundsParams {
+    count: u32,
+    dimensions: u32,
+    stride_words: u32,
+    _pad: u32,
+}
+
+pub type Bounds2D = ([f32; 2], [f32; 2]);
+pub type Bounds3D = ([f32; 3], [f32; 3]);
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct BoundsComputeSupport {
+    compute_shaders: bool,
+}
+
+impl BoundsComputeSupport {
+    pub const fn cpu_only() -> Self {
+        Self {
+            compute_shaders: false,
+        }
+    }
+
+    pub const fn compute_shaders() -> Self {
+        Self {
+            compute_shaders: true,
+        }
+    }
+
+    pub fn from_adapter(adapter: &wgpu::Adapter) -> Self {
+        Self {
+            compute_shaders: adapter
+                .get_downlevel_capabilities()
+                .flags
+                .contains(wgpu::DownlevelFlags::COMPUTE_SHADERS),
+        }
+    }
+
+    pub const fn supports_compute_shaders(self) -> bool {
+        self.compute_shaders
+    }
+}
+
+pub async fn segment_bounds_2d(
+    device: &wgpu::Device,
+    queue: &wgpu::Queue,
+    support: BoundsComputeSupport,
+    segments: &[Segment2D],
+    uploaded: Option<UploadedSegmentBuffer>,
+) -> Result<Bounds2D, ReadbackError> {
+    if segments.is_empty() {
+        return Ok(fallback_bounds_2d());
+    }
+    if !support.supports_compute_shaders() {
+        return Ok(cpu_segment_bounds_2d(segments));
+    }
+    compute_bounds_2d(
+        device,
+        queue,
+        segments.len() as u32,
+        DIMENSIONS_2D,
+        std::mem::size_of::<Segment2D>() as u32 / 4,
+        bytemuck::cast_slice(segments),
+        uploaded,
+    )
+    .await
+}
+
+pub async fn standalone_segment_bounds_2d(segments: &[Segment2D]) -> Bounds2D {
+    if segments.is_empty() {
+        return fallback_bounds_2d();
+    }
+    match crate::wgpu_util::create_headless_device("bounds_compute_device", "bounds compute").await
+    {
+        Ok((device, queue, support)) => segment_bounds_2d(&device, &queue, support, segments, None)
+            .await
+            .unwrap_or_else(|error| {
+                log::warn!("GPU 2D bounds readback failed; using CPU fallback: {error}");
+                cpu_segment_bounds_2d(segments)
+            }),
+        Err(error) => {
+            log::warn!("Failed to create GPU bounds device; using CPU fallback: {error:?}");
+            cpu_segment_bounds_2d(segments)
+        }
+    }
+}
+
+pub async fn depth_segment_bounds_2d(
+    device: &wgpu::Device,
+    queue: &wgpu::Queue,
+    support: BoundsComputeSupport,
+    segments: &[TopologicalDepthSegment2D],
+    uploaded: Option<UploadedSegmentBuffer>,
+) -> Result<Bounds2D, ReadbackError> {
+    if segments.is_empty() {
+        return Ok(fallback_bounds_2d());
+    }
+    if !support.supports_compute_shaders() {
+        return Ok(cpu_depth_segment_bounds_2d(segments));
+    }
+    compute_bounds_2d(
+        device,
+        queue,
+        segments.len() as u32,
+        DIMENSIONS_2D,
+        std::mem::size_of::<TopologicalDepthSegment2D>() as u32 / 4,
+        bytemuck::cast_slice(segments),
+        uploaded,
+    )
+    .await
+}
+
+pub async fn standalone_depth_segment_bounds_2d(
+    segments: &[TopologicalDepthSegment2D],
+) -> Bounds2D {
+    if segments.is_empty() {
+        return fallback_bounds_2d();
+    }
+    match crate::wgpu_util::create_headless_device("bounds_compute_device", "bounds compute").await
+    {
+        Ok((device, queue, support)) => {
+            depth_segment_bounds_2d(&device, &queue, support, segments, None)
+                .await
+                .unwrap_or_else(|error| {
+                    log::warn!("GPU 2D depth bounds readback failed; using CPU fallback: {error}");
+                    cpu_depth_segment_bounds_2d(segments)
+                })
+        }
+        Err(error) => {
+            log::warn!("Failed to create GPU bounds device; using CPU fallback: {error:?}");
+            cpu_depth_segment_bounds_2d(segments)
+        }
+    }
+}
+
+pub async fn segment_bounds_3d(
+    device: &wgpu::Device,
+    queue: &wgpu::Queue,
+    support: BoundsComputeSupport,
+    segments: &[Segment3D],
+    uploaded: Option<UploadedSegmentBuffer>,
+) -> Result<Bounds3D, ReadbackError> {
+    if segments.is_empty() {
+        return Ok(fallback_bounds_3d());
+    }
+    if !support.supports_compute_shaders() {
+        return Ok(cpu_segment_bounds_3d(segments));
+    }
+    compute_bounds_3d(
+        device,
+        queue,
+        segments.len() as u32,
+        DIMENSIONS_3D,
+        std::mem::size_of::<Segment3D>() as u32 / 4,
+        bytemuck::cast_slice(segments),
+        uploaded,
+    )
+    .await
+}
+
+pub async fn standalone_segment_bounds_3d(segments: &[Segment3D]) -> Bounds3D {
+    if segments.is_empty() {
+        return fallback_bounds_3d();
+    }
+    match crate::wgpu_util::create_headless_device("bounds_compute_device", "bounds compute").await
+    {
+        Ok((device, queue, support)) => segment_bounds_3d(&device, &queue, support, segments, None)
+            .await
+            .unwrap_or_else(|error| {
+                log::warn!("GPU 3D bounds readback failed; using CPU fallback: {error}");
+                cpu_segment_bounds_3d(segments)
+            }),
+        Err(error) => {
+            log::warn!("Failed to create GPU bounds device; using CPU fallback: {error:?}");
+            cpu_segment_bounds_3d(segments)
+        }
+    }
+}
+
+pub async fn depth_segment_bounds_3d(
+    device: &wgpu::Device,
+    queue: &wgpu::Queue,
+    support: BoundsComputeSupport,
+    segments: &[TopologicalDepthSegment3D],
+    uploaded: Option<UploadedSegmentBuffer>,
+) -> Result<Bounds3D, ReadbackError> {
+    if segments.is_empty() {
+        return Ok(fallback_bounds_3d());
+    }
+    if !support.supports_compute_shaders() {
+        return Ok(cpu_depth_segment_bounds_3d(segments));
+    }
+    compute_bounds_3d(
+        device,
+        queue,
+        segments.len() as u32,
+        DIMENSIONS_3D,
+        std::mem::size_of::<TopologicalDepthSegment3D>() as u32 / 4,
+        bytemuck::cast_slice(segments),
+        uploaded,
+    )
+    .await
+}
+
+pub async fn standalone_depth_segment_bounds_3d(
+    segments: &[TopologicalDepthSegment3D],
+) -> Bounds3D {
+    if segments.is_empty() {
+        return fallback_bounds_3d();
+    }
+    match crate::wgpu_util::create_headless_device("bounds_compute_device", "bounds compute").await
+    {
+        Ok((device, queue, support)) => {
+            depth_segment_bounds_3d(&device, &queue, support, segments, None)
+                .await
+                .unwrap_or_else(|error| {
+                    log::warn!("GPU 3D depth bounds readback failed; using CPU fallback: {error}");
+                    cpu_depth_segment_bounds_3d(segments)
+                })
+        }
+        Err(error) => {
+            log::warn!("Failed to create GPU bounds device; using CPU fallback: {error:?}");
+            cpu_depth_segment_bounds_3d(segments)
+        }
+    }
+}
+
+async fn compute_bounds_2d(
+    device: &wgpu::Device,
+    queue: &wgpu::Queue,
+    count: u32,
+    dimensions: u32,
+    stride_words: u32,
+    segment_bytes: &[u8],
+    uploaded: Option<UploadedSegmentBuffer>,
+) -> Result<Bounds2D, ReadbackError> {
+    let words = compute_bounds_words(
+        device,
+        queue,
+        count,
+        dimensions,
+        stride_words,
+        segment_bytes,
+        uploaded,
+    )
+    .await?;
+    Ok((
+        [
+            ordered_u32_to_float(words[0]),
+            ordered_u32_to_float(words[1]),
+        ],
+        [
+            ordered_u32_to_float(words[3]),
+            ordered_u32_to_float(words[4]),
+        ],
+    ))
+}
+
+async fn compute_bounds_3d(
+    device: &wgpu::Device,
+    queue: &wgpu::Queue,
+    count: u32,
+    dimensions: u32,
+    stride_words: u32,
+    segment_bytes: &[u8],
+    uploaded: Option<UploadedSegmentBuffer>,
+) -> Result<Bounds3D, ReadbackError> {
+    let words = compute_bounds_words(
+        device,
+        queue,
+        count,
+        dimensions,
+        stride_words,
+        segment_bytes,
+        uploaded,
+    )
+    .await?;
+    Ok((
+        [
+            ordered_u32_to_float(words[0]),
+            ordered_u32_to_float(words[1]),
+            ordered_u32_to_float(words[2]),
+        ],
+        [
+            ordered_u32_to_float(words[3]),
+            ordered_u32_to_float(words[4]),
+            ordered_u32_to_float(words[5]),
+        ],
+    ))
+}
+
+async fn compute_bounds_words(
+    device: &wgpu::Device,
+    queue: &wgpu::Queue,
+    count: u32,
+    dimensions: u32,
+    stride_words: u32,
+    segment_bytes: &[u8],
+    uploaded: Option<UploadedSegmentBuffer>,
+) -> Result<[u32; BOUNDS_3D_WORDS], ReadbackError> {
+    let count = uploaded
+        .as_ref()
+        .map(|uploaded| uploaded.count)
+        .unwrap_or(count);
+    let segment_buffer;
+    let segment_buffer = match uploaded {
+        Some(uploaded) => uploaded.buffer,
+        None => {
+            segment_buffer = device.create_buffer_init(&wgpu::util::BufferInitDescriptor {
+                label: Some("bounds_compute_temp_segments"),
+                contents: segment_bytes,
+                usage: wgpu::BufferUsages::STORAGE,
+            });
+            segment_buffer
+        }
+    };
+
+    let init_words = [u32::MAX, u32::MAX, u32::MAX, 0, 0, 0];
+    let bounds_buffer = device.create_buffer_init(&wgpu::util::BufferInitDescriptor {
+        label: Some("bounds_compute_output"),
+        contents: bytemuck::cast_slice(&init_words),
+        usage: wgpu::BufferUsages::STORAGE
+            | wgpu::BufferUsages::COPY_SRC
+            | wgpu::BufferUsages::COPY_DST,
+    });
+    let params = BoundsParams {
+        count,
+        dimensions,
+        stride_words,
+        _pad: 0,
+    };
+    let params_buffer = device.create_buffer_init(&wgpu::util::BufferInitDescriptor {
+        label: Some("bounds_compute_params"),
+        contents: bytemuck::bytes_of(&params),
+        usage: wgpu::BufferUsages::UNIFORM,
+    });
+    let readback = device.create_buffer(&wgpu::BufferDescriptor {
+        label: Some("bounds_compute_readback"),
+        size: std::mem::size_of::<[u32; BOUNDS_3D_WORDS]>() as u64,
+        usage: wgpu::BufferUsages::COPY_DST | wgpu::BufferUsages::MAP_READ,
+        mapped_at_creation: false,
+    });
+
+    let shader = device.create_shader_module(wgpu::ShaderModuleDescriptor {
+        label: Some("bounds_compute_shader"),
+        source: wgpu::ShaderSource::Wgsl(include_str!("bounds_compute.wgsl").into()),
+    });
+    let bind_group_layout = device.create_bind_group_layout(&wgpu::BindGroupLayoutDescriptor {
+        label: Some("bounds_compute_bind_group_layout"),
+        entries: &[
+            wgpu::BindGroupLayoutEntry {
+                binding: 0,
+                visibility: wgpu::ShaderStages::COMPUTE,
+                ty: wgpu::BindingType::Buffer {
+                    ty: wgpu::BufferBindingType::Storage { read_only: true },
+                    has_dynamic_offset: false,
+                    min_binding_size: None,
+                },
+                count: None,
+            },
+            wgpu::BindGroupLayoutEntry {
+                binding: 1,
+                visibility: wgpu::ShaderStages::COMPUTE,
+                ty: wgpu::BindingType::Buffer {
+                    ty: wgpu::BufferBindingType::Storage { read_only: false },
+                    has_dynamic_offset: false,
+                    min_binding_size: None,
+                },
+                count: None,
+            },
+            wgpu::BindGroupLayoutEntry {
+                binding: 2,
+                visibility: wgpu::ShaderStages::COMPUTE,
+                ty: wgpu::BindingType::Buffer {
+                    ty: wgpu::BufferBindingType::Uniform,
+                    has_dynamic_offset: false,
+                    min_binding_size: None,
+                },
+                count: None,
+            },
+        ],
+    });
+    let bind_group = device.create_bind_group(&wgpu::BindGroupDescriptor {
+        label: Some("bounds_compute_bind_group"),
+        layout: &bind_group_layout,
+        entries: &[
+            wgpu::BindGroupEntry {
+                binding: 0,
+                resource: wgpu::BindingResource::Buffer(wgpu::BufferBinding {
+                    buffer: &segment_buffer,
+                    offset: 0,
+                    size: wgpu::BufferSize::new(segment_bytes.len() as u64),
+                }),
+            },
+            wgpu::BindGroupEntry {
+                binding: 1,
+                resource: wgpu::BindingResource::Buffer(wgpu::BufferBinding {
+                    buffer: &bounds_buffer,
+                    offset: 0,
+                    size: wgpu::BufferSize::new(
+                        std::mem::size_of::<[u32; BOUNDS_3D_WORDS]>() as u64
+                    ),
+                }),
+            },
+            wgpu::BindGroupEntry {
+                binding: 2,
+                resource: params_buffer.as_entire_binding(),
+            },
+        ],
+    });
+    let pipeline_layout = device.create_pipeline_layout(&wgpu::PipelineLayoutDescriptor {
+        label: Some("bounds_compute_pipeline_layout"),
+        bind_group_layouts: &[Some(&bind_group_layout)],
+        immediate_size: 0,
+    });
+    let pipeline = device.create_compute_pipeline(&wgpu::ComputePipelineDescriptor {
+        label: Some("bounds_compute_pipeline"),
+        layout: Some(&pipeline_layout),
+        module: &shader,
+        entry_point: Some("bounds_segments"),
+        compilation_options: Default::default(),
+        cache: None,
+    });
+
+    let mut encoder = device.create_command_encoder(&wgpu::CommandEncoderDescriptor {
+        label: Some("bounds_compute_encoder"),
+    });
+    {
+        let mut pass = encoder.begin_compute_pass(&wgpu::ComputePassDescriptor {
+            label: Some("bounds_compute_pass"),
+            timestamp_writes: None,
+        });
+        pass.set_pipeline(&pipeline);
+        pass.set_bind_group(0, &bind_group, &[]);
+        pass.dispatch_workgroups(count.div_ceil(WORKGROUP_SIZE), 1, 1);
+    }
+    encoder.copy_buffer_to_buffer(
+        &bounds_buffer,
+        0,
+        &readback,
+        0,
+        std::mem::size_of::<[u32; BOUNDS_3D_WORDS]>() as u64,
+    );
+    queue.submit([encoder.finish()]);
+
+    map_read_buffer(device, &readback).await?;
+    let mut words = [0u32; BOUNDS_3D_WORDS];
+    {
+        let mapped = readback.slice(..).get_mapped_range();
+        words.copy_from_slice(bytemuck::cast_slice(&mapped));
+    }
+    readback.unmap();
+    Ok(words)
+}
+
+fn fallback_bounds_2d() -> Bounds2D {
+    ([-1.0, -1.0], [1.0, 1.0])
+}
+
+fn fallback_bounds_3d() -> Bounds3D {
+    ([-1.0, -1.0, -1.0], [1.0, 1.0, 1.0])
+}
+
+fn ordered_u32_to_float(u: u32) -> f32 {
+    if (u & 0x8000_0000) != 0 {
+        f32::from_bits(u & 0x7fff_ffff)
+    } else {
+        f32::from_bits(!u)
+    }
+}
+
+fn cpu_segment_bounds_2d(segments: &[Segment2D]) -> Bounds2D {
+    reduce_bounds_2d(
+        segments
+            .iter()
+            .flat_map(|segment| [segment.start, segment.end]),
+    )
+}
+
+fn cpu_depth_segment_bounds_2d(segments: &[TopologicalDepthSegment2D]) -> Bounds2D {
+    reduce_bounds_2d(
+        segments
+            .iter()
+            .flat_map(|segment| [segment.start, segment.end]),
+    )
+}
+
+fn cpu_segment_bounds_3d(segments: &[Segment3D]) -> Bounds3D {
+    reduce_bounds_3d(
+        segments
+            .iter()
+            .flat_map(|segment| [segment.start, segment.end]),
+    )
+}
+
+fn cpu_depth_segment_bounds_3d(segments: &[TopologicalDepthSegment3D]) -> Bounds3D {
+    reduce_bounds_3d(
+        segments
+            .iter()
+            .flat_map(|segment| [segment.start, segment.end]),
+    )
+}
+
+fn reduce_bounds_2d(points: impl Iterator<Item = glam::Vec2>) -> Bounds2D {
+    let mut min = glam::Vec2::splat(f32::INFINITY);
+    let mut max = glam::Vec2::splat(f32::NEG_INFINITY);
+    for point in points {
+        min = min.min(point);
+        max = max.max(point);
+    }
+    ([min.x, min.y], [max.x, max.y])
+}
+
+fn reduce_bounds_3d(points: impl Iterator<Item = glam::Vec3>) -> Bounds3D {
+    let mut min = glam::Vec3::splat(f32::INFINITY);
+    let mut max = glam::Vec3::splat(f32::NEG_INFINITY);
+    for point in points {
+        min = min.min(point);
+        max = max.max(point);
+    }
+    ([min.x, min.y, min.z], [max.x, max.y, max.z])
+}
+
+#[cfg(all(test, not(target_arch = "wasm32")))]
+mod tests {
+    use super::*;
+
+    const EPS: f32 = 1e-5;
+
+    fn close(a: f32, b: f32) -> bool {
+        (a - b).abs() < EPS
+    }
+
+    fn assert_bounds_2d(actual: Bounds2D, min: [f32; 2], max: [f32; 2]) {
+        assert!(close(actual.0[0], min[0]), "min x: {:?}", actual);
+        assert!(close(actual.0[1], min[1]), "min y: {:?}", actual);
+        assert!(close(actual.1[0], max[0]), "max x: {:?}", actual);
+        assert!(close(actual.1[1], max[1]), "max y: {:?}", actual);
+    }
+
+    fn assert_bounds_3d(actual: Bounds3D, min: [f32; 3], max: [f32; 3]) {
+        assert!(close(actual.0[0], min[0]), "min x: {:?}", actual);
+        assert!(close(actual.0[1], min[1]), "min y: {:?}", actual);
+        assert!(close(actual.0[2], min[2]), "min z: {:?}", actual);
+        assert!(close(actual.1[0], max[0]), "max x: {:?}", actual);
+        assert!(close(actual.1[1], max[1]), "max y: {:?}", actual);
+        assert!(close(actual.1[2], max[2]), "max z: {:?}", actual);
+    }
+
+    #[test]
+    fn cpu_fallback_bounds_2d_cover_negative_coordinates() {
+        let segments = [
+            Segment2D {
+                start: glam::Vec2::new(2.0, -3.0),
+                end: glam::Vec2::new(-4.0, 1.0),
+            },
+            Segment2D {
+                start: glam::Vec2::new(0.5, 6.0),
+                end: glam::Vec2::new(3.0, -2.0),
+            },
+        ];
+        assert_bounds_2d(cpu_segment_bounds_2d(&segments), [-4.0, -3.0], [3.0, 6.0]);
+    }
+
+    #[test]
+    fn cpu_fallback_bounds_3d_use_packed_vertex_layout() {
+        let segments = [TopologicalDepthSegment3D {
+            start: glam::Vec3::new(-2.0, 3.0, -4.0),
+            end: glam::Vec3::new(5.0, -6.0, 7.0),
+            topological_depth: 9,
+        }];
+        assert_bounds_3d(
+            cpu_depth_segment_bounds_3d(&segments),
+            [-2.0, -6.0, -4.0],
+            [5.0, 3.0, 7.0],
+        );
+    }
+
+    #[test]
+    fn zero_segments_use_fallback_bounds() {
+        let (device, queue, support) = pollster::block_on(
+            crate::wgpu_util::create_headless_device("bounds_zero_test_device", "bounds zero test"),
+        )
+        .expect("failed to create test device");
+        let bounds = pollster::block_on(segment_bounds_2d(&device, &queue, support, &[], None))
+            .expect("bounds failed");
+        assert_bounds_2d(bounds, [-1.0, -1.0], [1.0, 1.0]);
+    }
+
+    #[test]
+    fn gpu_bounds_2d_are_tight() {
+        let segments = [
+            Segment2D {
+                start: glam::Vec2::new(0.0, 0.0),
+                end: glam::Vec2::new(2.0, 1.0),
+            },
+            Segment2D {
+                start: glam::Vec2::new(-1.0, 3.0),
+                end: glam::Vec2::new(4.0, -2.0),
+            },
+        ];
+        let (device, queue, support) = pollster::block_on(
+            crate::wgpu_util::create_headless_device("bounds_2d_test_device", "bounds 2D test"),
+        )
+        .expect("failed to create test device");
+        let bounds =
+            pollster::block_on(segment_bounds_2d(&device, &queue, support, &segments, None))
+                .expect("bounds failed");
+        assert_bounds_2d(bounds, [-1.0, -2.0], [4.0, 3.0]);
+    }
+
+    #[test]
+    fn gpu_bounds_3d_depth_records_are_tight() {
+        let segments = [
+            TopologicalDepthSegment3D {
+                start: glam::Vec3::new(-2.0, 3.0, -4.0),
+                end: glam::Vec3::new(5.0, -6.0, 7.0),
+                topological_depth: 9,
+            },
+            TopologicalDepthSegment3D {
+                start: glam::Vec3::new(1.0, -8.0, 2.0),
+                end: glam::Vec3::new(0.0, 4.0, -9.0),
+                topological_depth: 1,
+            },
+        ];
+        let (device, queue, support) =
+            pollster::block_on(crate::wgpu_util::create_headless_device(
+                "bounds_3d_depth_test_device",
+                "bounds 3D depth test",
+            ))
+            .expect("failed to create test device");
+        let bounds = pollster::block_on(depth_segment_bounds_3d(
+            &device, &queue, support, &segments, None,
+        ))
+        .expect("bounds failed");
+        assert_bounds_3d(bounds, [-2.0, -8.0, -9.0], [5.0, 4.0, 7.0]);
+    }
+}

--- a/crates/lsystem-renderer/src/bounds_compute.wgsl
+++ b/crates/lsystem-renderer/src/bounds_compute.wgsl
@@ -1,0 +1,60 @@
+struct BoundsParams {
+    count: u32,
+    dimensions: u32,
+    stride_words: u32,
+    _pad: u32,
+}
+
+struct BoundsOutput {
+    min_x: atomic<u32>,
+    min_y: atomic<u32>,
+    min_z: atomic<u32>,
+    max_x: atomic<u32>,
+    max_y: atomic<u32>,
+    max_z: atomic<u32>,
+}
+
+@group(0) @binding(0)
+var<storage, read> segment_words: array<u32>;
+
+@group(0) @binding(1)
+var<storage, read_write> bounds: BoundsOutput;
+
+@group(0) @binding(2)
+var<uniform> params: BoundsParams;
+
+fn float_to_ordered_u32(f: f32) -> u32 {
+    let bits = bitcast<u32>(f);
+    return select(bits | 0x80000000u, ~bits, (bits & 0x80000000u) != 0u);
+}
+
+fn ordered_word(index: u32) -> u32 {
+    return float_to_ordered_u32(bitcast<f32>(segment_words[index]));
+}
+
+@compute @workgroup_size(64)
+fn bounds_segments(@builtin(global_invocation_id) id: vec3<u32>) {
+    let index = id.x;
+    if index >= params.count {
+        return;
+    }
+
+    let base = index * params.stride_words;
+    let ax = ordered_word(base);
+    let ay = ordered_word(base + 1u);
+    let bx_offset = select(3u, 2u, params.dimensions == 2u);
+    let bx = ordered_word(base + bx_offset);
+    let by = ordered_word(base + bx_offset + 1u);
+
+    atomicMin(&bounds.min_x, min(ax, bx));
+    atomicMin(&bounds.min_y, min(ay, by));
+    atomicMax(&bounds.max_x, max(ax, bx));
+    atomicMax(&bounds.max_y, max(ay, by));
+
+    if params.dimensions == 3u {
+        let az = ordered_word(base + 2u);
+        let bz = ordered_word(base + 5u);
+        atomicMin(&bounds.min_z, min(az, bz));
+        atomicMax(&bounds.max_z, max(az, bz));
+    }
+}

--- a/crates/lsystem-renderer/src/lib.rs
+++ b/crates/lsystem-renderer/src/lib.rs
@@ -1,5 +1,6 @@
 #[cfg(feature = "png")]
 pub mod animation_export;
+pub mod bounds_compute;
 pub mod camera;
 #[allow(dead_code, unused_imports, clippy::all)]
 mod generated_shader {
@@ -11,4 +12,5 @@ pub mod lsystem_bridge;
 mod offscreen;
 #[cfg(feature = "png")]
 pub mod png_export;
+pub mod readback;
 mod wgpu_util;

--- a/crates/lsystem-renderer/src/line_renderer.rs
+++ b/crates/lsystem-renderer/src/line_renderer.rs
@@ -151,6 +151,12 @@ struct GrowableVertexBuffer {
     count: u32,
 }
 
+#[derive(Clone)]
+pub struct UploadedSegmentBuffer {
+    pub buffer: wgpu::Buffer,
+    pub count: u32,
+}
+
 impl GrowableVertexBuffer {
     fn new() -> Self {
         Self {
@@ -174,7 +180,9 @@ impl GrowableVertexBuffer {
                 self.buffer = Some(device.create_buffer(&wgpu::BufferDescriptor {
                     label: Some(label),
                     size: self.capacity,
-                    usage: wgpu::BufferUsages::VERTEX | wgpu::BufferUsages::COPY_DST,
+                    usage: wgpu::BufferUsages::VERTEX
+                        | wgpu::BufferUsages::STORAGE
+                        | wgpu::BufferUsages::COPY_DST,
                     mapped_at_creation: false,
                 }));
             }
@@ -183,6 +191,13 @@ impl GrowableVertexBuffer {
             }
         }
         self.count = segments.len() as u32;
+    }
+
+    fn uploaded(&self) -> Option<UploadedSegmentBuffer> {
+        Some(UploadedSegmentBuffer {
+            buffer: self.buffer.as_ref()?.clone(),
+            count: self.count,
+        })
     }
 }
 
@@ -381,6 +396,13 @@ impl LinePipeline2D {
         queue.write_buffer(&self.color_params_buffer, 0, &color_params.uniform_bytes());
     }
 
+    pub fn active_uploaded_segment_buffer(&self) -> Option<UploadedSegmentBuffer> {
+        match self.active_segment_buffer {
+            ActiveSegmentBuffer::Normal => self.segment_buffer.uploaded(),
+            ActiveSegmentBuffer::TopologicalDepth => self.depth_segment_buffer.uploaded(),
+        }
+    }
+
     pub fn write_transform(&self, queue: &wgpu::Queue, transform: Transform) {
         queue.write_buffer(&self.uniform_buffer, 0, &transform.uniform_bytes());
     }
@@ -536,6 +558,13 @@ impl LinePipeline3D {
         queue.write_buffer(&self.color_params_buffer, 0, &color_params.uniform_bytes());
     }
 
+    pub fn active_uploaded_segment_buffer(&self) -> Option<UploadedSegmentBuffer> {
+        match self.active_segment_buffer {
+            ActiveSegmentBuffer::Normal => self.segment_buffer.uploaded(),
+            ActiveSegmentBuffer::TopologicalDepth => self.depth_segment_buffer.uploaded(),
+        }
+    }
+
     pub fn write_mvp(&self, queue: &wgpu::Queue, mvp: Mvp) {
         queue.write_buffer(&self.mvp_buffer, 0, &mvp.uniform_bytes());
     }
@@ -637,6 +666,7 @@ pub struct GpuContext {
     #[allow(clippy::arc_with_non_send_sync)]
     pub queue: Arc<wgpu::Queue>,
     surface_config: wgpu::SurfaceConfiguration,
+    bounds_compute_support: crate::bounds_compute::BoundsComputeSupport,
 }
 
 impl GpuContext {
@@ -658,6 +688,8 @@ impl GpuContext {
             .await
             .map_err(GpuInitError::RequestAdapter)?;
         let adapter_info = adapter.get_info();
+        let bounds_compute_support =
+            crate::bounds_compute::BoundsComputeSupport::from_adapter(&adapter);
         log::info!(
             "Selected surface GPU adapter: {} ({})",
             adapter_info.name,
@@ -703,7 +735,12 @@ impl GpuContext {
             device,
             queue,
             surface_config,
+            bounds_compute_support,
         })
+    }
+
+    pub fn bounds_compute_support(&self) -> crate::bounds_compute::BoundsComputeSupport {
+        self.bounds_compute_support
     }
 
     pub fn surface_format(&self) -> wgpu::TextureFormat {

--- a/crates/lsystem-renderer/src/lsystem_bridge.rs
+++ b/crates/lsystem-renderer/src/lsystem_bridge.rs
@@ -8,48 +8,26 @@ use crate::line_renderer::{
 
 pub struct SegmentData {
     pub segments: Vec<Segment2D>,
-    pub bounds_min: [f32; 2],
-    pub bounds_max: [f32; 2],
 }
 
 pub struct SegmentDataBuilder {
-    min_x: f32,
-    min_y: f32,
-    max_x: f32,
-    max_y: f32,
     segments: Vec<Segment2D>,
 }
 
 impl SegmentDataBuilder {
     pub fn new() -> Self {
         Self {
-            min_x: f32::INFINITY,
-            min_y: f32::INFINITY,
-            max_x: f32::NEG_INFINITY,
-            max_y: f32::NEG_INFINITY,
             segments: Vec::new(),
         }
     }
 
     pub fn push_segment(&mut self, [a, b]: [Vec2; 2]) {
-        self.min_x = self.min_x.min(a.x).min(b.x);
-        self.min_y = self.min_y.min(a.y).min(b.y);
-        self.max_x = self.max_x.max(a.x).max(b.x);
-        self.max_y = self.max_y.max(a.y).max(b.y);
         self.segments.push(Segment2D { start: a, end: b });
     }
 
     pub fn finish(self) -> SegmentData {
-        let (bounds_min, bounds_max) = if self.min_x.is_infinite() {
-            ([-1.0, -1.0], [1.0, 1.0])
-        } else {
-            ([self.min_x, self.min_y], [self.max_x, self.max_y])
-        };
-
         SegmentData {
             segments: self.segments,
-            bounds_min,
-            bounds_max,
         }
     }
 }
@@ -70,8 +48,6 @@ pub fn geometry_to_segments(segments: impl Iterator<Item = [Vec2; 2]>) -> Segmen
 
 pub struct TopologicalDepthSegmentData {
     pub segments: Vec<TopologicalDepthSegment2D>,
-    pub bounds_min: [f32; 2],
-    pub bounds_max: [f32; 2],
     max_topological_depth: u32,
 }
 
@@ -82,10 +58,6 @@ impl TopologicalDepthSegmentData {
 }
 
 pub struct TopologicalDepthSegmentDataBuilder {
-    min_x: f32,
-    min_y: f32,
-    max_x: f32,
-    max_y: f32,
     max_topological_depth: u32,
     segments: Vec<TopologicalDepthSegment2D>,
 }
@@ -93,10 +65,6 @@ pub struct TopologicalDepthSegmentDataBuilder {
 impl TopologicalDepthSegmentDataBuilder {
     pub fn new() -> Self {
         Self {
-            min_x: f32::INFINITY,
-            min_y: f32::INFINITY,
-            max_x: f32::NEG_INFINITY,
-            max_y: f32::NEG_INFINITY,
             max_topological_depth: 0,
             segments: Vec::new(),
         }
@@ -104,10 +72,6 @@ impl TopologicalDepthSegmentDataBuilder {
 
     pub fn push_segment(&mut self, segment: Segment2DWithTopologicalDepth) {
         let [a, b] = segment.points;
-        self.min_x = self.min_x.min(a.x).min(b.x);
-        self.min_y = self.min_y.min(a.y).min(b.y);
-        self.max_x = self.max_x.max(a.x).max(b.x);
-        self.max_y = self.max_y.max(a.y).max(b.y);
         self.max_topological_depth = self.max_topological_depth.max(segment.topological_depth);
         self.segments.push(TopologicalDepthSegment2D {
             start: a,
@@ -117,16 +81,8 @@ impl TopologicalDepthSegmentDataBuilder {
     }
 
     pub fn finish(self) -> TopologicalDepthSegmentData {
-        let (bounds_min, bounds_max) = if self.min_x.is_infinite() {
-            ([-1.0, -1.0], [1.0, 1.0])
-        } else {
-            ([self.min_x, self.min_y], [self.max_x, self.max_y])
-        };
-
         TopologicalDepthSegmentData {
             segments: self.segments,
-            bounds_min,
-            bounds_max,
             max_topological_depth: self.max_topological_depth,
         }
     }
@@ -150,57 +106,26 @@ pub fn geometry_to_depth_segments(
 
 pub struct SegmentData3D {
     pub segments: Vec<Segment3D>,
-    pub bounds_min: [f32; 3],
-    pub bounds_max: [f32; 3],
 }
 
 pub struct SegmentDataBuilder3D {
-    min_x: f32,
-    min_y: f32,
-    min_z: f32,
-    max_x: f32,
-    max_y: f32,
-    max_z: f32,
     segments: Vec<Segment3D>,
 }
 
 impl SegmentDataBuilder3D {
     pub fn new() -> Self {
         Self {
-            min_x: f32::INFINITY,
-            min_y: f32::INFINITY,
-            min_z: f32::INFINITY,
-            max_x: f32::NEG_INFINITY,
-            max_y: f32::NEG_INFINITY,
-            max_z: f32::NEG_INFINITY,
             segments: Vec::new(),
         }
     }
 
     pub fn push_segment(&mut self, [a, b]: [Vec3; 2]) {
-        self.min_x = self.min_x.min(a.x).min(b.x);
-        self.min_y = self.min_y.min(a.y).min(b.y);
-        self.min_z = self.min_z.min(a.z).min(b.z);
-        self.max_x = self.max_x.max(a.x).max(b.x);
-        self.max_y = self.max_y.max(a.y).max(b.y);
-        self.max_z = self.max_z.max(a.z).max(b.z);
         self.segments.push(Segment3D { start: a, end: b });
     }
 
     pub fn finish(self) -> SegmentData3D {
-        let (bounds_min, bounds_max) = if self.min_x.is_infinite() {
-            ([-1.0, -1.0, -1.0], [1.0, 1.0, 1.0])
-        } else {
-            (
-                [self.min_x, self.min_y, self.min_z],
-                [self.max_x, self.max_y, self.max_z],
-            )
-        };
-
         SegmentData3D {
             segments: self.segments,
-            bounds_min,
-            bounds_max,
         }
     }
 }
@@ -221,8 +146,6 @@ pub fn geometry_to_segments_3d(segments: impl Iterator<Item = [Vec3; 2]>) -> Seg
 
 pub struct TopologicalDepthSegmentData3D {
     pub segments: Vec<TopologicalDepthSegment3D>,
-    pub bounds_min: [f32; 3],
-    pub bounds_max: [f32; 3],
     max_topological_depth: u32,
 }
 
@@ -233,12 +156,6 @@ impl TopologicalDepthSegmentData3D {
 }
 
 pub struct TopologicalDepthSegmentDataBuilder3D {
-    min_x: f32,
-    min_y: f32,
-    min_z: f32,
-    max_x: f32,
-    max_y: f32,
-    max_z: f32,
     max_topological_depth: u32,
     segments: Vec<TopologicalDepthSegment3D>,
 }
@@ -246,12 +163,6 @@ pub struct TopologicalDepthSegmentDataBuilder3D {
 impl TopologicalDepthSegmentDataBuilder3D {
     pub fn new() -> Self {
         Self {
-            min_x: f32::INFINITY,
-            min_y: f32::INFINITY,
-            min_z: f32::INFINITY,
-            max_x: f32::NEG_INFINITY,
-            max_y: f32::NEG_INFINITY,
-            max_z: f32::NEG_INFINITY,
             max_topological_depth: 0,
             segments: Vec::new(),
         }
@@ -259,12 +170,6 @@ impl TopologicalDepthSegmentDataBuilder3D {
 
     pub fn push_segment(&mut self, segment: Segment3DWithTopologicalDepth) {
         let [a, b] = segment.points;
-        self.min_x = self.min_x.min(a.x).min(b.x);
-        self.min_y = self.min_y.min(a.y).min(b.y);
-        self.min_z = self.min_z.min(a.z).min(b.z);
-        self.max_x = self.max_x.max(a.x).max(b.x);
-        self.max_y = self.max_y.max(a.y).max(b.y);
-        self.max_z = self.max_z.max(a.z).max(b.z);
         self.max_topological_depth = self.max_topological_depth.max(segment.topological_depth);
         self.segments.push(TopologicalDepthSegment3D {
             start: a,
@@ -274,19 +179,8 @@ impl TopologicalDepthSegmentDataBuilder3D {
     }
 
     pub fn finish(self) -> TopologicalDepthSegmentData3D {
-        let (bounds_min, bounds_max) = if self.min_x.is_infinite() {
-            ([-1.0, -1.0, -1.0], [1.0, 1.0, 1.0])
-        } else {
-            (
-                [self.min_x, self.min_y, self.min_z],
-                [self.max_x, self.max_y, self.max_z],
-            )
-        };
-
         TopologicalDepthSegmentData3D {
             segments: self.segments,
-            bounds_min,
-            bounds_max,
             max_topological_depth: self.max_topological_depth,
         }
     }
@@ -524,30 +418,22 @@ mod tests {
     }
 
     #[test]
-    fn empty_geometry_uses_fallback_bounds() {
-        let SegmentData {
-            segments,
-            bounds_min,
-            bounds_max,
-        } = geometry_to_segments(generate(&cfg("A")));
+    fn empty_geometry_collects_no_segments() {
+        let SegmentData { segments } = geometry_to_segments(generate(&cfg("A")));
         assert!(segments.is_empty());
-        assert!(close(bounds_min[0], -1.0) && close(bounds_min[1], -1.0));
-        assert!(close(bounds_max[0], 1.0) && close(bounds_max[1], 1.0));
     }
 
     #[test]
-    fn empty_depth_geometry_uses_fallback_bounds_and_zero_max_depth() {
+    fn empty_depth_geometry_collects_no_segments_and_zero_max_depth() {
         let data =
             geometry_to_depth_segments(lsystem_core::generate_with_topological_depth(&cfg("A")));
 
         assert!(data.segments.is_empty());
         assert_eq!(data.max_topological_depth(), 0);
-        assert!(close(data.bounds_min[0], -1.0) && close(data.bounds_min[1], -1.0));
-        assert!(close(data.bounds_max[0], 1.0) && close(data.bounds_max[1], 1.0));
     }
 
     #[test]
-    fn empty_depth_geometry_3d_uses_fallback_bounds_and_zero_max_depth() {
+    fn empty_depth_geometry_3d_collects_no_segments_and_zero_max_depth() {
         let data = geometry_to_depth_segments_3d(lsystem_core::generate_3d_with_topological_depth(
             &GenerationConfig {
                 dimensions: Dimensions::ThreeD,
@@ -562,34 +448,20 @@ mod tests {
 
         assert!(data.segments.is_empty());
         assert_eq!(data.max_topological_depth(), 0);
-        assert_eq!(data.bounds_min, [-1.0, -1.0, -1.0]);
-        assert_eq!(data.bounds_max, [1.0, 1.0, 1.0]);
     }
 
     #[test]
-    fn single_segment_produces_one_segment_record_and_tight_bounds() {
-        let SegmentData {
-            segments,
-            bounds_min,
-            bounds_max,
-        } = geometry_to_segments(generate(&cfg("F")));
+    fn single_segment_produces_one_segment_record() {
+        let SegmentData { segments } = geometry_to_segments(generate(&cfg("F")));
         assert_eq!(segments.len(), 1);
         assert!(close(segments[0].start[0], 0.0) && close(segments[0].start[1], 0.0));
         assert!(close(segments[0].end[0], 1.0) && close(segments[0].end[1], 0.0));
-        assert!(close(bounds_min[0], 0.0) && close(bounds_min[1], 0.0));
-        assert!(close(bounds_max[0], 1.0) && close(bounds_max[1], 0.0));
     }
 
     #[test]
-    fn bounds_are_tight_over_all_segments() {
-        let SegmentData {
-            segments,
-            bounds_min,
-            bounds_max,
-        } = geometry_to_segments(generate(&cfg("F+F-F")));
+    fn geometry_collects_all_segments() {
+        let SegmentData { segments } = geometry_to_segments(generate(&cfg("F+F-F")));
         assert_eq!(segments.len(), 3);
-        assert!(close(bounds_min[0], 0.0) && close(bounds_min[1], 0.0));
-        assert!(close(bounds_max[0], 2.0) && close(bounds_max[1], 1.0));
     }
 
     #[test]
@@ -603,8 +475,6 @@ mod tests {
         assert_eq!(data.segments[1].topological_depth, 1);
         assert_eq!(data.segments[2].topological_depth, 1);
         assert_eq!(data.max_topological_depth(), 1);
-        assert!(close(data.bounds_min[0], 0.0) && close(data.bounds_min[1], 0.0));
-        assert!(close(data.bounds_max[0], 2.0) && close(data.bounds_max[1], 1.0));
     }
 
     #[test]
@@ -626,9 +496,6 @@ mod tests {
         assert_eq!(data.segments[1].topological_depth, 1);
         assert_eq!(data.segments[2].topological_depth, 1);
         assert_eq!(data.max_topological_depth(), 1);
-        assert!(close(data.bounds_min[0], 0.0) && close(data.bounds_min[1], 0.0));
-        assert!(close(data.bounds_max[0], 2.0) && close(data.bounds_max[1], 1.0));
-        assert!(close(data.bounds_min[2], 0.0) && close(data.bounds_max[2], 0.0));
     }
 
     #[test]

--- a/crates/lsystem-renderer/src/offscreen.rs
+++ b/crates/lsystem-renderer/src/offscreen.rs
@@ -1,10 +1,8 @@
 //! Offscreen GPU rendering shared by the PNG and APNG export paths.
 
-use std::error::Error;
-use std::fmt::{Display, Formatter};
-
 use lsystem_core::{Config, Dimensions};
 
+use crate::bounds_compute::{self, BoundsComputeSupport};
 use crate::camera::Camera;
 use crate::line_renderer::{ColorParams, LinePipeline2D, LinePipeline3D};
 use crate::lsystem_bridge::{
@@ -12,30 +10,10 @@ use crate::lsystem_bridge::{
     geometry_to_segments, geometry_to_segments_3d, viewport_transform,
 };
 use crate::png_export::{ExportError, MAX_DIMENSION, MIN_DIMENSION};
+use crate::readback::{ReadbackError, map_read_buffer};
 
 const FORMAT: wgpu::TextureFormat = wgpu::TextureFormat::Rgba8UnormSrgb;
 const BYTES_PER_PIXEL: u32 = 4;
-
-#[derive(Debug)]
-pub(crate) enum ReadbackError {
-    Map(wgpu::BufferAsyncError),
-    ChannelClosed,
-    // Only constructed on non-wasm; wasm uses a polling loop that doesn't return PollError
-    #[cfg_attr(target_arch = "wasm32", allow(dead_code))]
-    Poll(wgpu::PollError),
-}
-
-impl Display for ReadbackError {
-    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
-        match self {
-            Self::Map(e) => write!(f, "failed to map readback buffer: {e}"),
-            Self::ChannelClosed => write!(f, "readback callback was dropped"),
-            Self::Poll(e) => write!(f, "failed to poll GPU device: {e}"),
-        }
-    }
-}
-
-impl Error for ReadbackError {}
 
 pub(crate) fn validate_width(width: u32) -> Result<(), ExportError> {
     if (MIN_DIMENSION..=MAX_DIMENSION).contains(&width) {
@@ -76,7 +54,12 @@ pub(crate) struct ExportScene {
 
 impl ExportScene {
     /// Generates the L-system geometry for `config` and uploads it to `device`.
-    pub(crate) fn new(device: &wgpu::Device, queue: &wgpu::Queue, config: &Config) -> Self {
+    pub(crate) async fn new(
+        device: &wgpu::Device,
+        queue: &wgpu::Queue,
+        bounds_support: BoundsComputeSupport,
+        config: &Config,
+    ) -> Result<Self, ReadbackError> {
         let line = &config.colors.line;
         let needs_depth =
             line.needs_topological_depth() && config.generation.has_stack_directives();
@@ -93,21 +76,37 @@ impl ExportScene {
                         Some(data.max_topological_depth()),
                     );
                     pipeline.upload_with_topological_depth(device, queue, &data.segments, cp);
-                    (cp, data.bounds_min, data.bounds_max)
+                    let bounds = bounds_compute::depth_segment_bounds_2d(
+                        device,
+                        queue,
+                        bounds_support,
+                        &data.segments,
+                        pipeline.active_uploaded_segment_buffer(),
+                    )
+                    .await?;
+                    (cp, bounds.0, bounds.1)
                 } else {
                     let data = geometry_to_segments(lsystem_core::generate(&config.generation));
                     let cp = color_params_from_config(line, data.segments.len() as u32, None);
                     pipeline.upload(device, queue, &data.segments, cp);
-                    (cp, data.bounds_min, data.bounds_max)
+                    let bounds = bounds_compute::segment_bounds_2d(
+                        device,
+                        queue,
+                        bounds_support,
+                        &data.segments,
+                        pipeline.active_uploaded_segment_buffer(),
+                    )
+                    .await?;
+                    (cp, bounds.0, bounds.1)
                 };
-                Self {
+                Ok(Self {
                     geometry: SceneGeometry::TwoD {
                         pipeline,
                         bounds_min,
                         bounds_max,
                     },
                     color_params,
-                }
+                })
             }
             Dimensions::ThreeD => {
                 let mut pipeline = LinePipeline3D::new(device, FORMAT);
@@ -121,22 +120,38 @@ impl ExportScene {
                         Some(data.max_topological_depth()),
                     );
                     pipeline.upload_with_topological_depth(device, queue, &data.segments, cp);
-                    (cp, data.bounds_min, data.bounds_max)
+                    let bounds = bounds_compute::depth_segment_bounds_3d(
+                        device,
+                        queue,
+                        bounds_support,
+                        &data.segments,
+                        pipeline.active_uploaded_segment_buffer(),
+                    )
+                    .await?;
+                    (cp, bounds.0, bounds.1)
                 } else {
                     let data =
                         geometry_to_segments_3d(lsystem_core::generate_3d(&config.generation));
                     let cp = color_params_from_config(line, data.segments.len() as u32, None);
                     pipeline.upload(device, queue, &data.segments, cp);
-                    (cp, data.bounds_min, data.bounds_max)
+                    let bounds = bounds_compute::segment_bounds_3d(
+                        device,
+                        queue,
+                        bounds_support,
+                        &data.segments,
+                        pipeline.active_uploaded_segment_buffer(),
+                    )
+                    .await?;
+                    (cp, bounds.0, bounds.1)
                 };
-                Self {
+                Ok(Self {
                     geometry: SceneGeometry::ThreeD {
                         pipeline,
                         bounds_min,
                         bounds_max,
                     },
                     color_params,
-                }
+                })
             }
         }
     }
@@ -288,42 +303,7 @@ impl RenderTarget {
         );
         queue.submit([encoder.finish()]);
 
-        let (sender, receiver) = futures_channel::oneshot::channel();
-        self.readback
-            .slice(..)
-            .map_async(wgpu::MapMode::Read, move |result| {
-                let _ = sender.send(result);
-            });
-        #[cfg(not(target_arch = "wasm32"))]
-        {
-            device
-                .poll(wgpu::PollType::Wait {
-                    submission_index: None,
-                    timeout: None,
-                })
-                .map_err(ReadbackError::Poll)?;
-            receiver
-                .await
-                .map_err(|_| ReadbackError::ChannelClosed)?
-                .map_err(ReadbackError::Map)?;
-        }
-        #[cfg(target_arch = "wasm32")]
-        {
-            let mut receiver = receiver;
-            loop {
-                let _ = device.poll(wgpu::PollType::Poll);
-                match receiver.try_recv() {
-                    Ok(Some(result)) => {
-                        result.map_err(ReadbackError::Map)?;
-                        break;
-                    }
-                    Ok(None) => {
-                        gloo_timers::future::TimeoutFuture::new(0).await;
-                    }
-                    Err(_) => return Err(ReadbackError::ChannelClosed),
-                }
-            }
-        }
+        map_read_buffer(device, &self.readback).await?;
         let rgba = {
             let mapped = self.readback.slice(..).get_mapped_range();
             self.layout.strip_padding(&mapped)

--- a/crates/lsystem-renderer/src/png_export.rs
+++ b/crates/lsystem-renderer/src/png_export.rs
@@ -3,8 +3,10 @@ use std::fmt::{Display, Formatter};
 
 use lsystem_core::Config;
 
+use crate::bounds_compute::BoundsComputeSupport;
 use crate::camera::Camera;
-use crate::offscreen::{ExportScene, ReadbackError, RenderTarget, validate_height, validate_width};
+use crate::offscreen::{ExportScene, RenderTarget, validate_height, validate_width};
+use crate::readback::ReadbackError;
 use crate::wgpu_util::{self, CreateDeviceError};
 
 /// Minimum export width and height in pixels accepted by [`render_png`] and
@@ -96,6 +98,7 @@ impl From<CreateDeviceError> for ExportError {
 pub async fn render_png(
     device: &wgpu::Device,
     queue: &wgpu::Queue,
+    bounds_support: BoundsComputeSupport,
     config: &Config,
     width: u32,
     height: u32,
@@ -104,7 +107,7 @@ pub async fn render_png(
     validate_width(width)?;
     validate_height(height)?;
 
-    let scene = ExportScene::new(device, queue, config);
+    let scene = ExportScene::new(device, queue, bounds_support, config).await?;
     scene.write_camera(queue, camera, width, height);
 
     let target = RenderTarget::new(device, width, height);
@@ -129,9 +132,18 @@ pub async fn render_png_standalone(
 ) -> Result<PngExport, ExportError> {
     validate_width(width)?;
     validate_height(height)?;
-    let (device, queue) =
+    let (device, queue, bounds_support) =
         wgpu_util::create_headless_device("png_export_device", "PNG export").await?;
-    render_png(&device, &queue, config, width, height, camera).await
+    render_png(
+        &device,
+        &queue,
+        bounds_support,
+        config,
+        width,
+        height,
+        camera,
+    )
+    .await
 }
 
 fn encode_png_rgba(width: u32, height: u32, rgba: &[u8]) -> Result<Vec<u8>, ExportError> {
@@ -187,7 +199,7 @@ mod gpu_tests {
 
     fn assert_png_renders(config: lsystem_core::Config) {
         let (render_result, validation_error) = pollster::block_on(async {
-            let (device, queue) =
+            let (device, queue, bounds_support) =
                 crate::wgpu_util::create_headless_device("png_export_test_device", "PNG export")
                     .await
                     .expect("failed to create headless test device");
@@ -196,6 +208,7 @@ mod gpu_tests {
             let render_result = render_png(
                 &device,
                 &queue,
+                bounds_support,
                 &config,
                 256,
                 128,

--- a/crates/lsystem-renderer/src/readback.rs
+++ b/crates/lsystem-renderer/src/readback.rs
@@ -1,0 +1,69 @@
+use std::error::Error;
+use std::fmt::{Display, Formatter};
+
+#[derive(Debug)]
+pub enum ReadbackError {
+    Map(wgpu::BufferAsyncError),
+    ChannelClosed,
+    // Only constructed on non-wasm; wasm uses a polling loop that doesn't return PollError.
+    #[cfg_attr(target_arch = "wasm32", allow(dead_code))]
+    Poll(wgpu::PollError),
+}
+
+impl Display for ReadbackError {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::Map(e) => write!(f, "failed to map readback buffer: {e}"),
+            Self::ChannelClosed => write!(f, "readback callback was dropped"),
+            Self::Poll(e) => write!(f, "failed to poll GPU device: {e}"),
+        }
+    }
+}
+
+impl Error for ReadbackError {}
+
+pub(crate) async fn map_read_buffer(
+    device: &wgpu::Device,
+    buffer: &wgpu::Buffer,
+) -> Result<(), ReadbackError> {
+    let (sender, receiver) = futures_channel::oneshot::channel();
+    buffer
+        .slice(..)
+        .map_async(wgpu::MapMode::Read, move |result| {
+            let _ = sender.send(result);
+        });
+
+    #[cfg(not(target_arch = "wasm32"))]
+    {
+        device
+            .poll(wgpu::PollType::Wait {
+                submission_index: None,
+                timeout: None,
+            })
+            .map_err(ReadbackError::Poll)?;
+        receiver
+            .await
+            .map_err(|_| ReadbackError::ChannelClosed)?
+            .map_err(ReadbackError::Map)?;
+    }
+
+    #[cfg(target_arch = "wasm32")]
+    {
+        let mut receiver = receiver;
+        loop {
+            let _ = device.poll(wgpu::PollType::Poll);
+            match receiver.try_recv() {
+                Ok(Some(result)) => {
+                    result.map_err(ReadbackError::Map)?;
+                    break;
+                }
+                Ok(None) => {
+                    gloo_timers::future::TimeoutFuture::new(0).await;
+                }
+                Err(_) => return Err(ReadbackError::ChannelClosed),
+            }
+        }
+    }
+
+    Ok(())
+}

--- a/crates/lsystem-renderer/src/wgpu_util.rs
+++ b/crates/lsystem-renderer/src/wgpu_util.rs
@@ -55,18 +55,23 @@ mod non_browser_wasm {
     }
 }
 
-#[cfg(feature = "png")]
 #[derive(Debug)]
 pub(crate) enum CreateDeviceError {
     NoAdapter,
     RequestDevice(wgpu::RequestDeviceError),
 }
 
-#[cfg(feature = "png")]
 pub(crate) async fn create_headless_device(
     label: &'static str,
     context: &'static str,
-) -> Result<(wgpu::Device, wgpu::Queue), CreateDeviceError> {
+) -> Result<
+    (
+        wgpu::Device,
+        wgpu::Queue,
+        crate::bounds_compute::BoundsComputeSupport,
+    ),
+    CreateDeviceError,
+> {
     let instance = new_instance().await;
     let adapter = instance
         .request_adapter(&wgpu::RequestAdapterOptions {
@@ -82,12 +87,14 @@ pub(crate) async fn create_headless_device(
         adapter_info.name,
         adapter_info.backend
     );
+    let bounds_compute_support =
+        crate::bounds_compute::BoundsComputeSupport::from_adapter(&adapter);
     let (device, queue) = adapter
         .request_device(&device_descriptor(label, &adapter))
         .await
         .map_err(CreateDeviceError::RequestDevice)?;
     install_uncaptured_error_handler(&device, context);
-    Ok((device, queue))
+    Ok((device, queue, bounds_compute_support))
 }
 
 pub(crate) fn install_uncaptured_error_handler(device: &wgpu::Device, context: &'static str) {

--- a/crates/lsystem-web-app/src/app.rs
+++ b/crates/lsystem-web-app/src/app.rs
@@ -1751,11 +1751,11 @@ pub(crate) fn App() -> impl IntoView {
                             if fmt == "svg" {
                                 export_svg(config);
                             } else if fmt == "png" {
-                                let Some(Some((device, queue, camera))) =
+                                let Some(Some((device, queue, bounds_support, camera))) =
                                     renderer.try_with_value(|opt| {
                                         opt.as_ref().map(|r| {
-                                            let (d, q) = r.device_queue();
-                                            (d, q, r.camera())
+                                            let (d, q, support) = r.device_queue();
+                                            (d, q, support, r.camera())
                                         })
                                     })
                                 else {
@@ -1765,6 +1765,7 @@ pub(crate) fn App() -> impl IntoView {
                                 export_png(
                                     device,
                                     queue,
+                                    bounds_support,
                                     camera,
                                     config,
                                     png_width.get_untracked(),
@@ -1772,11 +1773,11 @@ pub(crate) fn App() -> impl IntoView {
                                     move |e| export_error.set(Some(e)),
                                 );
                             } else {
-                                let Some(Some((device, queue, camera))) =
+                                let Some(Some((device, queue, bounds_support, camera))) =
                                     renderer.try_with_value(|opt| {
                                         opt.as_ref().map(|r| {
-                                            let (d, q) = r.device_queue();
-                                            (d, q, r.camera())
+                                            let (d, q, support) = r.device_queue();
+                                            (d, q, support, r.camera())
                                         })
                                     })
                                 else {
@@ -1813,6 +1814,7 @@ pub(crate) fn App() -> impl IntoView {
                                 crate::export::export_animation(
                                     device,
                                     queue,
+                                    bounds_support,
                                     camera,
                                     config,
                                     width,
@@ -2089,10 +2091,33 @@ fn with_renderer<F, H>(
     render: F,
 ) where
     F: FnOnce(&mut CanvasRenderer, &web_sys::HtmlCanvasElement) -> RenderStatus,
-    H: Fn(RenderStatus, web_sys::HtmlCanvasElement),
+    H: Fn(RenderStatus, web_sys::HtmlCanvasElement) + Copy + 'static,
 {
-    let status = renderer.try_update_value(|opt| opt.as_mut().map(|r| render(r, &canvas)));
-    if let Some(Some(status)) = status {
+    let outcome = renderer.try_update_value(|opt| {
+        opt.as_mut().map(|r| {
+            let status = render(r, &canvas);
+            let bounds_request = r.take_pending_bounds_request();
+            (status, bounds_request)
+        })
+    });
+    if let Some(Some((status, bounds_request))) = outcome {
+        if let Some(bounds_request) = bounds_request {
+            let canvas_for_bounds = canvas.clone();
+            wasm_bindgen_futures::spawn_local(async move {
+                let Some(update) = bounds_request.resolve().await else {
+                    return;
+                };
+                let status = renderer.try_update_value(|opt| {
+                    opt.as_mut().and_then(|r| {
+                        r.apply_bounds_update(update)
+                            .then(|| r.render(&canvas_for_bounds))
+                    })
+                });
+                if let Some(Some(status)) = status {
+                    recover_after_render(status, canvas_for_bounds);
+                }
+            });
+        }
         recover_after_render(status, canvas);
     }
 }

--- a/crates/lsystem-web-app/src/export.rs
+++ b/crates/lsystem-web-app/src/export.rs
@@ -3,6 +3,7 @@ use std::sync::Arc;
 use lsystem_app_model::sanitize_filename;
 use lsystem_core::Config;
 use lsystem_renderer::animation_export::AnimationParams;
+use lsystem_renderer::bounds_compute::BoundsComputeSupport;
 use lsystem_renderer::camera::Camera;
 use wasm_bindgen::JsCast;
 
@@ -13,9 +14,11 @@ pub(crate) fn export_svg(config: Config) {
     download_blob(blob, filename);
 }
 
+#[allow(clippy::too_many_arguments)]
 pub(crate) fn export_png(
     device: Arc<wgpu::Device>,
     queue: Arc<wgpu::Queue>,
+    bounds_support: BoundsComputeSupport,
     camera: Camera,
     config: Config,
     width: u32,
@@ -25,7 +28,13 @@ pub(crate) fn export_png(
     let filename = sanitize_filename(&config.name, "png");
     wasm_bindgen_futures::spawn_local(async move {
         match lsystem_renderer::png_export::render_png(
-            &device, &queue, &config, width, height, &camera,
+            &device,
+            &queue,
+            bounds_support,
+            &config,
+            width,
+            height,
+            &camera,
         )
         .await
         {
@@ -47,6 +56,7 @@ pub(crate) fn export_png(
 pub(crate) fn export_animation(
     device: Arc<wgpu::Device>,
     queue: Arc<wgpu::Queue>,
+    bounds_support: BoundsComputeSupport,
     camera: Camera,
     config: Config,
     width: u32,
@@ -60,6 +70,7 @@ pub(crate) fn export_animation(
         match lsystem_renderer::animation_export::render_animation(
             &device,
             &queue,
+            bounds_support,
             &config,
             width,
             height,

--- a/crates/lsystem-web-app/src/renderer.rs
+++ b/crates/lsystem-web-app/src/renderer.rs
@@ -4,6 +4,7 @@ use std::sync::atomic::{AtomicBool, Ordering};
 use web_time::{Duration, Instant};
 
 use lsystem_core::{Config, Dimensions};
+use lsystem_renderer::bounds_compute::{self, BoundsComputeSupport};
 use lsystem_renderer::camera::Camera;
 use lsystem_renderer::line_renderer::{
     ColorParams, FrameOutcome, FrameSkipReason, GpuContext, GpuInitError, LinePipeline2D,
@@ -11,8 +12,8 @@ use lsystem_renderer::line_renderer::{
     TopologicalDepthSegment3D,
 };
 use lsystem_renderer::lsystem_bridge::{
-    SegmentData, SegmentData3D, color_params_from_config, geometry_to_depth_segments,
-    geometry_to_depth_segments_3d, geometry_to_segments, geometry_to_segments_3d,
+    color_params_from_config, geometry_to_depth_segments, geometry_to_depth_segments_3d,
+    geometry_to_segments, geometry_to_segments_3d,
 };
 
 enum ActiveScene {
@@ -76,6 +77,151 @@ pub struct CanvasRenderer {
     hue_offset_degrees: f32,
     background: wgpu::Color,
     needs_upload: bool,
+    scene_revision: u64,
+    pending_bounds_request: Option<PendingBoundsRequest>,
+}
+
+pub(crate) enum BoundsUpdate {
+    TwoD {
+        revision: u64,
+        bounds_min: [f32; 2],
+        bounds_max: [f32; 2],
+    },
+    ThreeD {
+        revision: u64,
+        bounds_min: [f32; 3],
+        bounds_max: [f32; 3],
+    },
+}
+
+pub(crate) enum PendingBoundsRequest {
+    TwoD {
+        revision: u64,
+        device: Arc<wgpu::Device>,
+        queue: Arc<wgpu::Queue>,
+        support: BoundsComputeSupport,
+        segments: Vec<Segment2D>,
+        uploaded: lsystem_renderer::line_renderer::UploadedSegmentBuffer,
+    },
+    TwoDWithTopologicalDepth {
+        revision: u64,
+        device: Arc<wgpu::Device>,
+        queue: Arc<wgpu::Queue>,
+        support: BoundsComputeSupport,
+        segments: Vec<TopologicalDepthSegment2D>,
+        uploaded: lsystem_renderer::line_renderer::UploadedSegmentBuffer,
+    },
+    ThreeD {
+        revision: u64,
+        device: Arc<wgpu::Device>,
+        queue: Arc<wgpu::Queue>,
+        support: BoundsComputeSupport,
+        segments: Vec<Segment3D>,
+        uploaded: lsystem_renderer::line_renderer::UploadedSegmentBuffer,
+    },
+    ThreeDWithTopologicalDepth {
+        revision: u64,
+        device: Arc<wgpu::Device>,
+        queue: Arc<wgpu::Queue>,
+        support: BoundsComputeSupport,
+        segments: Vec<TopologicalDepthSegment3D>,
+        uploaded: lsystem_renderer::line_renderer::UploadedSegmentBuffer,
+    },
+}
+
+impl PendingBoundsRequest {
+    pub(crate) async fn resolve(self) -> Option<BoundsUpdate> {
+        match self {
+            Self::TwoD {
+                revision,
+                device,
+                queue,
+                support,
+                segments,
+                uploaded,
+            } => bounds_compute::segment_bounds_2d(
+                &device,
+                &queue,
+                support,
+                &segments,
+                Some(uploaded),
+            )
+            .await
+            .map(|(bounds_min, bounds_max)| BoundsUpdate::TwoD {
+                revision,
+                bounds_min,
+                bounds_max,
+            })
+            .map_err(|error| log::warn!("GPU 2D bounds readback failed: {error}"))
+            .ok(),
+            Self::TwoDWithTopologicalDepth {
+                revision,
+                device,
+                queue,
+                support,
+                segments,
+                uploaded,
+            } => bounds_compute::depth_segment_bounds_2d(
+                &device,
+                &queue,
+                support,
+                &segments,
+                Some(uploaded),
+            )
+            .await
+            .map(|(bounds_min, bounds_max)| BoundsUpdate::TwoD {
+                revision,
+                bounds_min,
+                bounds_max,
+            })
+            .map_err(|error| log::warn!("GPU 2D depth bounds readback failed: {error}"))
+            .ok(),
+            Self::ThreeD {
+                revision,
+                device,
+                queue,
+                support,
+                segments,
+                uploaded,
+            } => bounds_compute::segment_bounds_3d(
+                &device,
+                &queue,
+                support,
+                &segments,
+                Some(uploaded),
+            )
+            .await
+            .map(|(bounds_min, bounds_max)| BoundsUpdate::ThreeD {
+                revision,
+                bounds_min,
+                bounds_max,
+            })
+            .map_err(|error| log::warn!("GPU 3D bounds readback failed: {error}"))
+            .ok(),
+            Self::ThreeDWithTopologicalDepth {
+                revision,
+                device,
+                queue,
+                support,
+                segments,
+                uploaded,
+            } => bounds_compute::depth_segment_bounds_3d(
+                &device,
+                &queue,
+                support,
+                &segments,
+                Some(uploaded),
+            )
+            .await
+            .map(|(bounds_min, bounds_max)| BoundsUpdate::ThreeD {
+                revision,
+                bounds_min,
+                bounds_max,
+            })
+            .map_err(|error| log::warn!("GPU 3D depth bounds readback failed: {error}"))
+            .ok(),
+        }
+    }
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -105,6 +251,8 @@ impl CanvasRenderer {
             hue_offset_degrees: 0.0,
             background: wgpu::Color::BLACK,
             needs_upload: false,
+            scene_revision: 0,
+            pending_bounds_request: None,
         })
     }
 
@@ -129,6 +277,36 @@ impl CanvasRenderer {
 
     fn rebuild_scene(&mut self, config: &Config) {
         let started = Instant::now();
+        let previous_2d_bounds = match &self.scene {
+            ActiveScene::TwoD {
+                bounds_min,
+                bounds_max,
+                ..
+            }
+            | ActiveScene::TwoDWithTopologicalDepth {
+                bounds_min,
+                bounds_max,
+                ..
+            } => Some((*bounds_min, *bounds_max)),
+            _ => None,
+        };
+        let previous_3d_bounds = match &self.scene {
+            ActiveScene::ThreeD {
+                bounds_min,
+                bounds_max,
+                ..
+            }
+            | ActiveScene::ThreeDWithTopologicalDepth {
+                bounds_min,
+                bounds_max,
+                ..
+            } => Some((*bounds_min, *bounds_max)),
+            _ => None,
+        };
+        let bounds_2d = previous_2d_bounds.unwrap_or(([-1.0, -1.0], [1.0, 1.0]));
+        let bounds_3d = previous_3d_bounds.unwrap_or(([-1.0, -1.0, -1.0], [1.0, 1.0, 1.0]));
+        self.scene_revision = self.scene_revision.wrapping_add(1);
+        self.pending_bounds_request = None;
         match config.generation.dimensions {
             Dimensions::ThreeD => {
                 if config.generation.has_stack_directives() {
@@ -138,20 +316,17 @@ impl CanvasRenderer {
                     let max_topological_depth = data.max_topological_depth();
                     self.scene = ActiveScene::ThreeDWithTopologicalDepth {
                         segments: data.segments,
-                        bounds_min: data.bounds_min,
-                        bounds_max: data.bounds_max,
+                        bounds_min: bounds_3d.0,
+                        bounds_max: bounds_3d.1,
                         max_topological_depth,
                     };
                 } else {
-                    let SegmentData3D {
-                        segments,
-                        bounds_min,
-                        bounds_max,
-                    } = geometry_to_segments_3d(lsystem_core::generate_3d(&config.generation));
+                    let data =
+                        geometry_to_segments_3d(lsystem_core::generate_3d(&config.generation));
                     self.scene = ActiveScene::ThreeD {
-                        segments,
-                        bounds_min,
-                        bounds_max,
+                        segments: data.segments,
+                        bounds_min: bounds_3d.0,
+                        bounds_max: bounds_3d.1,
                     };
                 }
             }
@@ -163,20 +338,16 @@ impl CanvasRenderer {
                     let max_topological_depth = data.max_topological_depth();
                     self.scene = ActiveScene::TwoDWithTopologicalDepth {
                         segments: data.segments,
-                        bounds_min: data.bounds_min,
-                        bounds_max: data.bounds_max,
+                        bounds_min: bounds_2d.0,
+                        bounds_max: bounds_2d.1,
                         max_topological_depth,
                     };
                 } else {
-                    let SegmentData {
-                        segments,
-                        bounds_min,
-                        bounds_max,
-                    } = geometry_to_segments(lsystem_core::generate(&config.generation));
+                    let data = geometry_to_segments(lsystem_core::generate(&config.generation));
                     self.scene = ActiveScene::TwoD {
-                        segments,
-                        bounds_min,
-                        bounds_max,
+                        segments: data.segments,
+                        bounds_min: bounds_2d.0,
+                        bounds_max: bounds_2d.1,
                     };
                 }
             }
@@ -388,8 +559,64 @@ impl CanvasRenderer {
         Ok(())
     }
 
-    pub fn device_queue(&self) -> (Arc<wgpu::Device>, Arc<wgpu::Queue>) {
-        (Arc::clone(&self.gpu.device), Arc::clone(&self.gpu.queue))
+    pub fn device_queue(&self) -> (Arc<wgpu::Device>, Arc<wgpu::Queue>, BoundsComputeSupport) {
+        (
+            Arc::clone(&self.gpu.device),
+            Arc::clone(&self.gpu.queue),
+            self.gpu.bounds_compute_support(),
+        )
+    }
+
+    pub(crate) fn take_pending_bounds_request(&mut self) -> Option<PendingBoundsRequest> {
+        self.pending_bounds_request.take()
+    }
+
+    pub(crate) fn apply_bounds_update(&mut self, update: BoundsUpdate) -> bool {
+        match (update, &mut self.scene) {
+            (
+                BoundsUpdate::TwoD {
+                    revision,
+                    bounds_min,
+                    bounds_max,
+                },
+                ActiveScene::TwoD {
+                    bounds_min: scene_min,
+                    bounds_max: scene_max,
+                    ..
+                }
+                | ActiveScene::TwoDWithTopologicalDepth {
+                    bounds_min: scene_min,
+                    bounds_max: scene_max,
+                    ..
+                },
+            ) if revision == self.scene_revision => {
+                *scene_min = bounds_min;
+                *scene_max = bounds_max;
+                true
+            }
+            (
+                BoundsUpdate::ThreeD {
+                    revision,
+                    bounds_min,
+                    bounds_max,
+                },
+                ActiveScene::ThreeD {
+                    bounds_min: scene_min,
+                    bounds_max: scene_max,
+                    ..
+                }
+                | ActiveScene::ThreeDWithTopologicalDepth {
+                    bounds_min: scene_min,
+                    bounds_max: scene_max,
+                    ..
+                },
+            ) if revision == self.scene_revision => {
+                *scene_min = bounds_min;
+                *scene_max = bounds_max;
+                true
+            }
+            _ => false,
+        }
     }
 
     pub fn camera(&self) -> Camera {
@@ -405,6 +632,7 @@ impl CanvasRenderer {
         } = frame;
 
         let started = self.needs_upload.then(Instant::now);
+        let mut bounds_request = None;
 
         match &self.scene {
             ActiveScene::TwoD {
@@ -419,6 +647,16 @@ impl CanvasRenderer {
                         segments,
                         self.effective_color_params(),
                     );
+                    if let Some(uploaded) = self.pipeline_2d.active_uploaded_segment_buffer() {
+                        bounds_request = Some(PendingBoundsRequest::TwoD {
+                            revision: self.scene_revision,
+                            device: Arc::clone(&self.gpu.device),
+                            queue: Arc::clone(&self.gpu.queue),
+                            support: self.gpu.bounds_compute_support(),
+                            segments: segments.clone(),
+                            uploaded,
+                        });
+                    }
                     self.needs_upload = false;
                 }
                 self.pipeline_2d.write_transform(
@@ -444,6 +682,16 @@ impl CanvasRenderer {
                         segments,
                         self.effective_color_params(),
                     );
+                    if let Some(uploaded) = self.pipeline_2d.active_uploaded_segment_buffer() {
+                        bounds_request = Some(PendingBoundsRequest::TwoDWithTopologicalDepth {
+                            revision: self.scene_revision,
+                            device: Arc::clone(&self.gpu.device),
+                            queue: Arc::clone(&self.gpu.queue),
+                            support: self.gpu.bounds_compute_support(),
+                            segments: segments.clone(),
+                            uploaded,
+                        });
+                    }
                     self.needs_upload = false;
                 }
                 self.pipeline_2d.write_transform(
@@ -468,6 +716,16 @@ impl CanvasRenderer {
                         segments,
                         self.effective_color_params(),
                     );
+                    if let Some(uploaded) = self.pipeline_3d.active_uploaded_segment_buffer() {
+                        bounds_request = Some(PendingBoundsRequest::ThreeD {
+                            revision: self.scene_revision,
+                            device: Arc::clone(&self.gpu.device),
+                            queue: Arc::clone(&self.gpu.queue),
+                            support: self.gpu.bounds_compute_support(),
+                            segments: segments.clone(),
+                            uploaded,
+                        });
+                    }
                     self.needs_upload = false;
                 }
                 self.pipeline_3d.write_mvp(
@@ -493,6 +751,16 @@ impl CanvasRenderer {
                         segments,
                         self.effective_color_params(),
                     );
+                    if let Some(uploaded) = self.pipeline_3d.active_uploaded_segment_buffer() {
+                        bounds_request = Some(PendingBoundsRequest::ThreeDWithTopologicalDepth {
+                            revision: self.scene_revision,
+                            device: Arc::clone(&self.gpu.device),
+                            queue: Arc::clone(&self.gpu.queue),
+                            support: self.gpu.bounds_compute_support(),
+                            segments: segments.clone(),
+                            uploaded,
+                        });
+                    }
                     self.needs_upload = false;
                 }
                 self.pipeline_3d.write_mvp(
@@ -536,6 +804,7 @@ impl CanvasRenderer {
 
         self.gpu
             .end_frame(*frame, encoder, reconfigure_after_present);
+        self.pending_bounds_request = bounds_request;
 
         if let Some(started) = started {
             let segment_count = self.scene.total_segments();

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -31,15 +31,18 @@ GenerationConfig
   -> Segments2D / Segments3D
   -> renderer bridge segment records
   -> wgpu instance buffer
+  -> GPU bounds reduction for camera/export fitting
 ```
 
 The expansion and turtle layers are streaming iterators. They do not build the
 full expanded string or an intermediate vertex list before yielding geometry.
-The renderer bridge collects only the GPU instance records needed for upload.
-Do not introduce another collection of expanded symbols, raw geometry, or
-vertices; the renderer bridge's segment-instance `Vec` is the intentional
-collection point before GPU upload. Adding another large collection breaks the
-memory-bounded property for high iteration counts.
+The renderer bridge collects only the GPU instance records needed for upload;
+renderer bounds are reduced from those records with GPU compute after upload,
+falling back to a CPU reduction only when the selected adapter lacks compute
+shader support. Do not introduce another collection of expanded symbols, raw
+geometry, or vertices; the renderer bridge's segment-instance `Vec` is the
+intentional collection point before GPU upload. Adding another large collection
+breaks the memory-bounded property for high iteration counts.
 
 Config editing has a separate parse/validate/resolve pipeline.
 
@@ -115,10 +118,14 @@ offscreen exports.
   are still assembled by hand because the 2D and 3D pipelines bind different,
   sparse subsets of the shader's three bind groups.
 - `camera.rs` supports 2D pan/zoom and 3D orbit/elevation/roll/zoom.
-- `line_renderer.rs` defines GPU instance records, growable vertex buffers,
-  2D/3D line pipelines, color uniforms, and surface frame handling.
+- `line_renderer.rs` defines GPU instance records, growable storage-capable
+  vertex buffers, 2D/3D line pipelines, color uniforms, and surface frame
+  handling.
 - `lsystem_bridge.rs` converts core geometry iterators into GPU segment data and
   maps `LineColorConfig` into shader color parameters.
+- `bounds_compute.rs` reduces uploaded segment buffers to 2D/3D bounds with a
+  compute shader and async readback; SVG export keeps its separate CPU bounds
+  loop in `lsystem-core`.
 - `offscreen.rs`, `png_export.rs`, and `animation_export.rs` render PNG/APNG
   output with an offscreen target behind the `png` feature.
 - `wgpu_util.rs` centralizes instance/device setup and error logging for native


### PR DESCRIPTION
## Summary
- Move renderer bounds calculation from CPU segment builders to a GPU compute readback path with CPU fallback for adapters without compute shader support.
- Reuse uploaded segment buffers for bounds in renderer/export paths, including topological-depth record layouts.
- Thread async bounds handling through native, web, PNG, and APNG rendering while leaving SVG export unchanged.
- Update architecture docs for the new renderer bounds flow.