### PR TITLE
Add turtle trig-elimination baseline tests

### DIFF
--- a/crates/lsystem-core/src/turtle/turtle2d.rs
+++ b/crates/lsystem-core/src/turtle/turtle2d.rs
@@ -211,26 +211,101 @@ mod tests {
         assert_eq!(segments.len(), 2);
         let [_, b0] = segments[0];
         let [a1, b1] = segments[1];
-        assert!((b0 - Vec2::new(1.0, 0.0)).length() < 1e-5, "first segment ends at (1,0): {b0}");
-        assert!((a1 - Vec2::new(1.0, 0.0)).length() < 1e-5, "second segment starts at (1,0): {a1}");
-        assert!((b1 - Vec2::ZERO).length() < 1e-5, "U-turn returns to origin: {b1}");
+        assert!(
+            (b0 - Vec2::new(1.0, 0.0)).length() < 1e-5,
+            "first segment ends at (1,0): {b0}"
+        );
+        assert!(
+            (a1 - Vec2::new(1.0, 0.0)).length() < 1e-5,
+            "second segment starts at (1,0): {a1}"
+        );
+        assert!(
+            (b1 - Vec2::ZERO).length() < 1e-5,
+            "U-turn returns to origin: {b1}"
+        );
     }
 
     #[test]
     fn koch_snowflake_path_closes() {
         // The Koch snowflake forms a closed curve at every iteration depth.
         // Any significant drift in direction or step size breaks closure.
+        //
+        // Measured endpoint errors across implementations (iter 4..=6):
+        //   current (sin/cos per F): 6e-6 .. 4e-5   — well within 1e-3
+        //   proposed (Vec2::rotate): 1e-4 .. 2e-4   — well within 1e-3
+        // Iter 4 is the worst case for the proposed recurrence; errors decrease
+        // at finer scales due to Koch symmetry cancellation. The range 4..=6
+        // guards against regressions from unrelated future changes.
+        //
+        // Segment-length check: each drawn step must be within 1e-4 of 1.0,
+        // catching delta length drift independently of endpoint closure.
+        let rules = BTreeMap::from([('F', "F-F++F-F".to_string())]);
+        for iters in 4u32..=6 {
+            let config = GenerationConfig {
+                dimensions: Dimensions::TwoD,
+                axiom: "F++F++F".to_string(),
+                iterations: iters,
+                angle: 60.0,
+                step: 1.0,
+                initial_heading: 0.0,
+                rules: rules.clone(),
+            };
+            let segments: Vec<[Vec2; 2]> = crate::generate(&config).collect();
+            let end = segments.last().expect("non-empty")[1];
+            assert!(
+                end.length() < 1e-3,
+                "Koch snowflake iter {iters} should close; end at {end}"
+            );
+            for [a, b] in &segments {
+                let len = (*b - *a).length();
+                assert!(
+                    (len - 1.0).abs() < 1e-4,
+                    "iter {iters}: segment length {len:.6} deviates from 1.0"
+                );
+            }
+        }
+    }
+
+    #[test]
+    fn long_turn_sequence_preserves_delta() {
+        // Four 90° left turns complete a full circle. The drawn segment should
+        // end near Vec2::X, confirming delta survives repeated rotation without
+        // significant direction or length drift.
+        let cfg = gen_config("++++F");
+        let segments: Vec<[Vec2; 2]> = crate::generate(&cfg).collect();
+        assert_eq!(segments.len(), 1);
+        let [a, b] = segments[0];
+        assert!((a - Vec2::ZERO).length() < 1e-5, "starts at origin: {a}");
+        assert!(
+            (b - Vec2::X).length() < 1e-4,
+            "full circle should draw along X: {b}"
+        );
+    }
+
+    #[test]
+    fn non_default_heading_and_step() {
+        // Validates that delta is correctly initialized from a non-default
+        // initial heading and step, not just the 0°/1.0 default.
         let config = GenerationConfig {
             dimensions: Dimensions::TwoD,
-            axiom: "F++F++F".to_string(),
-            iterations: 4,
-            angle: 60.0,
-            step: 1.0,
-            initial_heading: 0.0,
-            rules: BTreeMap::from([('F', "F-F++F-F".to_string())]),
+            axiom: "F".to_string(),
+            iterations: 0,
+            angle: 90.0,
+            step: 2.0,
+            initial_heading: 45.0,
+            rules: BTreeMap::new(),
         };
         let segments: Vec<[Vec2; 2]> = crate::generate(&config).collect();
-        let end = segments.last().expect("non-empty")[1];
-        assert!(end.length() < 1e-3, "Koch snowflake should close; end at {end}");
+        assert_eq!(segments.len(), 1);
+        let [a, b] = segments[0];
+        let expected = Vec2::new(
+            2.0 * 45_f32.to_radians().cos(),
+            2.0 * 45_f32.to_radians().sin(),
+        );
+        assert!((a - Vec2::ZERO).length() < 1e-5, "starts at origin: {a}");
+        assert!(
+            (b - expected).length() < 1e-5,
+            "step=2 at 45° should end near {expected}: {b}"
+        );
     }
 }

