### PR TITLE
Stream generation via fold and strip no-op symbols

### DIFF
--- a/crates/lsystem-core/src/alphabet.rs
+++ b/crates/lsystem-core/src/alphabet.rs
@@ -1,7 +1,7 @@
 use crate::config::{ConfigError, Dimensions};
 
-const TERMINALS_UNIVERSAL: &str = "Ff+-|[]";
-const TERMINALS_3D: &str = "&^/\\";
+pub(crate) const TERMINALS_UNIVERSAL: &str = "Ff+-|[]";
+pub(crate) const TERMINALS_3D: &str = "&^/\\";
 
 pub fn validate_symbols(
     chars: &str,

--- a/crates/lsystem-core/src/grammar.rs
+++ b/crates/lsystem-core/src/grammar.rs
@@ -12,6 +12,8 @@ struct Frame {
 pub(crate) struct ExpandIter {
     arena: Vec<u8>,
     rules: Box<[Option<(u32, u32)>; 256]>,
+    terminal_rules: Box<[Option<(u32, u32)>; 256]>,
+    emit: [bool; 256],
     stack: Vec<Frame>,
     terminal_pos: u32,
     terminal_end: u32,
@@ -45,9 +47,14 @@ impl Iterator for ExpandIter {
                 frame.pos += 1;
                 (b, frame.depth)
             };
-            if depth > 0
-                && let Some((s, e)) = self.rules[byte as usize]
-            {
+            // Children entering depth 0 stream their span terminally, so they
+            // take the pre-filtered rule copies instead of the originals.
+            let table = if depth == 1 {
+                &self.terminal_rules
+            } else {
+                &self.rules
+            };
+            if let Some((s, e)) = table[byte as usize] {
                 self.stack.push(Frame {
                     pos: s,
                     end: e,
@@ -55,7 +62,55 @@ impl Iterator for ExpandIter {
                 });
                 continue;
             }
-            return Some(byte);
+            if self.emit[byte as usize] {
+                return Some(byte);
+            }
+        }
+    }
+
+    fn fold<B, F>(mut self, init: B, mut f: F) -> B
+    where
+        Self: Sized,
+        F: FnMut(B, Self::Item) -> B,
+    {
+        let mut acc = self.arena[self.terminal_pos as usize..self.terminal_end as usize]
+            .iter()
+            .copied()
+            .fold(init, &mut f);
+
+        loop {
+            let Some(frame) = self.stack.last_mut() else {
+                return acc;
+            };
+            if frame.pos == frame.end {
+                self.stack.pop();
+                continue;
+            }
+            if frame.depth == 0 {
+                let start = frame.pos as usize;
+                let end = frame.end as usize;
+                self.stack.pop();
+                acc = self.arena[start..end].iter().copied().fold(acc, &mut f);
+                continue;
+            }
+
+            let byte = self.arena[frame.pos as usize];
+            frame.pos += 1;
+            let depth = frame.depth - 1;
+            let table = if depth == 0 {
+                &self.terminal_rules
+            } else {
+                &self.rules
+            };
+            if let Some((s, e)) = table[byte as usize] {
+                self.stack.push(Frame {
+                    pos: s,
+                    end: e,
+                    depth,
+                });
+            } else if self.emit[byte as usize] {
+                acc = f(acc, byte);
+            }
         }
     }
 }
@@ -79,7 +134,12 @@ fn char_to_id(c: char, non_ascii: &mut Vec<(char, u8)>, next_id: &mut u8) -> u8 
     }
 }
 
