### PR TITLE
Precompute 3D rotation quaternions to eliminate per-rotation trig

### DIFF
--- a/crates/lsystem-core/src/turtle/turtle3d.rs
+++ b/crates/lsystem-core/src/turtle/turtle3d.rs
@@ -9,7 +9,13 @@ pub(crate) struct Segments3D<I: Iterator<Item = char>> {
 
 pub(crate) struct Segments3DWithTopologicalDepth<I: Iterator<Item = char>> {
     chars: I,
-    angle_rad: f32,
+    rot_yaw_plus: Quat,
+    rot_yaw_minus: Quat,
+    rot_pitch_down: Quat,
+    rot_pitch_up: Quat,
+    rot_roll_right: Quat,
+    rot_roll_left: Quat,
+    rot_uturn: Quat,
     step: f32,
     position: Vec3,
     orientation: Quat,
@@ -19,9 +25,16 @@ pub(crate) struct Segments3DWithTopologicalDepth<I: Iterator<Item = char>> {
 
 impl<I: Iterator<Item = char>> Segments3DWithTopologicalDepth<I> {
     pub(crate) fn new(chars: I, angle_deg: f32, step: f32, initial_heading_deg: f32) -> Self {
+        let angle_rad = angle_deg.to_radians();
         Self {
             chars,
-            angle_rad: angle_deg.to_radians(),
+            rot_yaw_plus: Quat::from_rotation_z(angle_rad),
+            rot_yaw_minus: Quat::from_rotation_z(-angle_rad),
+            rot_pitch_down: Quat::from_rotation_y(angle_rad),
+            rot_pitch_up: Quat::from_rotation_y(-angle_rad),
+            rot_roll_right: Quat::from_rotation_x(angle_rad),
+            rot_roll_left: Quat::from_rotation_x(-angle_rad),
+            rot_uturn: Quat::from_rotation_z(std::f32::consts::PI),
             step,
             position: Vec3::ZERO,
             orientation: Quat::from_rotation_z(initial_heading_deg.to_radians()),
@@ -52,27 +65,13 @@ impl<I: Iterator<Item = char>> Iterator for Segments3DWithTopologicalDepth<I> {
                     let forward = self.orientation * Vec3::X;
                     self.position += forward * self.step;
                 }
-                '+' => {
-                    self.orientation *= Quat::from_rotation_z(self.angle_rad);
-                }
-                '-' => {
-                    self.orientation *= Quat::from_rotation_z(-self.angle_rad);
-                }
-                '&' => {
-                    self.orientation *= Quat::from_rotation_y(self.angle_rad);
-                }
-                '^' => {
-                    self.orientation *= Quat::from_rotation_y(-self.angle_rad);
-                }
-                '/' => {
-                    self.orientation *= Quat::from_rotation_x(self.angle_rad);
-                }
-                '\\' => {
-                    self.orientation *= Quat::from_rotation_x(-self.angle_rad);
-                }
-                '|' => {
-                    self.orientation *= Quat::from_rotation_z(std::f32::consts::PI);
-                }
+                '+' => self.orientation *= self.rot_yaw_plus,
+                '-' => self.orientation *= self.rot_yaw_minus,
+                '&' => self.orientation *= self.rot_pitch_down,
+                '^' => self.orientation *= self.rot_pitch_up,
+                '/' => self.orientation *= self.rot_roll_right,
+                '\\' => self.orientation *= self.rot_roll_left,
+                '|' => self.orientation *= self.rot_uturn,
                 '[' => self
                     .stack
                     .push((self.position, self.orientation, self.topological_depth)),


### PR DESCRIPTION
## Summary

Replaces `angle_rad: f32` in `Segments3DWithTopologicalDepth` with seven precomputed rotation quaternions:

```rust
rot_yaw_plus   // +
rot_yaw_minus  // -
rot_pitch_down // &
rot_pitch_up   // ^
rot_roll_right // /
rot_roll_left  // \
rot_uturn      // |
```

Each rotation symbol now does `self.orientation *= self.rot_*` — a plain quaternion multiply — instead of calling `Quat::from_rotation_*()`, which internally calls sin/cos. The angle is constant for the entire generation pass, so the seven quaternions only need to be computed once in `::new`. Stack type and movement code (`F`/`f`) are unchanged.

## Benchmark results

Measured against a same-machine same-run baseline (Criterion, 100 samples):

| Benchmark | Change |
|-----------|--------|
| `generation_3d/branching_rotation_heavy` | −19% |
| `generation_3d/hilbert_3d` | −39% |
| `generation_3d/tree_roll_heavy` | −20% |
| `generation_3d/synthetic_3d_forward_heavy` | +3.6% |
| `generation_2d/*` (unchanged code) | within noise |

The forward-heavy regression comes from the struct growing by ~108 bytes (1 `f32` → 7 `Quat`s), adding cache pressure in the degenerate case of a grammar with no rotation symbols. Any grammar that uses rotations shows a large net improvement.