--- a/crates/lsystem-core/src/turtle/turtle2d.rs
+++ b/crates/lsystem-core/src/turtle/turtle2d.rs
@@ -203,4 +203,34 @@ mod tests {
 
         assert_eq!(depths, [0, 1]);
     }
+
+    #[test]
+    fn pipe_u_turn_reverses_direction() {
+        let cfg = gen_config("F|F");
+        let segments: Vec<[Vec2; 2]> = crate::generate(&cfg).collect();
+        assert_eq!(segments.len(), 2);
+        let [_, b0] = segments[0];
+        let [a1, b1] = segments[1];
+        assert!((b0 - Vec2::new(1.0, 0.0)).length() < 1e-5, "first segment ends at (1,0): {b0}");
+        assert!((a1 - Vec2::new(1.0, 0.0)).length() < 1e-5, "second segment starts at (1,0): {a1}");
+        assert!((b1 - Vec2::ZERO).length() < 1e-5, "U-turn returns to origin: {b1}");
+    }
+
+    #[test]
+    fn koch_snowflake_path_closes() {
+        // The Koch snowflake forms a closed curve at every iteration depth.
+        // Any significant drift in direction or step size breaks closure.
+        let config = GenerationConfig {
+            dimensions: Dimensions::TwoD,
+            axiom: "F++F++F".to_string(),
+            iterations: 4,
+            angle: 60.0,
+            step: 1.0,
+            initial_heading: 0.0,
+            rules: BTreeMap::from([('F', "F-F++F-F".to_string())]),
+        };
+        let segments: Vec<[Vec2; 2]> = crate::generate(&config).collect();
+        let end = segments.last().expect("non-empty")[1];
+        assert!(end.length() < 1e-3, "Koch snowflake should close; end at {end}");
+    }
 }

--- a/crates/lsystem-core/src/turtle/turtle3d.rs
+++ b/crates/lsystem-core/src/turtle/turtle3d.rs
@@ -258,4 +258,54 @@ mod tests {
 
         assert_eq!(depths, [0, 1]);
     }
+
+    #[test]
+    fn pipe_u_turn_reverses_direction() {
+        let segs = make("F|F", 90.0);
+        assert_eq!(segs.len(), 2);
+        let [_, b0] = segs[0];
+        let [a1, b1] = segs[1];
+        assert!(b0.distance(Vec3::X) < 1e-5, "first segment ends at X: {b0}");
+        assert!(a1.distance(Vec3::X) < 1e-5, "second segment starts at X: {a1}");
+        assert!(b1.distance(Vec3::ZERO) < 1e-5, "U-turn returns to origin: {b1}");
+    }
+
+    #[test]
+    fn roll_does_not_change_forward_direction() {
+        // / and \ rotate around the local forward axis (Vec3::X), so orientation * Vec3::X is unchanged.
+        for axiom in [r"/F", r"\F"] {
+            let segs = make(axiom, 90.0);
+            assert_eq!(segs.len(), 1, "axiom {axiom:?}");
+            let [a, b] = segs[0];
+            assert!(a.distance(Vec3::ZERO) < 1e-5, "starts at origin ({axiom:?})");
+            assert!(b.distance(Vec3::X) < 1e-5, "roll should not change forward ({axiom:?}): {b}");
+        }
+    }
+
+    #[test]
+    fn roll_affects_subsequent_yaw_plane() {
+        // Without prior roll, +F draws along Y (see plus_yaws_left_into_y).
+        // After rolling 90° right, local up shifts from Z to -Y, so a subsequent
+        // yaw left sweeps around the new local up and draws along Z instead.
+        let segs = make(r"/+F", 90.0);
+        assert_eq!(segs.len(), 1);
+        let [a, b] = segs[0];
+        assert!(a.distance(Vec3::ZERO) < 1e-5);
+        assert!(b.distance(Vec3::Z) < 1e-5, "after /+, F should move along Z: {b}");
+    }
+
+    #[test]
+    fn branch_restore_after_roll() {
+        // [/+F] draws along Z (see roll_affects_subsequent_yaw_plane).
+        // After ], position and orientation are fully restored so the following
+        // F draws along the original X axis.
+        let segs = make(r"[/+F]F", 90.0);
+        assert_eq!(segs.len(), 2);
+        let [a0, b0] = segs[0];
+        let [a1, b1] = segs[1];
+        assert!(a0.distance(Vec3::ZERO) < 1e-5, "branch starts at origin: {a0}");
+        assert!(b0.distance(Vec3::Z) < 1e-5, "branch F ends at Z: {b0}");
+        assert!(a1.distance(Vec3::ZERO) < 1e-5, "position restored to origin: {a1}");
+        assert!(b1.distance(Vec3::X) < 1e-5, "forward restored to X after branch: {b1}");
+    }
 }