-pub(crate) fn expand(axiom: &str, rules: &BTreeMap<char, String>, iterations: u32) -> ExpandIter {
+fn expand_impl(
+    axiom: &str,
+    rules: &BTreeMap<char, String>,
+    iterations: u32,
+    effects_only: bool,
+) -> ExpandIter {
     let mut non_ascii: Vec<(char, u8)> = Vec::new();
     let mut next_id = NON_ASCII_BASE;
     let mut arena: Vec<u8> = Vec::new();
@@ -101,17 +161,83 @@ pub(crate) fn expand(axiom: &str, rules: &BTreeMap<char, String>, iterations: u3
         rule_table[key_id] = Some((rhs_start, arena.len() as u32));
     }
 
+    // Effects-only expansion appends filtered copies of the axiom and each rule
+    // RHS (effect bytes only) to the arena. Depth-0 spans stream from these
+    // copies, and `emit` drops pass-through bytes yielded at depth > 0. The
+    // filtered table must be `Some` exactly where `rule_table` is: frame pushes
+    // select a table by depth and rely on the two agreeing.
+    let (terminal_rules, emit, axiom_start, axiom_end) = if effects_only {
+        let mut effect_table = [false; 256];
+        for &byte in b"Ff+-|[]&^/\\" {
+            effect_table[byte as usize] = true;
+        }
+
+        let filtered_axiom_start = arena.len() as u32;
+        for pos in 0..axiom_end as usize {
+            let byte = arena[pos];
+            if effect_table[byte as usize] {
+                arena.push(byte);
+            }
+        }
+        let filtered_axiom_end = arena.len() as u32;
+
+        let mut filtered_rule_table: Box<[Option<(u32, u32)>; 256]> = Box::new([None; 256]);
+        for symbol in 0..rule_table.len() {
+            let Some((start, end)) = rule_table[symbol] else {
+                continue;
+            };
+            let filtered_start = arena.len() as u32;
+            for pos in start as usize..end as usize {
+                let byte = arena[pos];
+                if effect_table[byte as usize] {
+                    arena.push(byte);
+                }
+            }
+            filtered_rule_table[symbol] = Some((filtered_start, arena.len() as u32));
+        }
+
+        // At zero iterations the axiom frame itself streams terminally, so it
+        // starts on the filtered copy.
+        if iterations == 0 {
+            (
+                filtered_rule_table,
+                effect_table,
+                filtered_axiom_start,
+                filtered_axiom_end,
+            )
+        } else {
+            (filtered_rule_table, effect_table, 0, axiom_end)
+        }
+    } else {
+        (rule_table.clone(), [true; 256], 0, axiom_end)
+    };
+
     ExpandIter {
         arena,
         rules: rule_table,
+        terminal_rules,
+        emit,
         stack: vec![Frame {
-            pos: 0,
+            pos: axiom_start,
             end: axiom_end,
             depth: iterations,
         }],
         terminal_pos: 0,
         terminal_end: 0,
     }
+}
+
+#[cfg(test)]
+pub(crate) fn expand(axiom: &str, rules: &BTreeMap<char, String>, iterations: u32) -> ExpandIter {
+    expand_impl(axiom, rules, iterations, false)
+}
+
+pub(crate) fn expand_effects(
+    axiom: &str,
+    rules: &BTreeMap<char, String>,
+    iterations: u32,
+) -> ExpandIter {
+    expand_impl(axiom, rules, iterations, true)
 }
 
 /// Returns the maximum iteration count for which the total number of drawn segments
@@ -182,6 +308,7 @@ pub fn unused_rules(axiom: &str, rules: &BTreeMap<char, String>) -> Vec<char> {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::test_util::collect_with_next;
 
     fn koch_rules() -> BTreeMap<char, String> {
         [('F', "F-F++F-F".to_string())].into()
@@ -220,6 +347,39 @@ mod tests {
         let result: Vec<u8> = expand("F++F++F", &koch_rules(), 1).collect();
         // Each F → F-F++F-F; the ++ between each F are carried through.
         assert_eq!(result, b"F-F++F-F++F-F++F-F++F-F++F-F");
+    }
+
+    #[test]
+    fn effect_expansion_matches_full_expansion_with_ignored_symbols_removed() {
+        let rules: BTreeMap<char, String> = [
+            ('X', "F+Y&ä".to_string()),
+            ('Y', "F[-X]^f".to_string()),
+            ('ä', "F/Z".to_string()),
+        ]
+        .into();
+        let is_effect = |byte: &u8| b"Ff+-|[]&^/\\".contains(byte);
+
+        for iterations in 0..=3 {
+            let expected: Vec<_> = expand("X|Y", &rules, iterations)
+                .filter(is_effect)
+                .collect();
+            let actual: Vec<_> = expand_effects("X|Y", &rules, iterations).collect();
+
+            assert_eq!(actual, expected, "iterations={iterations}");
+        }
+    }
+
+    #[test]
+    fn fold_matches_repeated_next_after_partial_terminal_consumption() {
+        let rules: BTreeMap<char, String> = [('F', "F+F-X".to_string())].into();
+        let mut folded = expand("F", &rules, 3);
+        let first = folded.next().unwrap();
+        let folded = folded.fold(vec![first], |mut bytes, byte| {
+            bytes.push(byte);
+            bytes
+        });
+
+        assert_eq!(folded, collect_with_next(expand("F", &rules, 3)));
     }
 
     #[test]

--- a/crates/lsystem-core/src/grammar.rs
+++ b/crates/lsystem-core/src/grammar.rs
@@ -1,5 +1,7 @@
 use std::collections::{BTreeMap, BTreeSet};
 
+use crate::alphabet::{TERMINALS_3D, TERMINALS_UNIVERSAL};
+
 const NON_ASCII_BASE: u8 = 128;
 const MAX_NON_ASCII_SYMBOLS: usize = (u8::MAX - NON_ASCII_BASE + 1) as usize;
 
@@ -168,7 +170,11 @@ fn expand_impl(
     // select a table by depth and rely on the two agreeing.
     let (terminal_rules, emit, axiom_start, axiom_end) = if effects_only {
         let mut effect_table = [false; 256];
-        for &byte in b"Ff+-|[]&^/\\" {
+        for &byte in TERMINALS_UNIVERSAL
+            .as_bytes()
+            .iter()
+            .chain(TERMINALS_3D.as_bytes())
+        {
             effect_table[byte as usize] = true;
         }
 
@@ -357,8 +363,9 @@ mod tests {
             ('ä', "F/Z".to_string()),
         ]
         .into();
-        let is_effect = |byte: &u8| b"Ff+-|[]&^/\\".contains(byte);
-
+        let is_effect = |byte: &u8| {
+            TERMINALS_UNIVERSAL.as_bytes().contains(byte) || TERMINALS_3D.as_bytes().contains(byte)
+        };
         for iterations in 0..=3 {
             let expected: Vec<_> = expand("X|Y", &rules, iterations)
                 .filter(is_effect)

--- a/crates/lsystem-core/src/lib.rs
+++ b/crates/lsystem-core/src/lib.rs
@@ -4,6 +4,8 @@ pub mod svg_export;
 pub(crate) mod alphabet;
 pub mod config;
 pub mod grammar;
+#[cfg(test)]
+pub(crate) mod test_util;
 pub(crate) mod turtle;
 
 pub use alphabet::{contains_3d_symbols, validate_bracket_balance, validate_symbols};
@@ -38,7 +40,7 @@ pub struct Segment3DWithTopologicalDepth {
 
 /// Expand the grammar and run the 2D turtle, returning a lazy iterator of line segments.
 pub fn generate(config: &GenerationConfig) -> impl Iterator<Item = [Vec2; 2]> + '_ {
-    let symbols = grammar::expand(&config.axiom, &config.rules, config.iterations);
+    let symbols = grammar::expand_effects(&config.axiom, &config.rules, config.iterations);
     turtle::turtle2d::Segments2D::new(symbols, config.angle, config.step, config.initial_heading)
 }
 
@@ -46,7 +48,7 @@ pub fn generate(config: &GenerationConfig) -> impl Iterator<Item = [Vec2; 2]> + 
 pub fn generate_with_topological_depth(
     config: &GenerationConfig,
 ) -> impl Iterator<Item = Segment2DWithTopologicalDepth> + '_ {
-    let symbols = grammar::expand(&config.axiom, &config.rules, config.iterations);
+    let symbols = grammar::expand_effects(&config.axiom, &config.rules, config.iterations);
     turtle::turtle2d::Segments2DWithTopologicalDepth::new(
         symbols,
         config.angle,
@@ -57,7 +59,7 @@ pub fn generate_with_topological_depth(
 
 /// Like `generate` but runs the 3D turtle.
 pub fn generate_3d(config: &GenerationConfig) -> impl Iterator<Item = [Vec3; 2]> + '_ {
-    let symbols = grammar::expand(&config.axiom, &config.rules, config.iterations);
+    let symbols = grammar::expand_effects(&config.axiom, &config.rules, config.iterations);
     turtle::turtle3d::Segments3D::new(symbols, config.angle, config.step, config.initial_heading)
 }
 
@@ -65,7 +67,7 @@ pub fn generate_3d(config: &GenerationConfig) -> impl Iterator<Item = [Vec3; 2]>
 pub fn generate_3d_with_topological_depth(
     config: &GenerationConfig,
 ) -> impl Iterator<Item = Segment3DWithTopologicalDepth> + '_ {
-    let symbols = grammar::expand(&config.axiom, &config.rules, config.iterations);
+    let symbols = grammar::expand_effects(&config.axiom, &config.rules, config.iterations);
     turtle::turtle3d::Segments3DWithTopologicalDepth::new(
         symbols,
         config.angle,

--- a/crates/lsystem-core/src/svg_export.rs
+++ b/crates/lsystem-core/src/svg_export.rs
@@ -12,8 +12,11 @@ use crate::{
 pub fn export_svg(config: &Config) -> String {
     let colors = config.colors;
     if colors.line.needs_topological_depth() && config.generation.has_stack_directives() {
-        let segments: Vec<Segment2DWithTopologicalDepth> =
-            generate_with_topological_depth(&config.generation).collect();
+        // for_each drives the pipeline's specialized `fold`; `collect` would
+        // pull every symbol one at a time through `next`.
+        let mut segments: Vec<Segment2DWithTopologicalDepth> = Vec::new();
+        generate_with_topological_depth(&config.generation)
+            .for_each(|segment| segments.push(segment));
         return export_svg_with_segments(
             &config.generation,
             &colors,
@@ -22,7 +25,9 @@ pub fn export_svg(config: &Config) -> String {
         );
     }
 
-    let segments: Vec<[Vec2; 2]> = generate(&config.generation).collect();
+    // for_each drives the pipeline's specialized `fold` (see above).
+    let mut segments: Vec<[Vec2; 2]> = Vec::new();
+    generate(&config.generation).for_each(|segment| segments.push(segment));
     export_svg_with_segments(
         &config.generation,
         &colors,

--- a/crates/lsystem-core/src/test_util.rs
+++ b/crates/lsystem-core/src/test_util.rs
@@ -1,0 +1,43 @@
+//! Shared helpers for tests that pin the `fold` fast path.
+
+/// Wraps an iterator so that draining it through `next` panics while `fold`
+/// delegates normally. Tests use it to prove a consumer stays on the
+/// specialized `fold` path.
+pub(crate) struct FoldOnly<I> {
+    inner: I,
+}
+
+impl<I> FoldOnly<I> {
+    pub(crate) fn new(inner: I) -> Self {
+        Self { inner }
+    }
+}
+
+impl<I: Iterator> Iterator for FoldOnly<I> {
+    type Item = I::Item;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        panic!("iterator must be drained through fold, not next")
+    }
+
+    fn fold<B, F>(self, init: B, f: F) -> B
+    where
+        Self: Sized,
+        F: FnMut(B, Self::Item) -> B,
+    {
+        self.inner.fold(init, f)
+    }
+}
+
+/// Drains an iterator through repeated `next` calls, bypassing any `fold`
+/// specialization. Equivalence tests use this as the oracle side; `collect`
+/// would stop being a valid oracle if std ever routed it through `fold`.
+pub(crate) fn collect_with_next<T>(mut iter: impl Iterator<Item = T>) -> Vec<T> {
+    let mut items = Vec::new();
+    loop {
+        match iter.next() {
+            Some(item) => items.push(item),
+            None => return items,
+        }
+    }
+}

--- a/crates/lsystem-core/src/turtle/turtle2d.rs
+++ b/crates/lsystem-core/src/turtle/turtle2d.rs
@@ -8,6 +8,12 @@ pub(crate) struct Segments2D<I: Iterator<Item = u8>> {
 
 pub(crate) struct Segments2DWithTopologicalDepth<I: Iterator<Item = u8>> {
     symbols: I,
+    state: TurtleState2D,
+}
+
+/// Turtle state plus the single symbol transition shared by `next` and `fold`,
+/// so the two iteration paths cannot drift apart.
+struct TurtleState2D {
     rot_plus: Vec2,
     rot_minus: Vec2,
     delta: Vec2,
@@ -16,17 +22,69 @@ pub(crate) struct Segments2DWithTopologicalDepth<I: Iterator<Item = u8>> {
     stack: Vec<(Vec2, Vec2, u32)>,
 }
 
+impl TurtleState2D {
+    #[inline]
+    fn apply(&mut self, symbol: u8) -> Option<Segment2DWithTopologicalDepth> {
+        match symbol {
+            b'F' => {
+                let next = self.position + self.delta;
+                let segment = Segment2DWithTopologicalDepth {
+                    points: [self.position, next],
+                    topological_depth: self.topological_depth,
+                };
+                self.position = next;
+                self.topological_depth = self.topological_depth.saturating_add(1);
+                Some(segment)
+            }
+            b'f' => {
+                self.position += self.delta;
+                None
+            }
+            b'+' => {
+                self.delta = self.delta.rotate(self.rot_plus);
+                None
+            }
+            b'-' => {
+                self.delta = self.delta.rotate(self.rot_minus);
+                None
+            }
+            b'|' => {
+                self.delta = -self.delta;
+                None
+            }
+            b'[' => {
+                self.stack
+                    .push((self.position, self.delta, self.topological_depth));
+                None
+            }
+            b']' => {
+                let state = self.stack.pop();
+                debug_assert!(state.is_some(), "unmatched ] in validated program");
+                if let Some((position, delta, topological_depth)) = state {
+                    self.position = position;
+                    self.delta = delta;
+                    self.topological_depth = topological_depth;
+                }
+                None
+            }
+            _ => None,
+        }
+    }
+}
+
 impl<I: Iterator<Item = u8>> Segments2DWithTopologicalDepth<I> {
     pub(crate) fn new(symbols: I, angle_deg: f32, step: f32, initial_heading_deg: f32) -> Self {
         let angle_rad = angle_deg.to_radians();
         Self {
             symbols,
-            rot_plus: Vec2::from_angle(angle_rad),
-            rot_minus: Vec2::from_angle(-angle_rad),
-            delta: Vec2::from_angle(initial_heading_deg.to_radians()) * step,
-            position: Vec2::ZERO,
-            topological_depth: 0,
-            stack: Vec::new(),
+            state: TurtleState2D {
+                rot_plus: Vec2::from_angle(angle_rad),
+                rot_minus: Vec2::from_angle(-angle_rad),
+                delta: Vec2::from_angle(initial_heading_deg.to_radians()) * step,
+                position: Vec2::ZERO,
+                topological_depth: 0,
+                stack: Vec::new(),
+            },
         }
     }
 }
@@ -36,38 +94,24 @@ impl<I: Iterator<Item = u8>> Iterator for Segments2DWithTopologicalDepth<I> {
 
     fn next(&mut self) -> Option<Self::Item> {
         loop {
-            match self.symbols.next()? {
-                b'F' => {
-                    let next = self.position + self.delta;
-                    let segment = Segment2DWithTopologicalDepth {
-                        points: [self.position, next],
-                        topological_depth: self.topological_depth,
-                    };
-                    self.position = next;
-                    self.topological_depth = self.topological_depth.saturating_add(1);
-                    return Some(segment);
-                }
-                b'f' => {
-                    self.position += self.delta;
-                }
-                b'+' => self.delta = self.delta.rotate(self.rot_plus),
-                b'-' => self.delta = self.delta.rotate(self.rot_minus),
-                b'|' => self.delta = -self.delta,
-                b'[' => self
-                    .stack
-                    .push((self.position, self.delta, self.topological_depth)),
-                b']' => {
-                    let state = self.stack.pop();
-                    debug_assert!(state.is_some(), "unmatched ] in validated program");
-                    if let Some((pos, delta, topological_depth)) = state {
-                        self.position = pos;
-                        self.delta = delta;
-                        self.topological_depth = topological_depth;
-                    }
-                }
-                _ => {}
+            let symbol = self.symbols.next()?;
+            if let Some(segment) = self.state.apply(symbol) {
+                return Some(segment);
             }
         }
+    }
+
+    fn fold<B, F>(self, init: B, mut f: F) -> B
+    where
+        Self: Sized,
+        F: FnMut(B, Self::Item) -> B,
+    {
+        let mut state = self.state;
+        self.symbols
+            .fold(init, |acc, symbol| match state.apply(symbol) {
+                Some(segment) => f(acc, segment),
+                None => acc,
+            })
     }
 }
 
@@ -90,11 +134,20 @@ impl<I: Iterator<Item = u8>> Iterator for Segments2D<I> {
     fn next(&mut self) -> Option<[Vec2; 2]> {
         self.inner.next().map(|segment| segment.points)
     }
+
+    fn fold<B, F>(self, init: B, mut f: F) -> B
+    where
+        Self: Sized,
+        F: FnMut(B, Self::Item) -> B,
+    {
+        self.inner.fold(init, |acc, segment| f(acc, segment.points))
+    }
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::test_util::{FoldOnly, collect_with_next};
     use crate::{Dimensions, GenerationConfig};
     use std::collections::BTreeMap;
 
@@ -312,5 +365,53 @@ mod tests {
             (b - expected).length() < 1e-5,
             "step=2 at 45° should end near {expected}: {b}"
         );
+    }
+
+    #[test]
+    fn fold_uses_symbol_fold_for_plain_and_depth_segments() {
+        let plain = Segments2D::new(FoldOnly::new(b"F[+F]f-F".iter().copied()), 90.0, 1.0, 0.0)
+            .fold(Vec::new(), |mut segments, segment| {
+                segments.push(segment);
+                segments
+            });
+        let with_depth = Segments2DWithTopologicalDepth::new(
+            FoldOnly::new(b"F[+F]f-F".iter().copied()),
+            90.0,
+            1.0,
+            0.0,
+        )
+        .fold(Vec::new(), |mut segments, segment| {
+            segments.push(segment);
+            segments
+        });
+
+        assert_eq!(plain.len(), 3);
+        assert_eq!(with_depth.len(), 3);
+    }
+
+    #[test]
+    fn plant_fold_matches_repeated_next_with_depths() {
+        let config = GenerationConfig {
+            dimensions: Dimensions::TwoD,
+            axiom: "X".to_string(),
+            iterations: 4,
+            angle: 23.4,
+            step: 1.0,
+            initial_heading: 90.0,
+            rules: BTreeMap::from([
+                ('X', "F+[[X]-X]-F[-FX]+X".to_string()),
+                ('F', "FF".to_string()),
+            ]),
+        };
+        let folded = crate::generate_with_topological_depth(&config).fold(
+            Vec::new(),
+            |mut segments, segment| {
+                segments.push(segment);
+                segments
+            },
+        );
+        let stepped = collect_with_next(crate::generate_with_topological_depth(&config));
+
+        assert_eq!(folded, stepped);
     }
 }

--- a/crates/lsystem-core/src/turtle/turtle3d.rs
+++ b/crates/lsystem-core/src/turtle/turtle3d.rs
@@ -9,6 +9,12 @@ pub(crate) struct Segments3D<I: Iterator<Item = u8>> {
 
 pub(crate) struct Segments3DWithTopologicalDepth<I: Iterator<Item = u8>> {
     symbols: I,
+    state: TurtleState3D,
+}
+
+/// Turtle state plus the single symbol transition shared by `next` and `fold`,
+/// so the two iteration paths cannot drift apart.
+struct TurtleState3D {
     rot_yaw_plus: Quat,
     rot_yaw_minus: Quat,
     rot_pitch_down: Quat,
@@ -23,23 +29,93 @@ pub(crate) struct Segments3DWithTopologicalDepth<I: Iterator<Item = u8>> {
     stack: Vec<(Vec3, Quat, u32)>,
 }
 
+impl TurtleState3D {
+    #[inline]
+    fn apply(&mut self, symbol: u8) -> Option<Segment3DWithTopologicalDepth> {
+        match symbol {
+            b'F' => {
+                let forward = self.orientation * Vec3::X;
+                let next = self.position + forward * self.step;
+                let segment = Segment3DWithTopologicalDepth {
+                    points: [self.position, next],
+                    topological_depth: self.topological_depth,
+                };
+                self.position = next;
+                self.topological_depth = self.topological_depth.saturating_add(1);
+                Some(segment)
+            }
+            b'f' => {
+                let forward = self.orientation * Vec3::X;
+                self.position += forward * self.step;
+                None
+            }
+            b'+' => {
+                self.orientation *= self.rot_yaw_plus;
+                None
+            }
+            b'-' => {
+                self.orientation *= self.rot_yaw_minus;
+                None
+            }
+            b'&' => {
+                self.orientation *= self.rot_pitch_down;
+                None
+            }
+            b'^' => {
+                self.orientation *= self.rot_pitch_up;
+                None
+            }
+            b'/' => {
+                self.orientation *= self.rot_roll_right;
+                None
+            }
+            b'\\' => {
+                self.orientation *= self.rot_roll_left;
+                None
+            }
+            b'|' => {
+                self.orientation *= self.rot_uturn;
+                None
+            }
+            b'[' => {
+                self.stack
+                    .push((self.position, self.orientation, self.topological_depth));
+                None
+            }
+            b']' => {
+                let state = self.stack.pop();
+                debug_assert!(state.is_some(), "unmatched ] in validated program");
+                if let Some((position, orientation, topological_depth)) = state {
+                    self.position = position;
+                    self.orientation = orientation;
+                    self.topological_depth = topological_depth;
+                }
+                None
+            }
+            _ => None,
+        }
+    }
+}
+
 impl<I: Iterator<Item = u8>> Segments3DWithTopologicalDepth<I> {
     pub(crate) fn new(symbols: I, angle_deg: f32, step: f32, initial_heading_deg: f32) -> Self {
         let angle_rad = angle_deg.to_radians();
         Self {
             symbols,
-            rot_yaw_plus: Quat::from_rotation_z(angle_rad),
-            rot_yaw_minus: Quat::from_rotation_z(-angle_rad),
-            rot_pitch_down: Quat::from_rotation_y(angle_rad),
-            rot_pitch_up: Quat::from_rotation_y(-angle_rad),
-            rot_roll_right: Quat::from_rotation_x(angle_rad),
-            rot_roll_left: Quat::from_rotation_x(-angle_rad),
-            rot_uturn: Quat::from_rotation_z(std::f32::consts::PI),
-            step,
-            position: Vec3::ZERO,
-            orientation: Quat::from_rotation_z(initial_heading_deg.to_radians()),
-            topological_depth: 0,
-            stack: Vec::new(),
+            state: TurtleState3D {
+                rot_yaw_plus: Quat::from_rotation_z(angle_rad),
+                rot_yaw_minus: Quat::from_rotation_z(-angle_rad),
+                rot_pitch_down: Quat::from_rotation_y(angle_rad),
+                rot_pitch_up: Quat::from_rotation_y(-angle_rad),
+                rot_roll_right: Quat::from_rotation_x(angle_rad),
+                rot_roll_left: Quat::from_rotation_x(-angle_rad),
+                rot_uturn: Quat::from_rotation_z(std::f32::consts::PI),
+                step,
+                position: Vec3::ZERO,
+                orientation: Quat::from_rotation_z(initial_heading_deg.to_radians()),
+                topological_depth: 0,
+                stack: Vec::new(),
+            },
         }
     }
 }
@@ -49,44 +125,24 @@ impl<I: Iterator<Item = u8>> Iterator for Segments3DWithTopologicalDepth<I> {
 
     fn next(&mut self) -> Option<Self::Item> {
         loop {
-            match self.symbols.next()? {
-                b'F' => {
-                    let forward = self.orientation * Vec3::X;
-                    let next = self.position + forward * self.step;
-                    let segment = Segment3DWithTopologicalDepth {
-                        points: [self.position, next],
-                        topological_depth: self.topological_depth,
-                    };
-                    self.position = next;
-                    self.topological_depth = self.topological_depth.saturating_add(1);
-                    return Some(segment);
-                }
-                b'f' => {
-                    let forward = self.orientation * Vec3::X;
-                    self.position += forward * self.step;
-                }
-                b'+' => self.orientation *= self.rot_yaw_plus,
-                b'-' => self.orientation *= self.rot_yaw_minus,
-                b'&' => self.orientation *= self.rot_pitch_down,
-                b'^' => self.orientation *= self.rot_pitch_up,
-                b'/' => self.orientation *= self.rot_roll_right,
-                b'\\' => self.orientation *= self.rot_roll_left,
-                b'|' => self.orientation *= self.rot_uturn,
-                b'[' => self
-                    .stack
-                    .push((self.position, self.orientation, self.topological_depth)),
-                b']' => {
-                    let state = self.stack.pop();
-                    debug_assert!(state.is_some(), "unmatched ] in validated program");
-                    if let Some((pos, orient, topological_depth)) = state {
-                        self.position = pos;
-                        self.orientation = orient;
-                        self.topological_depth = topological_depth;
-                    }
-                }
-                _ => {}
+            let symbol = self.symbols.next()?;
+            if let Some(segment) = self.state.apply(symbol) {
+                return Some(segment);
             }
         }
+    }
+
+    fn fold<B, F>(self, init: B, mut f: F) -> B
+    where
+        Self: Sized,
+        F: FnMut(B, Self::Item) -> B,
+    {
+        let mut state = self.state;
+        self.symbols
+            .fold(init, |acc, symbol| match state.apply(symbol) {
+                Some(segment) => f(acc, segment),
+                None => acc,
+            })
     }
 }
 
@@ -109,11 +165,20 @@ impl<I: Iterator<Item = u8>> Iterator for Segments3D<I> {
     fn next(&mut self) -> Option<[Vec3; 2]> {
         self.inner.next().map(|segment| segment.points)
     }
+
+    fn fold<B, F>(self, init: B, mut f: F) -> B
+    where
+        Self: Sized,
+        F: FnMut(B, Self::Item) -> B,
+    {
+        self.inner.fold(init, |acc, segment| f(acc, segment.points))
+    }
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::test_util::{FoldOnly, collect_with_next};
     use crate::{Dimensions, GenerationConfig};
     use std::collections::BTreeMap;
 
@@ -160,6 +225,51 @@ mod tests {
         let [a, b] = segments[0];
         assert!(a.distance(Vec3::ZERO) < 1e-5);
         assert!(b.distance(Vec3::Y) < 1e-5, "end: {b}");
+    }
+
+    #[test]
+    fn fold_uses_symbol_fold_for_plain_and_depth_segments() {
+        let plain = Segments3D::new(FoldOnly::new(br"F[+/F]f-F".iter().copied()), 90.0, 1.0, 0.0)
+            .fold(Vec::new(), |mut segments, segment| {
+                segments.push(segment);
+                segments
+            });
+        let with_depth = Segments3DWithTopologicalDepth::new(
+            FoldOnly::new(br"F[+/F]f-F".iter().copied()),
+            90.0,
+            1.0,
+            0.0,
+        )
+        .fold(Vec::new(), |mut segments, segment| {
+            segments.push(segment);
+            segments
+        });
+
+        assert_eq!(plain.len(), 3);
+        assert_eq!(with_depth.len(), 3);
+    }
+
+    #[test]
+    fn hilbert_fold_matches_repeated_next_with_depths() {
+        let config = GenerationConfig {
+            dimensions: Dimensions::ThreeD,
+            axiom: "X".to_string(),
+            iterations: 3,
+            angle: 90.0,
+            step: 1.0,
+            initial_heading: 0.0,
+            rules: BTreeMap::from([('X', r"^\XF^\XFX-F^//XFX&F+//XFX-F/X-/".to_string())]),
+        };
+        let folded = crate::generate_3d_with_topological_depth(&config).fold(
+            Vec::new(),
+            |mut segments, segment| {
+                segments.push(segment);
+                segments
+            },
+        );
+        let stepped = collect_with_next(crate::generate_3d_with_topological_depth(&config));
+
+        assert_eq!(folded, stepped);
     }
 
     #[test]

--- a/crates/lsystem-renderer/src/lsystem_bridge.rs
+++ b/crates/lsystem-renderer/src/lsystem_bridge.rs
@@ -62,9 +62,7 @@ impl Default for SegmentDataBuilder {
 
 pub fn geometry_to_segments(segments: impl Iterator<Item = [Vec2; 2]>) -> SegmentData {
     let mut builder = SegmentDataBuilder::new();
-    for segment in segments {
-        builder.push_segment(segment);
-    }
+    segments.for_each(|segment| builder.push_segment(segment));
     builder.finish()
 }
 
@@ -142,9 +140,7 @@ pub fn geometry_to_depth_segments(
     segments: impl Iterator<Item = Segment2DWithTopologicalDepth>,
 ) -> TopologicalDepthSegmentData {
     let mut builder = TopologicalDepthSegmentDataBuilder::new();
-    for segment in segments {
-        builder.push_segment(segment);
-    }
+    segments.for_each(|segment| builder.push_segment(segment));
     builder.finish()
 }
 
@@ -213,9 +209,7 @@ impl Default for SegmentDataBuilder3D {
 
 pub fn geometry_to_segments_3d(segments: impl Iterator<Item = [Vec3; 2]>) -> SegmentData3D {
     let mut builder = SegmentDataBuilder3D::new();
-    for segment in segments {
-        builder.push_segment(segment);
-    }
+    segments.for_each(|segment| builder.push_segment(segment));
     builder.finish()
 }
 
@@ -302,9 +296,7 @@ pub fn geometry_to_depth_segments_3d(
     segments: impl Iterator<Item = Segment3DWithTopologicalDepth>,
 ) -> TopologicalDepthSegmentData3D {
     let mut builder = TopologicalDepthSegmentDataBuilder3D::new();
-    for segment in segments {
-        builder.push_segment(segment);
-    }
+    segments.for_each(|segment| builder.push_segment(segment));
     builder.finish()
 }
 
@@ -391,6 +383,34 @@ mod tests {
 
     const EPS: f32 = 1e-5;
 
+    struct FoldOnly<T> {
+        items: std::vec::IntoIter<T>,
+    }
+
+    impl<T> FoldOnly<T> {
+        fn new(items: Vec<T>) -> Self {
+            Self {
+                items: items.into_iter(),
+            }
+        }
+    }
+
+    impl<T> Iterator for FoldOnly<T> {
+        type Item = T;
+
+        fn next(&mut self) -> Option<Self::Item> {
+            panic!("renderer bridge must drain geometry through fold")
+        }
+
+        fn fold<B, F>(self, init: B, f: F) -> B
+        where
+            Self: Sized,
+            F: FnMut(B, Self::Item) -> B,
+        {
+            self.items.fold(init, f)
+        }
+    }
+
     fn close(a: f32, b: f32) -> bool {
         (a - b).abs() < EPS
     }
@@ -398,6 +418,30 @@ mod tests {
     fn hex_rgba(hex: Rgb) -> Vec4 {
         let [r, g, b] = hex.to_array();
         Vec4::new(r, g, b, 1.0)
+    }
+
+    #[test]
+    fn geometry_drains_use_iterator_fold() {
+        let segment_2d = [Vec2::ZERO, Vec2::X];
+        let segment_3d = [Vec3::ZERO, Vec3::X];
+
+        let plain_2d = geometry_to_segments(FoldOnly::new(vec![segment_2d]));
+        let depth_2d =
+            geometry_to_depth_segments(FoldOnly::new(vec![Segment2DWithTopologicalDepth {
+                points: segment_2d,
+                topological_depth: 0,
+            }]));
+        let plain_3d = geometry_to_segments_3d(FoldOnly::new(vec![segment_3d]));
+        let depth_3d =
+            geometry_to_depth_segments_3d(FoldOnly::new(vec![Segment3DWithTopologicalDepth {
+                points: segment_3d,
+                topological_depth: 0,
+            }]));
+
+        assert_eq!(plain_2d.segments.len(), 1);
+        assert_eq!(depth_2d.segments.len(), 1);
+        assert_eq!(plain_3d.segments.len(), 1);
+        assert_eq!(depth_3d.segments.len(), 1);
     }
 
     #[test]


### PR DESCRIPTION
Profiling the generation benchmark showed ~46% of self time in per-symbol iterator dispatch and ~5% in per-byte bounds-checked arena indexing — overhead, not arithmetic. This PR removes most of it while keeping the public API and the streaming architecture unchanged.

## Expansion (`lsystem-core/src/grammar.rs`)

- Specialize `Iterator::fold` on `ExpandIter`: terminal (depth-0) spans fold directly over arena slices (one bounds check per span instead of per byte); the frame stack is only touched at depth > 0. `next()` is unchanged and remains the resumable path and test oracle.
- Add `expand_effects`: appends filtered copies of the axiom and each rule RHS (effect bytes only) to the arena. Depth-0 frames stream the filtered spans, and an emit table drops pass-through bytes at depth > 0, so rewrite-only symbols (e.g. `X`, `Y` in the dragon and plant grammars) never reach the turtle. Frame pushes select the filtered or original rule table by depth with a single lookup.
- The `generate*` functions switch to `expand_effects`; unfiltered `expand` keeps its exact output for tests.

## Turtles (`turtle2d.rs`, `turtle3d.rs`)

- Symbol semantics move into `TurtleState2D/3D::apply`, a single transition function shared by `next` and the new `fold` specialization, so the two iteration paths cannot drift apart.
- `fold` moves the state into a local and drives `symbols.fold`, fusing grammar expansion, turtle stepping, and segment emission into one internal loop.

## Consumers

- The renderer bridge drain functions and SVG export now drain via `for_each`, which routes through the specialized `fold`; `collect()`/`for` loops would pull items one at a time through `next()`.

## Tests

- Stripping equivalence: `expand_effects` ≡ `expand` minus non-effect bytes (covers ruled non-ASCII symbols and 3D effect bytes).
- Fold/next equivalence: `fold` output matches repeated-`next` output segment-for-segment, including topological depths (plant 2D, Hilbert 3D), plus a fold-after-partial-`next` resume case.
- Fold-path canaries: `FoldOnly` test iterators panic in `next()` to pin that turtles and bridge stay on the `fold` path, since breaking the delegation would regress performance silently.

## Benchmarks (`cargo bench -p lsystem-core --bench generation`, vs `main`)

| Benchmark | Change |
|---|---|
| 2D dragon | −23% |
| 2D plant_a | −34% |
| 2D synthetic_forward_heavy | −45% |
| 3D branching_rotation_heavy | −24% |
| 3D hilbert_3d | −23% |
| 3D tree_roll_heavy | −14% |
| 3D synthetic_forward_heavy | −24% |