### PR TITLE
Optimize L-system grammar expansion

### DIFF
--- a/crates/lsystem-core/src/grammar.rs
+++ b/crates/lsystem-core/src/grammar.rs
@@ -1,5 +1,8 @@
 use std::collections::{BTreeMap, BTreeSet};
 
+const NON_ASCII_BASE: u8 = 128;
+const MAX_NON_ASCII_SYMBOLS: usize = (u8::MAX - NON_ASCII_BASE + 1) as usize;
+
 struct Frame {
     pos: u32,
     end: u32,
@@ -10,18 +13,34 @@ pub(crate) struct ExpandIter {
     arena: Vec<u8>,
     rules: Box<[Option<(u32, u32)>; 256]>,
     stack: Vec<Frame>,
+    terminal_pos: u32,
+    terminal_end: u32,
 }
 
 impl Iterator for ExpandIter {
     type Item = u8;
 
     fn next(&mut self) -> Option<u8> {
+        if self.terminal_pos < self.terminal_end {
+            let byte = self.arena[self.terminal_pos as usize];
+            self.terminal_pos += 1;
+            return Some(byte);
+        }
+
         loop {
-            while self.stack.last().is_some_and(|f| f.pos == f.end) {
-                self.stack.pop();
-            }
             let (byte, depth) = {
                 let frame = self.stack.last_mut()?;
+                if frame.pos == frame.end {
+                    self.stack.pop();
+                    continue;
+                }
+                if frame.depth == 0 {
+                    let pos = frame.pos;
+                    self.terminal_pos = pos + 1;
+                    self.terminal_end = frame.end;
+                    self.stack.pop();
+                    return Some(self.arena[pos as usize]);
+                }
                 let b = self.arena[frame.pos as usize];
                 frame.pos += 1;
                 (b, frame.depth)
@@ -41,6 +60,8 @@ impl Iterator for ExpandIter {
     }
 }
 
+/// Maps ASCII symbols to their byte values and assigns non-ASCII symbols
+/// sequential IDs from [`NON_ASCII_BASE`] through `u8::MAX`.
 fn char_to_id(c: char, non_ascii: &mut Vec<(char, u8)>, next_id: &mut u8) -> u8 {
     if c.is_ascii() {
         c as u8
@@ -48,8 +69,8 @@ fn char_to_id(c: char, non_ascii: &mut Vec<(char, u8)>, next_id: &mut u8) -> u8 
         id
     } else {
         assert!(
-            non_ascii.len() < 128,
-            "too many distinct non-ASCII symbols (max 128)"
+            non_ascii.len() < MAX_NON_ASCII_SYMBOLS,
+            "too many distinct non-ASCII symbols (max {MAX_NON_ASCII_SYMBOLS})"
         );
         let id = *next_id;
         *next_id = next_id.wrapping_add(1);
@@ -60,10 +81,12 @@ fn char_to_id(c: char, non_ascii: &mut Vec<(char, u8)>, next_id: &mut u8) -> u8 
 
 pub(crate) fn expand(axiom: &str, rules: &BTreeMap<char, String>, iterations: u32) -> ExpandIter {
     let mut non_ascii: Vec<(char, u8)> = Vec::new();
-    let mut next_id: u8 = 128;
+    let mut next_id = NON_ASCII_BASE;
     let mut arena: Vec<u8> = Vec::new();
     let mut rule_table: Box<[Option<(u32, u32)>; 256]> = Box::new([None; 256]);
 
+    // The axiom occupies the arena prefix. Each rule RHS is appended afterward,
+    // and the rule table records its half-open range in the shared arena.
     for c in axiom.chars() {
         arena.push(char_to_id(c, &mut non_ascii, &mut next_id));
     }
@@ -86,6 +109,8 @@ pub(crate) fn expand(axiom: &str, rules: &BTreeMap<char, String>, iterations: u3
             end: axiom_end,
             depth: iterations,
         }],
+        terminal_pos: 0,
+        terminal_end: 0,
     }
 }
 
@@ -166,6 +191,28 @@ mod tests {
     fn zero_iterations_returns_axiom() {
         let result: Vec<u8> = expand("F++F++F", &koch_rules(), 0).collect();
         assert_eq!(result, b"F++F++F");
+    }
+
+    #[test]
+    fn depth_zero_frame_streams_remaining_terminal_span_after_pop() {
+        let mut symbols = expand("ABC", &BTreeMap::new(), 0);
+
+        assert_eq!(symbols.next(), Some(b'A'));
+        assert!(symbols.stack.is_empty());
+        assert_eq!(symbols.collect::<Vec<_>>(), b"BC");
+    }
+
+    #[test]
+    fn empty_axiom_returns_no_symbols() {
+        let result: Vec<u8> = expand("", &koch_rules(), 1).collect();
+        assert!(result.is_empty());
+    }
+
+    #[test]
+    fn empty_rule_rhs_resumes_parent_frame() {
+        let rules: BTreeMap<char, String> = [('F', String::new())].into();
+        let result: Vec<u8> = expand("FA", &rules, 1).collect();
+        assert_eq!(result, b"A");
     }
 
     #[test]
@@ -253,7 +300,7 @@ mod tests {
     #[test]
     fn two_distinct_non_ascii_chars_get_distinct_ids() {
         // If 'ä' and 'ö' both got ID 128, the second rule would overwrite the
-        // first in the rule table and "äö" would expand to "FF" instead of "FFF".
+        // first in the rule table and "äö" would expand to "FFFF" instead of "FFF".
         let rules: BTreeMap<char, String> =
             [('ä', "F".to_string()), ('ö', "FF".to_string())].into();
         let result: Vec<u8> = expand("äö", &rules, 1).collect();
@@ -298,6 +345,13 @@ mod tests {
         let result: Vec<u8> = expand(&axiom, &BTreeMap::new(), 0).collect();
         assert_eq!(result.len(), 128);
         assert_eq!(result, (128u8..=255u8).collect::<Vec<_>>());
+    }
+
+    #[test]
+    #[should_panic(expected = "too many distinct non-ASCII symbols (max 128)")]
+    fn panics_on_129th_distinct_non_ascii_symbol() {
+        let axiom: String = ('\u{0080}'..='\u{0100}').collect();
+        let _ = expand(&axiom, &BTreeMap::new(), 0).collect::<Vec<_>>();
     }
 
     #[test]

--- a/crates/lsystem-core/src/grammar.rs
+++ b/crates/lsystem-core/src/grammar.rs
@@ -1,43 +1,91 @@
 use std::collections::{BTreeMap, BTreeSet};
 
-pub(crate) struct ExpandIter<'a> {
-    stack: Vec<(std::str::Chars<'a>, u32)>,
-    rules: &'a BTreeMap<char, String>,
+struct Frame {
+    pos: u32,
+    end: u32,
+    depth: u32,
 }
 
-impl Iterator for ExpandIter<'_> {
-    type Item = char;
+pub(crate) struct ExpandIter {
+    arena: Vec<u8>,
+    rules: Box<[Option<(u32, u32)>; 256]>,
+    stack: Vec<Frame>,
+}
 
-    fn next(&mut self) -> Option<char> {
+impl Iterator for ExpandIter {
+    type Item = u8;
+
+    fn next(&mut self) -> Option<u8> {
         loop {
-            let top = self.stack.last_mut()?;
-            let depth = top.1;
-            match top.0.next() {
-                None => {
-                    self.stack.pop();
-                }
-                Some(ch) => {
-                    if depth > 0
-                        && let Some(rhs) = self.rules.get(&ch)
-                    {
-                        self.stack.push((rhs.chars(), depth - 1));
-                        continue;
-                    }
-                    return Some(ch);
-                }
+            while self.stack.last().is_some_and(|f| f.pos == f.end) {
+                self.stack.pop();
             }
+            let (byte, depth) = {
+                let frame = self.stack.last_mut()?;
+                let b = self.arena[frame.pos as usize];
+                frame.pos += 1;
+                (b, frame.depth)
+            };
+            if depth > 0
+                && let Some((s, e)) = self.rules[byte as usize]
+            {
+                self.stack.push(Frame {
+                    pos: s,
+                    end: e,
+                    depth: depth - 1,
+                });
+                continue;
+            }
+            return Some(byte);
         }
     }
 }
 
-pub(crate) fn expand<'a>(
-    axiom: &'a str,
-    rules: &'a BTreeMap<char, String>,
-    iterations: u32,
-) -> ExpandIter<'a> {
+fn char_to_id(c: char, non_ascii: &mut Vec<(char, u8)>, next_id: &mut u8) -> u8 {
+    if c.is_ascii() {
+        c as u8
+    } else if let Some(&(_, id)) = non_ascii.iter().find(|(ch, _)| *ch == c) {
+        id
+    } else {
+        assert!(
+            non_ascii.len() < 128,
+            "too many distinct non-ASCII symbols (max 128)"
+        );
+        let id = *next_id;
+        *next_id = next_id.wrapping_add(1);
+        non_ascii.push((c, id));
+        id
+    }
+}
+
+pub(crate) fn expand(axiom: &str, rules: &BTreeMap<char, String>, iterations: u32) -> ExpandIter {
+    let mut non_ascii: Vec<(char, u8)> = Vec::new();
+    let mut next_id: u8 = 128;
+    let mut arena: Vec<u8> = Vec::new();
+    let mut rule_table: Box<[Option<(u32, u32)>; 256]> = Box::new([None; 256]);
+
+    for c in axiom.chars() {
+        arena.push(char_to_id(c, &mut non_ascii, &mut next_id));
+    }
+    let axiom_end = arena.len() as u32;
+
+    for (k, v) in rules {
+        let key_id = char_to_id(*k, &mut non_ascii, &mut next_id) as usize;
+        let rhs_start = arena.len() as u32;
+        for c in v.chars() {
+            arena.push(char_to_id(c, &mut non_ascii, &mut next_id));
+        }
+        rule_table[key_id] = Some((rhs_start, arena.len() as u32));
+    }
+
     ExpandIter {
-        stack: vec![(axiom.chars(), iterations)],
-        rules,
+        arena,
+        rules: rule_table,
+        stack: vec![Frame {
+            pos: 0,
+            end: axiom_end,
+            depth: iterations,
+        }],
     }
 }
 
@@ -116,15 +164,15 @@ mod tests {
 
     #[test]
     fn zero_iterations_returns_axiom() {
-        let result: String = expand("F++F++F", &koch_rules(), 0).collect();
-        assert_eq!(result, "F++F++F");
+        let result: Vec<u8> = expand("F++F++F", &koch_rules(), 0).collect();
+        assert_eq!(result, b"F++F++F");
     }
 
     #[test]
     fn one_iteration_expands_f() {
-        let result: String = expand("F++F++F", &koch_rules(), 1).collect();
+        let result: Vec<u8> = expand("F++F++F", &koch_rules(), 1).collect();
         // Each F → F-F++F-F; the ++ between each F are carried through.
-        assert_eq!(result, "F-F++F-F++F-F++F-F++F-F++F-F");
+        assert_eq!(result, b"F-F++F-F++F-F++F-F++F-F++F-F");
     }
 
     #[test]
@@ -133,7 +181,7 @@ mod tests {
         let rules = koch_rules();
         for iter in 0..=4u32 {
             let f_count = expand("F++F++F", &rules, iter)
-                .filter(|&c| c == 'F')
+                .filter(|&b| b == b'F')
                 .count();
             assert_eq!(f_count, 3 * 4usize.pow(iter), "iter {iter}");
         }
@@ -172,8 +220,8 @@ mod tests {
         // iter 1: "F" → "FX"
         // iter 2: F→FX, X→X → "FXX"
         let rules: BTreeMap<char, String> = [('F', "FX".to_string())].into();
-        let result: String = expand("F", &rules, 2).collect();
-        assert_eq!(result, "FXX");
+        let result: Vec<u8> = expand("F", &rules, 2).collect();
+        assert_eq!(result, b"FXX");
     }
 
     #[test]
@@ -184,8 +232,72 @@ mod tests {
         // iter 2: a→a, A→aA, B→Bb, b→b  →  "aaABbb"
         let rules: BTreeMap<char, String> =
             [('A', "aA".to_string()), ('B', "Bb".to_string())].into();
-        let result: String = expand("AB", &rules, 2).collect();
-        assert_eq!(result, "aaABbb");
+        let result: Vec<u8> = expand("AB", &rules, 2).collect();
+        assert_eq!(result, b"aaABbb");
+    }
+
+    #[test]
+    fn non_ascii_rule_key_is_applied() {
+        let rules: BTreeMap<char, String> = [('ä', "FFF".to_string())].into();
+        let result: Vec<u8> = expand("ä", &rules, 1).collect();
+        assert_eq!(result, b"FFF");
+    }
+
+    #[test]
+    fn non_ascii_without_rule_passes_through() {
+        // 'ä' is assigned ID 128; with no rule it passes through unchanged.
+        let result: Vec<u8> = expand("ä", &BTreeMap::new(), 1).collect();
+        assert_eq!(result, [128u8]);
+    }
+
+    #[test]
+    fn two_distinct_non_ascii_chars_get_distinct_ids() {
+        // If 'ä' and 'ö' both got ID 128, the second rule would overwrite the
+        // first in the rule table and "äö" would expand to "FF" instead of "FFF".
+        let rules: BTreeMap<char, String> =
+            [('ä', "F".to_string()), ('ö', "FF".to_string())].into();
+        let result: Vec<u8> = expand("äö", &rules, 1).collect();
+        assert_eq!(result, b"FFF");
+    }
+
+    #[test]
+    fn non_ascii_in_rule_rhs_passes_through() {
+        // 'ä' in the RHS is encoded in the arena (ID 128) and passes through
+        // when the iterator encounters it with no rule of its own.
+        let rules: BTreeMap<char, String> = [('F', "äF".to_string())].into();
+        let result: Vec<u8> = expand("F", &rules, 1).collect();
+        assert_eq!(result, [128u8, b'F']);
+    }
+
+    #[test]
+    fn non_ascii_non_terminal_in_rhs_expands_correctly() {
+        // 'ä' appears in both a RHS and has its own rule.
+        // axiom "ä", rule ä→"äF":
+        //   iter 0: [128]
+        //   iter 1: ä→äF → [128, b'F']  (ä at depth 0 passes through)
+        //   iter 2: ä→äF, depth of inner ä is 0 → [128, b'F', b'F']
+        let rules: BTreeMap<char, String> = [('ä', "äF".to_string())].into();
+        let result: Vec<u8> = expand("ä", &rules, 2).collect();
+        assert_eq!(result, [128u8, b'F', b'F']);
+    }
+
+    #[test]
+    fn mixed_ascii_and_non_ascii_axiom_with_rules() {
+        // "Fä": F has no rule (passes through), ä → "FF".
+        // iter 1: F passes through, ä→FF → "FFF"
+        let rules: BTreeMap<char, String> = [('ä', "FF".to_string())].into();
+        let result: Vec<u8> = expand("Fä", &rules, 1).collect();
+        assert_eq!(result, b"FFF");
+    }
+
+    #[test]
+    fn supports_128_distinct_non_ascii_symbols() {
+        // U+0080..=U+00FF are exactly 128 distinct non-ASCII chars (IDs 128..=255).
+        // None of them have rules, so they all pass through unchanged.
+        let axiom: String = ('\u{0080}'..='\u{00FF}').collect();
+        let result: Vec<u8> = expand(&axiom, &BTreeMap::new(), 0).collect();
+        assert_eq!(result.len(), 128);
+        assert_eq!(result, (128u8..=255u8).collect::<Vec<_>>());
     }
 
     #[test]

--- a/crates/lsystem-core/src/lib.rs
+++ b/crates/lsystem-core/src/lib.rs
@@ -38,17 +38,17 @@ pub struct Segment3DWithTopologicalDepth {
 
 /// Expand the grammar and run the 2D turtle, returning a lazy iterator of line segments.
 pub fn generate(config: &GenerationConfig) -> impl Iterator<Item = [Vec2; 2]> + '_ {
-    let chars = grammar::expand(&config.axiom, &config.rules, config.iterations);
-    turtle::turtle2d::Segments2D::new(chars, config.angle, config.step, config.initial_heading)
+    let symbols = grammar::expand(&config.axiom, &config.rules, config.iterations);
+    turtle::turtle2d::Segments2D::new(symbols, config.angle, config.step, config.initial_heading)
 }
 
 /// Expand the grammar and run the 2D turtle with per-segment topological depth.
 pub fn generate_with_topological_depth(
     config: &GenerationConfig,
 ) -> impl Iterator<Item = Segment2DWithTopologicalDepth> + '_ {
-    let chars = grammar::expand(&config.axiom, &config.rules, config.iterations);
+    let symbols = grammar::expand(&config.axiom, &config.rules, config.iterations);
     turtle::turtle2d::Segments2DWithTopologicalDepth::new(
-        chars,
+        symbols,
         config.angle,
         config.step,
         config.initial_heading,
@@ -57,17 +57,17 @@ pub fn generate_with_topological_depth(
 
 /// Like `generate` but runs the 3D turtle.
 pub fn generate_3d(config: &GenerationConfig) -> impl Iterator<Item = [Vec3; 2]> + '_ {
-    let chars = grammar::expand(&config.axiom, &config.rules, config.iterations);
-    turtle::turtle3d::Segments3D::new(chars, config.angle, config.step, config.initial_heading)
+    let symbols = grammar::expand(&config.axiom, &config.rules, config.iterations);
+    turtle::turtle3d::Segments3D::new(symbols, config.angle, config.step, config.initial_heading)
 }
 
 /// Like `generate_with_topological_depth` but runs the 3D turtle.
 pub fn generate_3d_with_topological_depth(
     config: &GenerationConfig,
 ) -> impl Iterator<Item = Segment3DWithTopologicalDepth> + '_ {
-    let chars = grammar::expand(&config.axiom, &config.rules, config.iterations);
+    let symbols = grammar::expand(&config.axiom, &config.rules, config.iterations);
     turtle::turtle3d::Segments3DWithTopologicalDepth::new(
-        chars,
+        symbols,
         config.angle,
         config.step,
         config.initial_heading,

--- a/crates/lsystem-core/src/turtle/turtle2d.rs
+++ b/crates/lsystem-core/src/turtle/turtle2d.rs
@@ -2,12 +2,12 @@ use glam::Vec2;
 
 use crate::Segment2DWithTopologicalDepth;
 
-pub(crate) struct Segments2D<I: Iterator<Item = char>> {
+pub(crate) struct Segments2D<I: Iterator<Item = u8>> {
     inner: Segments2DWithTopologicalDepth<I>,
 }
 
-pub(crate) struct Segments2DWithTopologicalDepth<I: Iterator<Item = char>> {
-    chars: I,
+pub(crate) struct Segments2DWithTopologicalDepth<I: Iterator<Item = u8>> {
+    symbols: I,
     rot_plus: Vec2,
     rot_minus: Vec2,
     delta: Vec2,
@@ -16,11 +16,11 @@ pub(crate) struct Segments2DWithTopologicalDepth<I: Iterator<Item = char>> {
     stack: Vec<(Vec2, Vec2, u32)>,
 }
 
-impl<I: Iterator<Item = char>> Segments2DWithTopologicalDepth<I> {
-    pub(crate) fn new(chars: I, angle_deg: f32, step: f32, initial_heading_deg: f32) -> Self {
+impl<I: Iterator<Item = u8>> Segments2DWithTopologicalDepth<I> {
+    pub(crate) fn new(symbols: I, angle_deg: f32, step: f32, initial_heading_deg: f32) -> Self {
         let angle_rad = angle_deg.to_radians();
         Self {
-            chars,
+            symbols,
             rot_plus: Vec2::from_angle(angle_rad),
             rot_minus: Vec2::from_angle(-angle_rad),
             delta: Vec2::from_angle(initial_heading_deg.to_radians()) * step,
@@ -31,13 +31,13 @@ impl<I: Iterator<Item = char>> Segments2DWithTopologicalDepth<I> {
     }
 }
 
-impl<I: Iterator<Item = char>> Iterator for Segments2DWithTopologicalDepth<I> {
+impl<I: Iterator<Item = u8>> Iterator for Segments2DWithTopologicalDepth<I> {
     type Item = Segment2DWithTopologicalDepth;
 
     fn next(&mut self) -> Option<Self::Item> {
         loop {
-            match self.chars.next()? {
-                'F' => {
+            match self.symbols.next()? {
+                b'F' => {
                     let next = self.position + self.delta;
                     let segment = Segment2DWithTopologicalDepth {
                         points: [self.position, next],
@@ -47,16 +47,16 @@ impl<I: Iterator<Item = char>> Iterator for Segments2DWithTopologicalDepth<I> {
                     self.topological_depth = self.topological_depth.saturating_add(1);
                     return Some(segment);
                 }
-                'f' => {
+                b'f' => {
                     self.position += self.delta;
                 }
-                '+' => self.delta = self.delta.rotate(self.rot_plus),
-                '-' => self.delta = self.delta.rotate(self.rot_minus),
-                '|' => self.delta = -self.delta,
-                '[' => self
+                b'+' => self.delta = self.delta.rotate(self.rot_plus),
+                b'-' => self.delta = self.delta.rotate(self.rot_minus),
+                b'|' => self.delta = -self.delta,
+                b'[' => self
                     .stack
                     .push((self.position, self.delta, self.topological_depth)),
-                ']' => {
+                b']' => {
                     let state = self.stack.pop();
                     debug_assert!(state.is_some(), "unmatched ] in validated program");
                     if let Some((pos, delta, topological_depth)) = state {
@@ -71,15 +71,20 @@ impl<I: Iterator<Item = char>> Iterator for Segments2DWithTopologicalDepth<I> {
     }
 }
 
-impl<I: Iterator<Item = char>> Segments2D<I> {
-    pub(crate) fn new(chars: I, angle_deg: f32, step: f32, initial_heading_deg: f32) -> Self {
+impl<I: Iterator<Item = u8>> Segments2D<I> {
+    pub(crate) fn new(symbols: I, angle_deg: f32, step: f32, initial_heading_deg: f32) -> Self {
         Self {
-            inner: Segments2DWithTopologicalDepth::new(chars, angle_deg, step, initial_heading_deg),
+            inner: Segments2DWithTopologicalDepth::new(
+                symbols,
+                angle_deg,
+                step,
+                initial_heading_deg,
+            ),
         }
     }
 }
 
-impl<I: Iterator<Item = char>> Iterator for Segments2D<I> {
+impl<I: Iterator<Item = u8>> Iterator for Segments2D<I> {
     type Item = [Vec2; 2];
 
     fn next(&mut self) -> Option<[Vec2; 2]> {

--- a/crates/lsystem-core/src/turtle/turtle3d.rs
+++ b/crates/lsystem-core/src/turtle/turtle3d.rs
@@ -3,12 +3,12 @@ use glam::{Quat, Vec3};
 use crate::Segment3DWithTopologicalDepth;
 
 /// Heading = `orientation * Vec3::X`, left = `* Vec3::Y`, up = `* Vec3::Z`.
-pub(crate) struct Segments3D<I: Iterator<Item = char>> {
+pub(crate) struct Segments3D<I: Iterator<Item = u8>> {
     inner: Segments3DWithTopologicalDepth<I>,
 }
 
-pub(crate) struct Segments3DWithTopologicalDepth<I: Iterator<Item = char>> {
-    chars: I,
+pub(crate) struct Segments3DWithTopologicalDepth<I: Iterator<Item = u8>> {
+    symbols: I,
     rot_yaw_plus: Quat,
     rot_yaw_minus: Quat,
     rot_pitch_down: Quat,
@@ -23,11 +23,11 @@ pub(crate) struct Segments3DWithTopologicalDepth<I: Iterator<Item = char>> {
     stack: Vec<(Vec3, Quat, u32)>,
 }
 
-impl<I: Iterator<Item = char>> Segments3DWithTopologicalDepth<I> {
-    pub(crate) fn new(chars: I, angle_deg: f32, step: f32, initial_heading_deg: f32) -> Self {
+impl<I: Iterator<Item = u8>> Segments3DWithTopologicalDepth<I> {
+    pub(crate) fn new(symbols: I, angle_deg: f32, step: f32, initial_heading_deg: f32) -> Self {
         let angle_rad = angle_deg.to_radians();
         Self {
-            chars,
+            symbols,
             rot_yaw_plus: Quat::from_rotation_z(angle_rad),
             rot_yaw_minus: Quat::from_rotation_z(-angle_rad),
             rot_pitch_down: Quat::from_rotation_y(angle_rad),
@@ -44,13 +44,13 @@ impl<I: Iterator<Item = char>> Segments3DWithTopologicalDepth<I> {
     }
 }
 
-impl<I: Iterator<Item = char>> Iterator for Segments3DWithTopologicalDepth<I> {
+impl<I: Iterator<Item = u8>> Iterator for Segments3DWithTopologicalDepth<I> {
     type Item = Segment3DWithTopologicalDepth;
 
     fn next(&mut self) -> Option<Self::Item> {
         loop {
-            match self.chars.next()? {
-                'F' => {
+            match self.symbols.next()? {
+                b'F' => {
                     let forward = self.orientation * Vec3::X;
                     let next = self.position + forward * self.step;
                     let segment = Segment3DWithTopologicalDepth {
@@ -61,21 +61,21 @@ impl<I: Iterator<Item = char>> Iterator for Segments3DWithTopologicalDepth<I> {
                     self.topological_depth = self.topological_depth.saturating_add(1);
                     return Some(segment);
                 }
-                'f' => {
+                b'f' => {
                     let forward = self.orientation * Vec3::X;
                     self.position += forward * self.step;
                 }
-                '+' => self.orientation *= self.rot_yaw_plus,
-                '-' => self.orientation *= self.rot_yaw_minus,
-                '&' => self.orientation *= self.rot_pitch_down,
-                '^' => self.orientation *= self.rot_pitch_up,
-                '/' => self.orientation *= self.rot_roll_right,
-                '\\' => self.orientation *= self.rot_roll_left,
-                '|' => self.orientation *= self.rot_uturn,
-                '[' => self
+                b'+' => self.orientation *= self.rot_yaw_plus,
+                b'-' => self.orientation *= self.rot_yaw_minus,
+                b'&' => self.orientation *= self.rot_pitch_down,
+                b'^' => self.orientation *= self.rot_pitch_up,
+                b'/' => self.orientation *= self.rot_roll_right,
+                b'\\' => self.orientation *= self.rot_roll_left,
+                b'|' => self.orientation *= self.rot_uturn,
+                b'[' => self
                     .stack
                     .push((self.position, self.orientation, self.topological_depth)),
-                ']' => {
+                b']' => {
                     let state = self.stack.pop();
                     debug_assert!(state.is_some(), "unmatched ] in validated program");
                     if let Some((pos, orient, topological_depth)) = state {
@@ -90,15 +90,20 @@ impl<I: Iterator<Item = char>> Iterator for Segments3DWithTopologicalDepth<I> {
     }
 }
 
-impl<I: Iterator<Item = char>> Segments3D<I> {
-    pub(crate) fn new(chars: I, angle_deg: f32, step: f32, initial_heading_deg: f32) -> Self {
+impl<I: Iterator<Item = u8>> Segments3D<I> {
+    pub(crate) fn new(symbols: I, angle_deg: f32, step: f32, initial_heading_deg: f32) -> Self {
         Self {
-            inner: Segments3DWithTopologicalDepth::new(chars, angle_deg, step, initial_heading_deg),
+            inner: Segments3DWithTopologicalDepth::new(
+                symbols,
+                angle_deg,
+                step,
+                initial_heading_deg,
+            ),
         }
     }
 }
 
-impl<I: Iterator<Item = char>> Iterator for Segments3D<I> {
+impl<I: Iterator<Item = u8>> Iterator for Segments3D<I> {
     type Item = [Vec3; 2];
 
     fn next(&mut self) -> Option<[Vec3; 2]> {
@@ -117,7 +122,7 @@ mod tests {
     }
 
     fn make_with_heading(axiom: &str, angle_deg: f32, initial_heading_deg: f32) -> Vec<[Vec3; 2]> {
-        Segments3D::new(axiom.chars(), angle_deg, 1.0, initial_heading_deg).collect()
+        Segments3D::new(axiom.bytes(), angle_deg, 1.0, initial_heading_deg).collect()
     }
 
     #[test]

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -27,7 +27,7 @@ Runtime generation starts from a resolved `GenerationConfig`.
 
 ```text
 GenerationConfig
-  -> OwnedExpandIter
+  -> ExpandIter
   -> Segments2D / Segments3D
   -> renderer bridge segment records
   -> wgpu instance buffer
@@ -62,7 +62,7 @@ than caching resolved values inside the editor document.
 `lsystem-core` owns the grammar and turtle semantics:
 
 - `alphabet.rs` validates reserved symbols for 2D and 3D.
-- `grammar.rs` provides lazy borrowed and owned expansion iterators.
+- `grammar.rs` provides a lazy owned expansion iterator.
 - `turtle/turtle2d.rs` yields 2D line segments from expanded symbols.
 - `turtle/turtle3d.rs` yields 3D line segments using quaternion orientation.
 - `config.rs` defines validated runtime config and color types.


### PR DESCRIPTION
## Summary

- replace borrowed character traversal and tree-map rule lookup with an owned byte arena, compact frames, and a fixed 256-entry rule table
- update the 2D and 3D turtle iterators to consume byte symbols while preserving distinct non-ASCII grammar symbols and existing generation APIs
- reduce expansion hot-loop bookkeeping with a single top-frame access and direct streaming of depth-zero terminal spans
- add coverage for empty frames, non-ASCII mapping and capacity boundaries, and document the owned expansion data flow and arena invariants

## Design

Expansion remains lazy and memory-bounded. The axiom and rule right-hand sides share one arena, frames carry half-open ranges into that arena, and the renderer bridge remains the first intentional geometry collection point.