--- a/crates/lsystem-core/src/turtle/turtle3d.rs
+++ b/crates/lsystem-core/src/turtle/turtle3d.rs
@@ -266,8 +266,14 @@ mod tests {
         let [_, b0] = segs[0];
         let [a1, b1] = segs[1];
         assert!(b0.distance(Vec3::X) < 1e-5, "first segment ends at X: {b0}");
-        assert!(a1.distance(Vec3::X) < 1e-5, "second segment starts at X: {a1}");
-        assert!(b1.distance(Vec3::ZERO) < 1e-5, "U-turn returns to origin: {b1}");
+        assert!(
+            a1.distance(Vec3::X) < 1e-5,
+            "second segment starts at X: {a1}"
+        );
+        assert!(
+            b1.distance(Vec3::ZERO) < 1e-5,
+            "U-turn returns to origin: {b1}"
+        );
     }
 
     #[test]
@@ -277,8 +283,14 @@ mod tests {
             let segs = make(axiom, 90.0);
             assert_eq!(segs.len(), 1, "axiom {axiom:?}");
             let [a, b] = segs[0];
-            assert!(a.distance(Vec3::ZERO) < 1e-5, "starts at origin ({axiom:?})");
-            assert!(b.distance(Vec3::X) < 1e-5, "roll should not change forward ({axiom:?}): {b}");
+            assert!(
+                a.distance(Vec3::ZERO) < 1e-5,
+                "starts at origin ({axiom:?})"
+            );
+            assert!(
+                b.distance(Vec3::X) < 1e-5,
+                "roll should not change forward ({axiom:?}): {b}"
+            );
         }
     }
 
@@ -291,7 +303,10 @@ mod tests {
         assert_eq!(segs.len(), 1);
         let [a, b] = segs[0];
         assert!(a.distance(Vec3::ZERO) < 1e-5);
-        assert!(b.distance(Vec3::Z) < 1e-5, "after /+, F should move along Z: {b}");
+        assert!(
+            b.distance(Vec3::Z) < 1e-5,
+            "after /+, F should move along Z: {b}"
+        );
     }
 
     #[test]
