### PR TITLE
Add fractal microbenchmarks

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -47,6 +47,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "alloca"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e5a7d05ea6aea7e9e64d25b9156ba2fee3fdd659e34e41063cd2fc7cd020d7f4"
+dependencies = [
+ "cc",
+]
+
+[[package]]
 name = "allocator-api2"
 version = "0.2.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -94,6 +103,12 @@ checksum = "819e7219dbd41043ac279b19830f2efc897156490d7fd6ea916720117ee66311"
 dependencies = [
  "libc",
 ]
+
+[[package]]
+name = "anes"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4b46cbb362ab8752921c97e041f5e366ee6297bd428a31275b9fcf1e380f7299"
 
 [[package]]
 name = "anstream"
@@ -536,6 +551,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fd6c0e7b807d60291f42f33f58480c0bfafe28ed08286446f45e463728cf9c1c"
 
 [[package]]
+name = "cast"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "37b2a672a2cb129a2e41c10b1224bb368f9f37a2b16b612598138befd7b37eb5"
+
+[[package]]
 name = "cc"
 version = "1.2.63"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -558,6 +579,58 @@ name = "cfg_aliases"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724"
+
+[[package]]
+name = "ciborium"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "42e69ffd6f0917f5c029256a24d0161db17cea3997d185db0d35926308770f0e"
+dependencies = [
+ "ciborium-io",
+ "ciborium-ll",
+ "serde",
+]
+
+[[package]]
+name = "ciborium-io"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "05afea1e0a06c9be33d539b876f1ce3692f4afea2cb41f740e7743225ed1c757"
+
+[[package]]
+name = "ciborium-ll"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "57663b653d948a338bfb3eeba9bb2fd5fcfaecb9e199e87e1eda4d9e8b240fd9"
+dependencies = [
+ "ciborium-io",
+ "half",
+]
+
+[[package]]
+name = "clap"
+version = "4.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1ddb117e43bbf7dacf0a4190fef4d345b9bad68dfc649cb349e7d17d28428e51"
+dependencies = [
+ "clap_builder",
+]
+
+[[package]]
+name = "clap_builder"
+version = "4.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "714a53001bf66416adb0e2ef5ac857140e7dc3a0c48fb28b2f10762fc4b5069f"
+dependencies = [
+ "anstyle",
+ "clap_lex",
+]
+
+[[package]]
+name = "clap_lex"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
 
 [[package]]
 name = "clipboard-win"
@@ -812,6 +885,60 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9481c1c90cbf2ac953f07c8d4a58aa3945c425b7185c9154d67a65e4230da511"
 dependencies = [
  "cfg-if",
+]
+
+[[package]]
+name = "criterion"
+version = "0.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "950046b2aa2492f9a536f5f4f9a3de7b9e2476e575e05bd6c333371add4d98f3"
+dependencies = [
+ "alloca",
+ "anes",
+ "cast",
+ "ciborium",
+ "clap",
+ "criterion-plot",
+ "itertools 0.13.0",
+ "num-traits",
+ "oorandom",
+ "page_size",
+ "plotters",
+ "rayon",
+ "regex",
+ "serde",
+ "serde_json",
+ "tinytemplate",
+ "walkdir",
+]
+
+[[package]]
+name = "criterion-plot"
+version = "0.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d8d80a2f4f5b554395e47b5d8305bc3d27813bacb73493eb1001e8f76dae29ea"
+dependencies = [
+ "cast",
+ "itertools 0.13.0",
+]
+
+[[package]]
+name = "crossbeam-deque"
+version = "0.8.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9dd111b7b7f7d55b72c0a6ae361660ee5853c9af73f70c3c2ef6858b950e2e51"
+dependencies = [
+ "crossbeam-epoch",
+ "crossbeam-utils",
+]
+
+[[package]]
+name = "crossbeam-epoch"
+version = "0.9.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5b82ac4a3c2ca9c3460964f020e1402edd5753411d7737aa39c3714ad1b5420e"
+dependencies = [
+ "crossbeam-utils",
 ]
 
 [[package]]
@@ -1987,6 +2114,15 @@ checksum = "a6cb138bb79a146c1bd460005623e142ef0181e3d0219cb493e02f7d08a35695"
 
 [[package]]
 name = "itertools"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "413ee7dfc52ee1a4949ceeb7dbc8a33f2d6c088194d9f922fb8318faf1f01186"