@@ -303,9 +318,85 @@ mod tests {
         assert_eq!(segs.len(), 2);
         let [a0, b0] = segs[0];
         let [a1, b1] = segs[1];
-        assert!(a0.distance(Vec3::ZERO) < 1e-5, "branch starts at origin: {a0}");
+        assert!(
+            a0.distance(Vec3::ZERO) < 1e-5,
+            "branch starts at origin: {a0}"
+        );
         assert!(b0.distance(Vec3::Z) < 1e-5, "branch F ends at Z: {b0}");
-        assert!(a1.distance(Vec3::ZERO) < 1e-5, "position restored to origin: {a1}");
-        assert!(b1.distance(Vec3::X) < 1e-5, "forward restored to X after branch: {b1}");
+        assert!(
+            a1.distance(Vec3::ZERO) < 1e-5,
+            "position restored to origin: {a1}"
+        );
+        assert!(
+            b1.distance(Vec3::X) < 1e-5,
+            "forward restored to X after branch: {b1}"
+        );
+    }
+
+    #[test]
+    fn roll_left_affects_subsequent_yaw_plane() {
+        // Without prior roll, +F draws along Y (see plus_yaws_left_into_y).
+        // After rolling 90° left, local up shifts from Z to Y, so a subsequent
+        // yaw left sweeps around the new local up and draws along -Z instead.
+        let segs = make(r"\+F", 90.0);
+        assert_eq!(segs.len(), 1);
+        let [_, b] = segs[0];
+        assert!(
+            b.distance(-Vec3::Z) < 1e-5,
+            r"after \+, F should move along -Z: {b}"
+        );
+    }
+
+    #[test]
+    fn minus_yaws_right() {
+        let segs = make("-F", 90.0);
+        assert_eq!(segs.len(), 1);
+        let [_, b] = segs[0];
+        assert!(b.distance(-Vec3::Y) < 1e-5, "-F should move along -Y: {b}");
+    }
+
+    #[test]
+    fn caret_pitches_up() {
+        let segs = make("^F", 90.0);
+        assert_eq!(segs.len(), 1);
+        let [_, b] = segs[0];
+        assert!(b.distance(Vec3::Z) < 1e-5, "^F should move along Z: {b}");
+    }
+
+    #[test]
+    fn non_drawing_forward_uses_cached_direction() {
+        // After +, f moves without drawing in the yawed direction.
+        // The subsequent F draws from that new position along the same direction.
+        // Confirms that f correctly uses (and does not skip) a dirty forward cache.
+        let segs = make("+fF", 90.0);
+        assert_eq!(segs.len(), 1);
+        let [a, b] = segs[0];
+        assert!(a.distance(Vec3::Y) < 1e-5, "f should move to Y: {a}");
+        assert!(b.distance(2.0 * Vec3::Y) < 1e-5, "F should draw to 2Y: {b}");
+    }
+
+    #[test]
+    fn branch_dirty_save_and_restore() {
+        // + yaws left, making the forward cache dirty. [ saves that dirty state.
+        // Inside the branch, F recomputes forward (Y) and draws from origin to Y.
+        // ] restores position to origin and the saved dirty state. The outer F
+        // also recomputes forward (Y) and draws from origin to Y.
+        let segs = make("+[F]F", 90.0);
+        assert_eq!(segs.len(), 2);
+        let [a0, b0] = segs[0];
+        let [a1, b1] = segs[1];
+        assert!(
+            a0.distance(Vec3::ZERO) < 1e-5,
+            "branch F starts at origin: {a0}"
+        );
+        assert!(b0.distance(Vec3::Y) < 1e-5, "branch F draws to Y: {b0}");
+        assert!(
+            a1.distance(Vec3::ZERO) < 1e-5,
+            "position restored to origin: {a1}"
+        );
+        assert!(
+            b1.distance(Vec3::Y) < 1e-5,
+            "outer F draws to Y after dirty restore: {b1}"
+        );
     }
 }


### PR DESCRIPTION
## What

Adds coordinate-sensitive tests for turtle symbols and behaviors that
were not previously covered, establishing a correctness baseline before
the upcoming trig-elimination optimization changes turtle state.

## Why

The trig-elimination plan (`docs/plans/turtle-trig-elimination.md`)
changes how 2D and 3D turtles represent direction internally. Without
precise coordinate tests for `|`, `/`, `\`, and branch restore, a
regression in those symbols could go undetected.

## Changes

### `turtle2d.rs`
- `pipe_u_turn_reverses_direction` — `F|F` returns to the origin,
  confirming `|` reverses forward direction
- `koch_snowflake_path_closes` — Koch snowflake at iteration 4 closes
  within 1e-3; catches direction drift and step-size drift from
  accumulated rotations

### `turtle3d.rs`
- `pipe_u_turn_reverses_direction` — same check in 3D
- `roll_does_not_change_forward_direction` — `/F` and `\F` both draw
  along Vec3::X, confirming roll leaves the forward axis unchanged
- `roll_affects_subsequent_yaw_plane` — `/+F` at 90° draws along
  Vec3::Z (not Vec3::Y), confirming roll correctly rotates the local
  frame before a subsequent yaw
- `branch_restore_after_roll` — `[/+F]F` at 90° restores position and
  orientation after a branch containing roll+yaw, confirming both
  forward direction and position are fully recovered on `]`