+dependencies = [
+ "either",
+]
+
+[[package]]
+name = "itertools"
 version = "0.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2b192c782037fadd9cfa75548310488aabdbf3d2da73885b31bd0abd03351285"
@@ -2247,7 +2383,7 @@ dependencies = [
  "convert_case 0.11.0",
  "convert_case_extras",
  "html-escape",
- "itertools",
+ "itertools 0.14.0",
  "leptos_hot_reload",
  "prettyplease",
  "proc-macro-error2",
@@ -2411,6 +2547,7 @@ dependencies = [
 name = "lsystem-core"
 version = "0.1.0"
 dependencies = [
+ "criterion",
  "glam 0.33.0",
  "thiserror 2.0.18",
 ]
@@ -2420,6 +2557,7 @@ name = "lsystem-renderer"
 version = "0.1.0"
 dependencies = [
  "bytemuck",
+ "criterion",
  "encase",
  "futures-channel",
  "glam 0.33.0",
@@ -3024,6 +3162,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "384b8ab6d37215f3c5301a95a4accb5d64aa607f1fcb26a11b5303878451b4fe"
 
 [[package]]
+name = "oorandom"
+version = "11.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d6790f58c7ff633d8771f42965289203411a5e5c68388703c06e14f24770b41e"
+
+[[package]]
 name = "or_poisoned"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3075,6 +3219,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "36820e9051aca1014ddc75770aab4d68bc1e9e632f0f5627c4086bc216fb583b"
 dependencies = [
  "ttf-parser",
+]
+
+[[package]]
+name = "page_size"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "30d5b2194ed13191c1999ae0704b7839fb18384fa22e49b57eeaa97d79ce40da"
+dependencies = [
+ "libc",
+ "winapi",
 ]
 
 [[package]]
@@ -3189,6 +3343,34 @@ name = "plain"
 version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b4596b6d070b27117e987119b4dac604f3c58cfb0b191112e24771b2faeac1a6"
+
+[[package]]
+name = "plotters"
+version = "0.3.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5aeb6f403d7a4911efb1e33402027fc44f29b5bf6def3effcc22d7bb75f2b747"
+dependencies = [
+ "num-traits",
+ "plotters-backend",
+ "plotters-svg",
+ "wasm-bindgen",
+ "web-sys",
+]
+
+[[package]]
+name = "plotters-backend"
+version = "0.3.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df42e13c12958a16b3f7f4386b9ab1f3e7933914ecea48da7139435263a4172a"
+
+[[package]]
+name = "plotters-svg"
+version = "0.3.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "51bae2ac328883f7acdfea3d66a7c35751187f870bc81f94563733a154d7a670"
+dependencies = [
+ "plotters-backend",
+]
 
 [[package]]
 name = "png"
@@ -3416,6 +3598,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "rayon"
+version = "1.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fb39b166781f92d482534ef4b4b1b2568f42613b53e5b6c160e24cfbfa30926d"
+dependencies = [
+ "either",
+ "rayon-core",
+]
+
+[[package]]
+name = "rayon-core"
+version = "1.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "22e18b0f0062d30d4230b2e85ff77fdfe4326feb054b9783a3460d8435c8ab91"
+dependencies = [
+ "crossbeam-deque",
+ "crossbeam-utils",
+]
+
+[[package]]
 name = "reactive_graph"
 version = "0.2.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3447,7 +3649,7 @@ checksum = "c30fd35b7d299c591293bb69fed47a703eb2703b1cff0493e78b16ed007e5382"
 dependencies = [
  "guardian",
  "indexmap",
- "itertools",
+ "itertools 0.14.0",
  "or_poisoned",
  "paste",
  "reactive_graph",
@@ -4083,7 +4285,7 @@ dependencies = [
  "futures",
  "html-escape",
  "indexmap",
- "itertools",
+ "itertools 0.14.0",
  "js-sys",
  "next_tuple",
  "oco_ref",
@@ -4217,6 +4419,16 @@ checksum = "c8323304221c2a851516f22236c5722a72eaa19749016521d6dff0824447d96d"
 dependencies = [
  "displaydoc",
  "zerovec",
+]
+
+[[package]]
+name = "tinytemplate"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "be4d6b5f19ff7664e8c98d03e2139cb510db9b0a60b55f8e8709b689d939b6bc"
+dependencies = [
+ "serde",
+ "serde_json",
 ]
 
 [[package]]
@@ -4965,6 +5177,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "winapi"
+version = "0.3.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c839a674fcd7a98952e593242ea400abe93992746761e38641405d28b00f419"
+dependencies = [
+ "winapi-i686-pc-windows-gnu",
+ "winapi-x86_64-pc-windows-gnu",
+]
+
+[[package]]
+name = "winapi-i686-pc-windows-gnu"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6"
+
+[[package]]
 name = "winapi-util"
 version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4972,6 +5200,12 @@ checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
  "windows-sys 0.61.2",
 ]
+
+[[package]]
+name = "winapi-x86_64-pc-windows-gnu"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 
 [[package]]
 name = "windows"

--- a/crates/lsystem-core/Cargo.toml
+++ b/crates/lsystem-core/Cargo.toml
@@ -10,3 +10,10 @@ svg = []
 [dependencies]
 glam = { workspace = true, features = ["bytemuck"] }
 thiserror.workspace = true
+
+[dev-dependencies]
+criterion = "0.8.2"
+
+[[bench]]
+name = "generation"
+harness = false

--- a/crates/lsystem-core/benches/generation.rs
+++ b/crates/lsystem-core/benches/generation.rs
@@ -1,0 +1,90 @@
+use std::collections::BTreeMap;
+use std::hint::black_box;
+use std::ops::RangeInclusive;
+use std::time::Duration;
+
+use criterion::{BenchmarkId, Criterion, criterion_group, criterion_main};
+use lsystem_core::{Dimensions, GenerationConfig, generate, generate_3d};
+
+struct GenerationBenchCase {
+    fractal_name: &'static str,
+    iterations: RangeInclusive<u32>,
+}
+
+fn bench_generation(c: &mut Criterion) {
+    let mut bench_generation_case =
+        |case: GenerationBenchCase, generation_for_iterations: &dyn Fn(u32) -> GenerationConfig| {
+            let group_name = format!("generate_{}", case.fractal_name);
+            let mut group = c.benchmark_group(group_name);
+            group
+                .sample_size(50)
+                .measurement_time(Duration::from_secs(10));
+            for iterations in case.iterations {
+                group.bench_with_input(
+                    BenchmarkId::from_parameter(iterations),
+                    &iterations,
+                    |b, &iterations| {
+                        let config = generation_for_iterations(iterations);
+                        match config.dimensions {
+                            Dimensions::TwoD => {
+                                b.iter(|| black_box(generate(black_box(&config)).count()));
+                            }
+                            Dimensions::ThreeD => {
+                                b.iter(|| black_box(generate_3d(black_box(&config)).count()));
+                            }
+                        }
+                    },
+                );
+            }
+            group.finish();
+        };
+
+    bench_generation_case(
+        GenerationBenchCase {
+            fractal_name: "koch_2d",
+            iterations: 9..=11,
+        },
+        &|iterations| GenerationConfig {
+            dimensions: Dimensions::TwoD,
+            axiom: "F++F++F".to_string(),
+            iterations,
+            angle: 60.0,
+            step: 1.0,
+            initial_heading: 0.0,
+            rules: BTreeMap::from([('F', "F-F++F-F".to_string())]),
+        },
+    );
+    bench_generation_case(
+        GenerationBenchCase {
+            fractal_name: "branching_2d",
+            iterations: 9..=11,
+        },
+        &|iterations| GenerationConfig {
+            dimensions: Dimensions::TwoD,
+            axiom: "F".to_string(),
+            iterations,
+            angle: 25.0,
+            step: 1.0,
+            initial_heading: 90.0,
+            rules: BTreeMap::from([('F', "F[+F]F[-F]F".to_string())]),
+        },
+    );
+    bench_generation_case(
+        GenerationBenchCase {
+            fractal_name: "branching_3d",
+            iterations: 8..=10,
+        },
+        &|iterations| GenerationConfig {
+            dimensions: Dimensions::ThreeD,
+            axiom: "F".to_string(),
+            iterations,
+            angle: 22.5,
+            step: 1.0,
+            initial_heading: 90.0,
+            rules: BTreeMap::from([('F', "F[+F][-F][&F][^F]F".to_string())]),
+        },
+    );
+}
+
+criterion_group!(benches, bench_generation);
+criterion_main!(benches);

--- a/crates/lsystem-core/benches/generation.rs
+++ b/crates/lsystem-core/benches/generation.rs
@@ -41,47 +41,36 @@ fn bench_generation(c: &mut Criterion) {
 
     bench_generation_case(
         GenerationBenchCase {
-            fractal_name: "koch_2d",
-            iterations: 9..=11,
+            fractal_name: "harter_heighway_dragon",
+            iterations: 19..=21,
         },
         &|iterations| GenerationConfig {
             dimensions: Dimensions::TwoD,
-            axiom: "F++F++F".to_string(),
+            axiom: "FX".to_string(),
             iterations,
-            angle: 60.0,
+            angle: 90.0,
             step: 1.0,
             initial_heading: 0.0,
-            rules: BTreeMap::from([('F', "F-F++F-F".to_string())]),
-        },
-    );
-    bench_generation_case(
-        GenerationBenchCase {
-            fractal_name: "branching_2d",
-            iterations: 9..=11,
-        },
-        &|iterations| GenerationConfig {
-            dimensions: Dimensions::TwoD,
-            axiom: "F".to_string(),
-            iterations,
-            angle: 25.0,
-            step: 1.0,
-            initial_heading: 90.0,
-            rules: BTreeMap::from([('F', "F[+F]F[-F]F".to_string())]),
+            rules: BTreeMap::from([('X', "X+YF+".to_string()), ('Y', "-FX-Y".to_string())]),
         },
     );
     bench_generation_case(
         GenerationBenchCase {
             fractal_name: "branching_3d",
-            iterations: 8..=10,
+            iterations: 9..=11,
         },
         &|iterations| GenerationConfig {
             dimensions: Dimensions::ThreeD,
-            axiom: "F".to_string(),
+            axiom: "X".to_string(),
             iterations,
-            angle: 22.5,
+            angle: 30.0,
             step: 1.0,
             initial_heading: 90.0,
-            rules: BTreeMap::from([('F', "F[+F][-F][&F][^F]F".to_string())]),
+            rules: BTreeMap::from([
+                ('X', "Y[+X][-X][&X][^X]".to_string()),
+                ('Y', "FFFZ".to_string()),
+                ('Z', "FZ".to_string()),
+            ]),
         },
     );
 }

--- a/crates/lsystem-renderer/Cargo.toml
+++ b/crates/lsystem-renderer/Cargo.toml
@@ -25,4 +25,10 @@ wgpu.workspace = true
 wgsl_to_wgpu = "0.18"
 
 [dev-dependencies]
+criterion = "0.8.2"
 pollster = "0.4"
+
+[[bench]]
+name = "offscreen_render"
+harness = false
+required-features = ["png"]

--- a/crates/lsystem-renderer/benches/offscreen_render.rs
+++ b/crates/lsystem-renderer/benches/offscreen_render.rs
@@ -1,0 +1,126 @@
+use std::collections::BTreeMap;
+use std::hint::black_box;
+use std::ops::RangeInclusive;
+use std::time::Duration;
+
+use criterion::{BenchmarkId, Criterion, criterion_group, criterion_main};
+use lsystem_core::{ColorConfig, Config, Dimensions, GenerationConfig, LineColorConfig, Rgb};
+use lsystem_renderer::camera::Camera;
+use lsystem_renderer::png_export::render_rgba;
+
+struct RenderBenchCase {
+    fractal_name: &'static str,
+    iterations: RangeInclusive<u32>,
+    image_size: (u32, u32),
+    colors: ColorConfig,
+}
+
+async fn create_headless_device() -> (wgpu::Device, wgpu::Queue) {
+    let instance = wgpu::Instance::new(wgpu::InstanceDescriptor::new_without_display_handle());
+    let adapter = instance
+        .request_adapter(&wgpu::RequestAdapterOptions {
+            power_preference: wgpu::PowerPreference::default(),
+            compatible_surface: None,
+            force_fallback_adapter: false,
+        })
+        .await
+        .expect("no GPU adapter available for offscreen render benchmark");
+    adapter
+        .request_device(&wgpu::DeviceDescriptor {
+            label: Some("offscreen_render_bench_device"),
+            ..Default::default()
+        })
+        .await
+        .expect("failed to create offscreen render benchmark device")
+}
+
+fn bench_offscreen_render(c: &mut Criterion) {
+    let (device, queue) = pollster::block_on(create_headless_device());
+    let camera = Camera::default();
+
+    let mut bench_render_case =
+        |case: RenderBenchCase, generation_for_iterations: &dyn Fn(u32) -> GenerationConfig| {
+            let (width, height) = case.image_size;
+            let group_name = format!("offscreen_rgba_{}_{}x{}", case.fractal_name, width, height);
+            let mut group = c.benchmark_group(group_name);
+            group
+                .sample_size(50)
+                .measurement_time(Duration::from_secs(10));
+            for iterations in case.iterations {
+                group.bench_with_input(
+                    BenchmarkId::from_parameter(iterations),
+                    &iterations,
+                    |b, &iterations| {
+                        let config = Config {
+                            name: case.fractal_name.to_string(),
+                            generation: generation_for_iterations(iterations),
+                            colors: case.colors,
+                        };
+                        b.iter(|| {
+                            let export = pollster::block_on(render_rgba(
+                                black_box(&device),
+                                black_box(&queue),
+                                black_box(&config),
+                                black_box(width),
+                                black_box(height),
+                                black_box(&camera),
+                            ))
+                            .expect("offscreen RGBA render failed");
+                            black_box(export.rgba.len())
+                        });
+                    },
+                );
+            }
+            group.finish();
+        };
+
+    bench_render_case(
+        RenderBenchCase {
+            fractal_name: "branching_2d",
+            iterations: 7..=9,
+            image_size: (512, 512),
+            colors: ColorConfig {
+                background: Rgb::new(0, 0, 0),
+                line: LineColorConfig::HueCycle {
+                    initial: Rgb::new(255, 255, 255),
+                },
+            },
+        },
+        &|iterations| GenerationConfig {
+            dimensions: Dimensions::TwoD,
+            axiom: "F".to_string(),
+            iterations,
+            angle: 25.0,
+            step: 1.0,
+            initial_heading: 90.0,
+            rules: BTreeMap::from([('F', "F[+F]F[-F]F".to_string())]),
+        },
+    );
+    bench_render_case(
+        RenderBenchCase {
+            fractal_name: "branching_3d",
+            iterations: 6..=8,
+            image_size: (512, 512),
+            colors: ColorConfig {
+                background: Rgb::new(0, 0, 0),
+                line: LineColorConfig::Gradient {
+                    start: Rgb::new(255, 128, 0),
+                    end: Rgb::new(0, 192, 255),
+                    topological_depth: true,
+                },
+            },
+        },
+        &|iterations| GenerationConfig {
+            dimensions: Dimensions::ThreeD,
+            axiom: "F".to_string(),
+            iterations,
+            angle: 22.5,
+            step: 1.0,
+            initial_heading: 90.0,
+            rules: BTreeMap::from([('F', "F[+F][-F][&F][^F]F".to_string())]),
+        },
+    );
+}
+
+criterion_group!(benches, bench_offscreen_render);
+criterion_main!(benches);

--- a/crates/lsystem-renderer/benches/offscreen_render.rs
+++ b/crates/lsystem-renderer/benches/offscreen_render.rs
@@ -7,6 +7,7 @@ use criterion::{BenchmarkId, Criterion, criterion_group, criterion_main};
 use lsystem_core::{ColorConfig, Config, Dimensions, GenerationConfig, LineColorConfig, Rgb};
 use lsystem_renderer::camera::Camera;
 use lsystem_renderer::png_export::render_rgba;
+use lsystem_renderer::wgpu_util::create_headless_device;
 
 struct RenderBenchCase {
     fractal_name: &'static str,
@@ -15,27 +16,12 @@ struct RenderBenchCase {
     colors: ColorConfig,
 }
 
-async fn create_headless_device() -> (wgpu::Device, wgpu::Queue) {
-    let instance = wgpu::Instance::new(wgpu::InstanceDescriptor::new_without_display_handle());
-    let adapter = instance
-        .request_adapter(&wgpu::RequestAdapterOptions {
-            power_preference: wgpu::PowerPreference::default(),
-            compatible_surface: None,
-            force_fallback_adapter: false,
-        })
-        .await
-        .expect("no GPU adapter available for offscreen render benchmark");
-    adapter
-        .request_device(&wgpu::DeviceDescriptor {
-            label: Some("offscreen_render_bench_device"),
-            ..Default::default()
-        })
-        .await
-        .expect("failed to create offscreen render benchmark device")
-}
-
 fn bench_offscreen_render(c: &mut Criterion) {
-    let (device, queue) = pollster::block_on(create_headless_device());
+    let (device, queue) = pollster::block_on(create_headless_device(
+        "offscreen_render_bench_device",
+        "offscreen render benchmark",
+    ))
+    .expect("no GPU adapter available for offscreen render benchmark");
     let camera = Camera::default();
 
     let mut bench_render_case =

--- a/crates/lsystem-renderer/benches/offscreen_render.rs
+++ b/crates/lsystem-renderer/benches/offscreen_render.rs
@@ -62,8 +62,8 @@ fn bench_offscreen_render(c: &mut Criterion) {
 
     bench_render_case(
         RenderBenchCase {
-            fractal_name: "branching_2d",
-            iterations: 7..=9,
+            fractal_name: "harter_heighway_dragon",
+            iterations: 19..=21,
             image_size: (512, 512),
             colors: ColorConfig {
                 background: Rgb::new(0, 0, 0),
@@ -74,36 +74,40 @@ fn bench_offscreen_render(c: &mut Criterion) {
         },
         &|iterations| GenerationConfig {
             dimensions: Dimensions::TwoD,
-            axiom: "F".to_string(),
+            axiom: "FX".to_string(),
             iterations,
-            angle: 25.0,
+            angle: 90.0,
             step: 1.0,
-            initial_heading: 90.0,
-            rules: BTreeMap::from([('F', "F[+F]F[-F]F".to_string())]),
+            initial_heading: 0.0,
+            rules: BTreeMap::from([('X', "X+YF+".to_string()), ('Y', "-FX-Y".to_string())]),
         },
     );
     bench_render_case(
         RenderBenchCase {
             fractal_name: "branching_3d",
-            iterations: 6..=8,
+            iterations: 9..=11,
             image_size: (512, 512),
             colors: ColorConfig {
                 background: Rgb::new(0, 0, 0),
                 line: LineColorConfig::Gradient {
-                    start: Rgb::new(255, 128, 0),
-                    end: Rgb::new(0, 192, 255),
-                    topological_depth: true,
+                    start: Rgb::new(89, 89, 13),
+                    end: Rgb::new(51, 217, 64),
+                    topological_depth: false,
                 },
             },
         },
         &|iterations| GenerationConfig {
             dimensions: Dimensions::ThreeD,
-            axiom: "F".to_string(),
+            axiom: "X".to_string(),
             iterations,
-            angle: 22.5,
+            angle: 30.0,
             step: 1.0,
             initial_heading: 90.0,
-            rules: BTreeMap::from([('F', "F[+F][-F][&F][^F]F".to_string())]),
+            rules: BTreeMap::from([
+                ('X', "Y[+X][-X][&X][^X]".to_string()),
+                ('Y', "FFFZ".to_string()),
+                ('Z', "FZ".to_string()),
+            ]),
         },
     );
 }

--- a/crates/lsystem-renderer/src/lib.rs
+++ b/crates/lsystem-renderer/src/lib.rs
@@ -11,4 +11,4 @@ pub mod lsystem_bridge;
 mod offscreen;
 #[cfg(feature = "png")]
 pub mod png_export;
-mod wgpu_util;
+pub mod wgpu_util;

--- a/crates/lsystem-renderer/src/png_export.rs
+++ b/crates/lsystem-renderer/src/png_export.rs
@@ -150,20 +150,6 @@ pub async fn render_rgba(
     })
 }
 
-/// Like [`render_rgba`], but creates its own headless GPU device.
-pub async fn render_rgba_standalone(
-    config: &Config,
-    width: u32,
-    height: u32,
-    camera: &Camera,
-) -> Result<RgbaExport, ExportError> {
-    validate_width(width)?;
-    validate_height(height)?;
-    let (device, queue) =
-        wgpu_util::create_headless_device("rgba_export_device", "RGBA export").await?;
-    render_rgba(&device, &queue, config, width, height, camera).await
-}
-
 /// Like [`render_png`], but creates its own headless GPU device.
 pub async fn render_png_standalone(
     config: &Config,

--- a/crates/lsystem-renderer/src/png_export.rs
+++ b/crates/lsystem-renderer/src/png_export.rs
@@ -20,6 +20,15 @@ pub struct PngExport {
     pub bytes: Vec<u8>,
 }
 
+/// Raw RGBA pixels rendered offscreen, together with their pixel dimensions.
+///
+/// Pixels are tightly packed in row-major order, four bytes per pixel.
+pub struct RgbaExport {
+    pub width: u32,
+    pub height: u32,
+    pub rgba: Vec<u8>,
+}
+
 /// Failures shared by still-PNG and APNG export.
 #[derive(Debug)]
 pub enum ExportError {
@@ -101,6 +110,28 @@ pub async fn render_png(
     height: u32,
     camera: &Camera,
 ) -> Result<PngExport, ExportError> {
+    let rgba = render_rgba(device, queue, config, width, height, camera).await?;
+    let bytes = encode_png_rgba(width, height, &rgba.rgba)?;
+    Ok(PngExport {
+        width,
+        height,
+        bytes,
+    })
+}
+
+/// Renders `config` to tightly packed RGBA bytes of the given dimensions on
+/// `device`, without PNG encoding.
+///
+/// `camera` selects the 3D orientation; 2D export always fits the geometry
+/// bounds and ignores camera pan/zoom.
+pub async fn render_rgba(
+    device: &wgpu::Device,
+    queue: &wgpu::Queue,
+    config: &Config,
+    width: u32,
+    height: u32,
+    camera: &Camera,
+) -> Result<RgbaExport, ExportError> {
     validate_width(width)?;
     validate_height(height)?;
 
@@ -112,12 +143,25 @@ pub async fn render_png(
         .render_frame(device, queue, config.colors.background.to_array(), &scene)
         .await?;
 
-    let bytes = encode_png_rgba(width, height, &rgba)?;
-    Ok(PngExport {
+    Ok(RgbaExport {
         width,
         height,
-        bytes,
+        rgba,
     })
+}
+
+/// Like [`render_rgba`], but creates its own headless GPU device.
+pub async fn render_rgba_standalone(
+    config: &Config,
+    width: u32,
+    height: u32,
+    camera: &Camera,
+) -> Result<RgbaExport, ExportError> {
+    validate_width(width)?;
+    validate_height(height)?;
+    let (device, queue) =
+        wgpu_util::create_headless_device("rgba_export_device", "RGBA export").await?;
+    render_rgba(&device, &queue, config, width, height, camera).await
 }
 
 /// Like [`render_png`], but creates its own headless GPU device.
@@ -219,6 +263,38 @@ mod gpu_tests {
         assert_eq!((info.width, info.height), (256, 128));
     }
 
+    fn assert_rgba_renders_without_png_encoding(config: lsystem_core::Config) {
+        let (render_result, validation_error) = pollster::block_on(async {
+            let (device, queue) =
+                crate::wgpu_util::create_headless_device("rgba_export_test_device", "RGBA export")
+                    .await
+                    .expect("failed to create headless test device");
+
+            let error_scope = device.push_error_scope(wgpu::ErrorFilter::Validation);
+            let render_result = render_rgba(
+                &device,
+                &queue,
+                &config,
+                64,
+                32,
+                &crate::camera::Camera::default(),
+            )
+            .await;
+            let validation_error = error_scope.pop().await;
+            (render_result, validation_error)
+        });
+        assert!(
+            validation_error.is_none(),
+            "wgpu validation error: {validation_error:?}"
+        );
+        let export = render_result.expect("render_rgba failed");
+
+        assert_eq!(export.width, 64);
+        assert_eq!(export.height, 32);
+        assert_eq!(export.rgba.len(), 64 * 32 * 4);
+        assert_ne!(&export.rgba[..8], b"\x89PNG\r\n\x1a\n");
+    }
+
     fn depth_gradient_config(dimensions: Dimensions) -> lsystem_core::Config {
         let mut config = trivial_config();
         config.generation.dimensions = dimensions;
@@ -234,6 +310,11 @@ mod gpu_tests {
     #[test]
     fn png_standalone_non_square_dimensions() {
         assert_png_renders(trivial_config());
+    }
+
+    #[test]
+    fn rgba_export_renders_trivial_2d_config_without_png_encoding() {
+        assert_rgba_renders_without_png_encoding(trivial_config());
     }
 
     #[test]

--- a/crates/lsystem-renderer/src/png_export.rs
+++ b/crates/lsystem-renderer/src/png_export.rs
@@ -215,23 +215,20 @@ mod gpu_tests {
         }
     }
 
-    fn assert_png_renders(config: lsystem_core::Config) {
+    /// Creates a headless device, runs `render` on it with wgpu validation
+    /// enabled, and asserts no validation error was raised.
+    fn render_with_validation_check<T>(
+        device_label: &'static str,
+        render: impl AsyncFnOnce(&wgpu::Device, &wgpu::Queue) -> Result<T, ExportError>,
+    ) -> T {
         let (render_result, validation_error) = pollster::block_on(async {
             let (device, queue) =
-                crate::wgpu_util::create_headless_device("png_export_test_device", "PNG export")
+                crate::wgpu_util::create_headless_device(device_label, device_label)
                     .await
                     .expect("failed to create headless test device");
 
             let error_scope = device.push_error_scope(wgpu::ErrorFilter::Validation);
-            let render_result = render_png(
-                &device,
-                &queue,
-                &config,
-                256,
-                128,
-                &crate::camera::Camera::default(),
-            )
-            .await;
+            let render_result = render(&device, &queue).await;
             let validation_error = error_scope.pop().await;
             (render_result, validation_error)
         });
@@ -239,7 +236,22 @@ mod gpu_tests {
             validation_error.is_none(),
             "wgpu validation error: {validation_error:?}"
         );
-        let export = render_result.expect("render_png failed");
+        render_result.expect("render failed")
+    }
+
+    fn assert_png_renders(config: lsystem_core::Config) {
+        let export =
+            render_with_validation_check("png_export_test_device", async |device, queue| {
+                render_png(
+                    device,
+                    queue,
+                    &config,
+                    256,
+                    128,
+                    &crate::camera::Camera::default(),
+                )
+                .await
+            });
 
         assert_eq!(export.width, 256);
         assert_eq!(export.height, 128);
@@ -250,30 +262,18 @@ mod gpu_tests {
     }
 
     fn assert_rgba_renders_without_png_encoding(config: lsystem_core::Config) {
-        let (render_result, validation_error) = pollster::block_on(async {
-            let (device, queue) =
-                crate::wgpu_util::create_headless_device("rgba_export_test_device", "RGBA export")
-                    .await
-                    .expect("failed to create headless test device");
-
-            let error_scope = device.push_error_scope(wgpu::ErrorFilter::Validation);
-            let render_result = render_rgba(
-                &device,
-                &queue,
-                &config,
-                64,
-                32,
-                &crate::camera::Camera::default(),
-            )
-            .await;
-            let validation_error = error_scope.pop().await;
-            (render_result, validation_error)
-        });
-        assert!(
-            validation_error.is_none(),
-            "wgpu validation error: {validation_error:?}"
-        );
-        let export = render_result.expect("render_rgba failed");
+        let export =
+            render_with_validation_check("rgba_export_test_device", async |device, queue| {
+                render_rgba(
+                    device,
+                    queue,
+                    &config,
+                    64,
+                    32,
+                    &crate::camera::Camera::default(),
+                )
+                .await
+            });
 
         assert_eq!(export.width, 64);
         assert_eq!(export.height, 32);

--- a/crates/lsystem-renderer/src/wgpu_util.rs
+++ b/crates/lsystem-renderer/src/wgpu_util.rs
@@ -57,13 +57,13 @@ mod non_browser_wasm {
 
 #[cfg(feature = "png")]
 #[derive(Debug)]
-pub(crate) enum CreateDeviceError {
+pub enum CreateDeviceError {
     NoAdapter,
     RequestDevice(wgpu::RequestDeviceError),
 }
 
 #[cfg(feature = "png")]
-pub(crate) async fn create_headless_device(
+pub async fn create_headless_device(
     label: &'static str,
     context: &'static str,
 ) -> Result<(wgpu::Device, wgpu::Queue), CreateDeviceError> {

--- a/docs/development.md
+++ b/docs/development.md
@@ -73,6 +73,23 @@ Run SVG export tests:
 cargo test -p lsystem-core --features svg svg_export
 ```
 
+## Benchmarking
+
+Run fractal generation microbenchmarks:
+
+```sh
+cargo bench -p lsystem-core --bench generation
+```
+
+Run offscreen renderer microbenchmarks:
+
+```sh
+cargo bench -p lsystem-renderer --features png --bench offscreen_render
+```
+
+The renderer benchmark measures offscreen RGBA rendering and GPU readback. It
+does not include PNG encoding time.
+
 ## Full Verification
 
 Run the same checks CI runs when a change affects code, build configuration,


### PR DESCRIPTION
## Summary
- Add Criterion benchmark targets for L-system generation across representative 2D and 3D fractal iteration ranges.
- Add offscreen RGBA rendering benchmarks that exercise GPU rendering and readback while excluding PNG encoding.
- Split raw RGBA export from PNG encoding so rendering costs can be measured directly, and document the benchmark commands.