### PR TITLE
Enforce bracket balance in GenerationConfig

### DIFF
--- a/crates/lsystem-app-model/src/editor_config.rs
+++ b/crates/lsystem-app-model/src/editor_config.rs
@@ -66,17 +66,17 @@ impl EditorGenerationConfig {
     /// Fills omitted `step` and `initial_heading` from `defaults`, and clamps
     /// `iterations` to `max_iterations`. Pass `u32::MAX` to skip clamping.
     pub fn resolve(&self, defaults: &ConfigDefaults, max_iterations: u32) -> GenerationConfig {
-        GenerationConfig {
-            dimensions: self.dimensions,
-            axiom: self.axiom.clone(),
-            iterations: self.iterations.min(max_iterations),
-            angle: self.angle,
-            step: self.step.unwrap_or_else(|| defaults.l_system.step()),
-            initial_heading: self
-                .initial_heading
+        GenerationConfig::new(
+            self.dimensions,
+            self.axiom.clone(),
+            self.iterations.min(max_iterations),
+            self.angle,
+            self.step.unwrap_or_else(|| defaults.l_system.step()),
+            self.initial_heading
                 .unwrap_or_else(|| defaults.l_system.initial_heading()),
-            rules: self.rules.clone(),
-        }
+            self.rules.clone(),
+        )
+        .expect("editor validation guarantees balance")
     }
 }
 
@@ -921,12 +921,12 @@ solid = "#00e680"
 
         assert_eq!(cfg.name, "Koch Snowflake");
         assert_eq!(cfg.generation.dimensions, Dimensions::TwoD);
-        assert_eq!(cfg.generation.axiom, "F++F++F");
+        assert_eq!(cfg.generation.axiom(), "F++F++F");
         assert_eq!(cfg.generation.angle, 60.0);
         assert_eq!(cfg.generation.step, 1.0);
         assert_eq!(cfg.generation.initial_heading, 0.0);
         assert_eq!(cfg.generation.iterations, 4);
-        assert_eq!(cfg.generation.rules[&'F'], "F-F++F-F");
+        assert_eq!(cfg.generation.rules()[&'F'], "F-F++F-F");
     }
 
     #[test]
@@ -1073,12 +1073,12 @@ solid = "#00e680"
         let cfg = parse_config(NESTED_KOCH_TOML).unwrap();
         assert_eq!(cfg.name, "Koch Snowflake");
         assert_eq!(cfg.generation.dimensions, Dimensions::TwoD);
-        assert_eq!(cfg.generation.axiom, "F++F++F");
+        assert_eq!(cfg.generation.axiom(), "F++F++F");
         assert_eq!(cfg.generation.angle, 60.0);
         assert_eq!(cfg.generation.step, 1.0);
         assert_eq!(cfg.generation.initial_heading, 0.0);
         assert_eq!(cfg.generation.iterations, 4);
-        assert_eq!(cfg.generation.rules[&'F'], "F-F++F-F");
+        assert_eq!(cfg.generation.rules()[&'F'], "F-F++F-F");
         assert_eq!(cfg.colors.background, hex("#000000"));
         match cfg.colors.line {
             LineColorConfig::HueCycle { initial } => assert_eq!(initial, hex("#408080")),
@@ -1346,8 +1346,8 @@ colors.line.solid = "#00e680"
 
         assert_eq!(cfg.name, "Dotted");
         assert_eq!(cfg.generation.dimensions, Dimensions::ThreeD);
-        assert_eq!(cfg.generation.axiom, "F\\F");
-        assert_eq!(cfg.generation.rules[&'F'], "F\\F");
+        assert_eq!(cfg.generation.axiom(), "F\\F");
+        assert_eq!(cfg.generation.rules()[&'F'], "F\\F");
     }
 
     #[test]
@@ -1427,18 +1427,18 @@ solid = "#1a334d"
         assert_eq!(source.to_toml_string(), toml);
         let doc = ConfigDocument::try_from(source).unwrap();
         let cfg = resolve_doc(&doc);
-        assert_eq!(cfg.generation.axiom, "F\\F");
-        assert_eq!(cfg.generation.rules[&'F'], "F\\F");
+        assert_eq!(cfg.generation.axiom(), "F\\F");
+        assert_eq!(cfg.generation.rules()[&'F'], "F\\F");
     }
 
     #[test]
     fn parses_valid_config() {
         let cfg = parse_config(NESTED_KOCH_TOML).unwrap();
-        assert_eq!(cfg.generation.axiom, "F++F++F");
+        assert_eq!(cfg.generation.axiom(), "F++F++F");
         assert_eq!(cfg.generation.angle, 60.0);
         assert_eq!(cfg.generation.step, 1.0);
         assert_eq!(cfg.generation.iterations, 4);
-        assert_eq!(cfg.generation.rules[&'F'], "F-F++F-F");
+        assert_eq!(cfg.generation.rules()[&'F'], "F-F++F-F");
     }
 
     #[test]
@@ -1705,8 +1705,8 @@ solid = "#00e680"
             r#"F = "F - F""#,
         );
         let cfg = parse_config(&toml).unwrap();
-        assert_eq!(cfg.generation.axiom, "F++F");
-        assert_eq!(cfg.generation.rules[&'F'], "F-F");
+        assert_eq!(cfg.generation.axiom(), "F++F");
+        assert_eq!(cfg.generation.rules()[&'F'], "F-F");
     }
 
     #[test]

--- a/crates/lsystem-core/benches/generation.rs
+++ b/crates/lsystem-core/benches/generation.rs
@@ -39,48 +39,51 @@ fn bench_generation(c: &mut Criterion) {
 
         // Bracketless 2D dragon stresses right-angle turns and drawn segments
         // without stack or topological depth costs, isolating common planar turtle work.
-        let config = GenerationConfig {
-            dimensions: Dimensions::TwoD,
-            axiom: "FX".to_string(),
-            iterations: 20,
-            angle: 90.0,
-            step: 1.0,
-            initial_heading: 0.0,
-            rules: BTreeMap::from([('X', "X+YF+".to_string()), ('Y', "-FX-Y".to_string())]),
-        };
+        let config = GenerationConfig::new(
+            Dimensions::TwoD,
+            "FX".to_string(),
+            20,
+            90.0,
+            1.0,
+            0.0,
+            BTreeMap::from([('X', "X+YF+".to_string()), ('Y', "-FX-Y".to_string())]),
+        )
+        .expect("balanced config");
         group.bench_function("dragon", |b| {
             b.iter(|| black_box(checksum_2d(black_box(&config))));
         });
 
         // Plant-style 2D branching covers non-right-angle turns, stack traffic,
         // ignored symbols, and topological depth metadata that affect emitted segments.
-        let config = GenerationConfig {
-            dimensions: Dimensions::TwoD,
-            axiom: "X".to_string(),
-            iterations: 9,
-            angle: 23.4,
-            step: 1.0,
-            initial_heading: 90.0,
-            rules: BTreeMap::from([
+        let config = GenerationConfig::new(
+            Dimensions::TwoD,
+            "X".to_string(),
+            9,
+            23.4,
+            1.0,
+            90.0,
+            BTreeMap::from([
                 ('X', "F+[[X]-X]-F[-FX]+X".to_string()),
                 ('F', "FF".to_string()),
             ]),
-        };
+        )
+        .expect("balanced config");
         group.bench_function("plant_a", |b| {
             b.iter(|| black_box(checksum_2d_with_topological_depth(black_box(&config))));
         });
 
         // Synthetic forward-heavy 2D isolates F/f movement so regressions in
         // the most direct segment-emission path are not hidden by rotations.
-        let config = GenerationConfig {
-            dimensions: Dimensions::TwoD,
-            axiom: "F".to_string(),
-            iterations: 9,
-            angle: 90.0,
-            step: 1.0,
-            initial_heading: 0.0,
-            rules: BTreeMap::from([('F', "FFFFfF".to_string())]),
-        };
+        let config = GenerationConfig::new(
+            Dimensions::TwoD,
+            "F".to_string(),
+            9,
+            90.0,
+            1.0,
+            0.0,
+            BTreeMap::from([('F', "FFFFfF".to_string())]),
+        )
+        .expect("balanced config");
         group.bench_function("synthetic_2d_forward_heavy", |b| {
             b.iter(|| black_box(checksum_2d(black_box(&config))));
         });
@@ -93,67 +96,71 @@ fn bench_generation(c: &mut Criterion) {
 
         // Branching 3D combines yaw, pitch, and stack operations to guard
         // realistic orientation-heavy segment generation from regressions.
-        let config = GenerationConfig {
-            dimensions: Dimensions::ThreeD,
-            axiom: "X".to_string(),
-            iterations: 10,
-            angle: 30.0,
-            step: 1.0,
-            initial_heading: 90.0,
-            rules: BTreeMap::from([
+        let config = GenerationConfig::new(
+            Dimensions::ThreeD,
+            "X".to_string(),
+            10,
+            30.0,
+            1.0,
+            90.0,
+            BTreeMap::from([
                 ('X', "Y[+X][-X][&X][^X]".to_string()),
                 ('Y', "FFFZ".to_string()),
                 ('Z', "FZ".to_string()),
             ]),
-        };
+        )
+        .expect("balanced config");
         group.bench_function("branching_rotation_heavy", |b| {
             b.iter(|| black_box(checksum_3d(black_box(&config))));
         });
 
         // Bracketless 3D Hilbert covers all rotation axes at 90 degrees, so
         // all-axis orientation cost is visible without stack traffic.
-        let config = GenerationConfig {
-            dimensions: Dimensions::ThreeD,
-            axiom: "X".to_string(),
-            iterations: 6,
-            angle: 90.0,
-            step: 1.0,
-            initial_heading: 0.0,
-            rules: BTreeMap::from([('X', r"^\XF^\XFX-F^//XFX&F+//XFX-F/X-/".to_string())]),
-        };
+        let config = GenerationConfig::new(
+            Dimensions::ThreeD,
+            "X".to_string(),
+            6,
+            90.0,
+            1.0,
+            0.0,
+            BTreeMap::from([('X', r"^\XF^\XFX-F^//XFX&F+//XFX-F/X-/".to_string())]),
+        )
+        .expect("balanced config");
         group.bench_function("hilbert_3d", |b| {
             b.iter(|| black_box(checksum_3d(black_box(&config))));
         });
 
         // Roll-heavy 3D tree exercises stack and topological depth-aware segment output;
         // it guards roll handling because roll should not change forward motion.
-        let config = GenerationConfig {
-            dimensions: Dimensions::ThreeD,
-            axiom: "A".to_string(),
-            iterations: 9,
-            angle: 40.0,
-            step: 1.0,
-            initial_heading: 90.0,
-            rules: BTreeMap::from([
+        let config = GenerationConfig::new(
+            Dimensions::ThreeD,
+            "A".to_string(),
+            9,
+            40.0,
+            1.0,
+            90.0,
+            BTreeMap::from([
                 ('A', r"F[+/A]/[-/A]F[&/A]/[^/A]".to_string()),
                 ('F', "FF".to_string()),
             ]),
-        };
+        )
+        .expect("balanced config");
         group.bench_function("tree_roll_heavy", |b| {
             b.iter(|| black_box(checksum_3d_with_topological_depth(black_box(&config))));
         });
 
         // Synthetic forward-heavy 3D isolates F/f movement so the direct 3D
         // segment-emission path has a baseline without rotation or stack noise.
-        let config = GenerationConfig {
-            dimensions: Dimensions::ThreeD,
-            axiom: "F".to_string(),
-            iterations: 9,
-            angle: 30.0,
-            step: 1.0,
-            initial_heading: 0.0,
-            rules: BTreeMap::from([('F', "FFFFfF".to_string())]),
-        };
+        let config = GenerationConfig::new(
+            Dimensions::ThreeD,
+            "F".to_string(),
+            9,
+            30.0,
+            1.0,
+            0.0,
+            BTreeMap::from([('F', "FFFFfF".to_string())]),
+        )
+        .expect("balanced config");
         group.bench_function("synthetic_3d_forward_heavy", |b| {
             b.iter(|| black_box(checksum_3d(black_box(&config))));
         });

--- a/crates/lsystem-core/src/config.rs
+++ b/crates/lsystem-core/src/config.rs
@@ -2,6 +2,7 @@ use std::collections::BTreeMap;
 
 use thiserror::Error;
 
+use crate::alphabet::validate_bracket_balance;
 use crate::grammar;
 
 #[derive(Debug, Error)]
@@ -188,10 +189,17 @@ pub struct Config {
 }
 
 /// Validated inputs needed to expand an L-system and run the turtle.
+///
+/// Construction goes through [`GenerationConfig::new`], which enforces
+/// single-letter rule keys and bracket balance on the axiom and every rule
+/// RHS — together these guarantee every expansion is balanced.
+/// Everything downstream (expansion, turtle stack handling, templates)
+/// relies on that invariant, so `axiom` and `rules` are read-only after
+/// construction.
 #[derive(Debug, Clone, PartialEq)]
 pub struct GenerationConfig {
     pub dimensions: Dimensions,
-    pub axiom: String,
+    axiom: String,
     pub iterations: u32,
     /// Turn angle in degrees.
     pub angle: f32,
@@ -200,11 +208,54 @@ pub struct GenerationConfig {
     /// Turtle heading at the start, in degrees (0 = +X, counter-clockwise positive).
     /// In 3D this is the initial yaw in the XY plane.
     pub initial_heading: f32,
-    /// Production rules: single ASCII letter → replacement string.
-    pub rules: BTreeMap<char, String>,
+    /// Production rules: single letter → replacement string.
+    rules: BTreeMap<char, String>,
 }
 
 impl GenerationConfig {
+    /// Creates a generation config, rejecting an unbalanced axiom or rule RHS
+    /// and rule keys that are not letters.
+    ///
+    /// Restricting rule keys to letters is part of the balance invariant: a
+    /// rule keyed on `[` or `]` could rewrite a bracket away and unbalance
+    /// the expansion even though every validated string is balanced.
+    pub fn new(
+        dimensions: Dimensions,
+        axiom: String,
+        iterations: u32,
+        angle: f32,
+        step: f32,
+        initial_heading: f32,
+        rules: BTreeMap<char, String>,
+    ) -> Result<Self, ConfigError> {
+        validate_bracket_balance(&axiom, "axiom")?;
+        for (key, rhs) in &rules {
+            if !key.is_alphabetic() {
+                return Err(ConfigError::InvalidRuleKey {
+                    key: key.to_string(),
+                });
+            }
+            validate_bracket_balance(rhs, &format!("rules.{key}"))?;
+        }
+        Ok(Self {
+            dimensions,
+            axiom,
+            iterations,
+            angle,
+            step,
+            initial_heading,
+            rules,
+        })
+    }
+
+    pub fn axiom(&self) -> &str {
+        &self.axiom
+    }
+
+    pub fn rules(&self) -> &BTreeMap<char, String> {
+        &self.rules
+    }
+
     /// Returns `true` if the axiom or any rule RHS contains a `[` push directive.
     ///
     /// Only `[` needs checking; bracket balance is validated, so `]` cannot appear alone.
@@ -220,6 +271,84 @@ impl GenerationConfig {
 
 pub(crate) fn has_stack_directives(axiom: &str, rules: &BTreeMap<char, String>) -> bool {
     axiom.contains('[') || rules.values().any(|rhs| rhs.contains('['))
+}
+
+#[cfg(test)]
+mod generation_config {
+    use super::*;
+
+    fn new(axiom: &str, rules: BTreeMap<char, String>) -> Result<GenerationConfig, ConfigError> {
+        GenerationConfig::new(
+            Dimensions::TwoD,
+            axiom.to_string(),
+            1,
+            90.0,
+            1.0,
+            0.0,
+            rules,
+        )
+    }
+
+    #[test]
+    fn accepts_balanced_axiom_and_rules() {
+        let config = new("F[+F]F", BTreeMap::from([('F', "F[-F]+[F]".to_string())]))
+            .expect("balanced config");
+        assert_eq!(config.axiom(), "F[+F]F");
+        assert_eq!(config.rules()[&'F'], "F[-F]+[F]");
+    }
+
+    #[test]
+    fn rejects_unbalanced_axiom() {
+        assert!(matches!(
+            new("F[+F", BTreeMap::new()),
+            Err(ConfigError::UnmatchedOpen { field, .. }) if field == "axiom"
+        ));
+        assert!(matches!(
+            new("F]F", BTreeMap::new()),
+            Err(ConfigError::UnmatchedClose { field, .. }) if field == "axiom"
+        ));
+    }
+
+    #[test]
+    fn rejects_unbalanced_rule_rhs() {
+        assert!(matches!(
+            new("F", BTreeMap::from([('F', "F[F".to_string())])),
+            Err(ConfigError::UnmatchedOpen { field, .. }) if field == "rules.F"
+        ));
+    }
+
+    #[test]
+    fn rejects_non_letter_rule_key() {
+        // A rule keyed on a bracket could rewrite the bracket away and
+        // unbalance the expansion, so keys are restricted to letters.
+        assert!(matches!(
+            new("[]", BTreeMap::from([('[', String::new())])),
+            Err(ConfigError::InvalidRuleKey { key }) if key == "["
+        ));
+        assert!(matches!(
+            new("F", BTreeMap::from([('+', "F".to_string())])),
+            Err(ConfigError::InvalidRuleKey { key }) if key == "+"
+        ));
+    }
+
+    #[test]
+    fn accepts_non_ascii_letter_rule_key() {
+        // Non-ASCII letters are valid rule symbols; the grammar assigns them
+        // dedicated byte IDs during compilation.
+        let config =
+            new("ä", BTreeMap::from([('ä', "F[+ä]".to_string())])).expect("balanced config");
+        assert_eq!(config.rules()[&'ä'], "F[+ä]");
+    }
+
+    #[test]
+    fn rejects_unbalanced_rhs_of_unreachable_rule() {
+        // Balance is a construction invariant of the whole config, not a
+        // property of what expansion happens to reach.
+        assert!(matches!(
+            new("F", BTreeMap::from([('Z', "F]".to_string())])),
+            Err(ConfigError::UnmatchedClose { field, .. }) if field == "rules.Z"
+        ));
+    }
 }
 
 #[cfg(test)]

--- a/crates/lsystem-core/src/lib.rs
+++ b/crates/lsystem-core/src/lib.rs
@@ -40,7 +40,7 @@ pub struct Segment3DWithTopologicalDepth {
 
 /// Expand the grammar and run the 2D turtle, returning a lazy iterator of line segments.
 pub fn generate(config: &GenerationConfig) -> impl Iterator<Item = [Vec2; 2]> + '_ {
-    let symbols = grammar::expand_effects(&config.axiom, &config.rules, config.iterations);
+    let symbols = grammar::expand_effects(config.axiom(), config.rules(), config.iterations);
     turtle::turtle2d::Segments2D::new(symbols, config.angle, config.step, config.initial_heading)
 }
 
@@ -48,7 +48,7 @@ pub fn generate(config: &GenerationConfig) -> impl Iterator<Item = [Vec2; 2]> + 
 pub fn generate_with_topological_depth(
     config: &GenerationConfig,
 ) -> impl Iterator<Item = Segment2DWithTopologicalDepth> + '_ {
-    let symbols = grammar::expand_effects(&config.axiom, &config.rules, config.iterations);
+    let symbols = grammar::expand_effects(config.axiom(), config.rules(), config.iterations);
     turtle::turtle2d::Segments2DWithTopologicalDepth::new(
         symbols,
         config.angle,
@@ -59,7 +59,7 @@ pub fn generate_with_topological_depth(
 
 /// Like `generate` but runs the 3D turtle.
 pub fn generate_3d(config: &GenerationConfig) -> impl Iterator<Item = [Vec3; 2]> + '_ {
-    let symbols = grammar::expand_effects(&config.axiom, &config.rules, config.iterations);
+    let symbols = grammar::expand_effects(config.axiom(), config.rules(), config.iterations);
     turtle::turtle3d::Segments3D::new(symbols, config.angle, config.step, config.initial_heading)
 }
 
@@ -67,7 +67,7 @@ pub fn generate_3d(config: &GenerationConfig) -> impl Iterator<Item = [Vec3; 2]>
 pub fn generate_3d_with_topological_depth(
     config: &GenerationConfig,
 ) -> impl Iterator<Item = Segment3DWithTopologicalDepth> + '_ {
-    let symbols = grammar::expand_effects(&config.axiom, &config.rules, config.iterations);
+    let symbols = grammar::expand_effects(config.axiom(), config.rules(), config.iterations);
     turtle::turtle3d::Segments3DWithTopologicalDepth::new(
         symbols,
         config.angle,

--- a/crates/lsystem-core/src/svg_export.rs
+++ b/crates/lsystem-core/src/svg_export.rs
@@ -225,15 +225,16 @@ mod tests {
     fn make_config(axiom: &str, line: LineColorConfig) -> Config {
         Config {
             name: "Test".to_string(),
-            generation: GenerationConfig {
-                dimensions: Dimensions::TwoD,
-                axiom: axiom.to_string(),
-                iterations: 1,
-                angle: 90.0,
-                step: 1.0,
-                initial_heading: 0.0,
-                rules: BTreeMap::new(),
-            },
+            generation: GenerationConfig::new(
+                Dimensions::TwoD,
+                axiom.to_string(),
+                1,
+                90.0,
+                1.0,
+                0.0,
+                BTreeMap::new(),
+            )
+            .expect("balanced config"),
             colors: ColorConfig {
                 background: Rgb::new(0, 0, 0),
                 line,

--- a/crates/lsystem-core/src/turtle/turtle2d.rs
+++ b/crates/lsystem-core/src/turtle/turtle2d.rs
@@ -152,15 +152,16 @@ mod tests {
     use std::collections::BTreeMap;
 
     fn gen_config(axiom: &str) -> GenerationConfig {
-        GenerationConfig {
-            dimensions: Dimensions::TwoD,
-            axiom: axiom.to_string(),
-            iterations: 0,
-            angle: 90.0,
-            step: 1.0,
-            initial_heading: 0.0,
-            rules: BTreeMap::new(),
-        }
+        GenerationConfig::new(
+            Dimensions::TwoD,
+            axiom.to_string(),
+            0,
+            90.0,
+            1.0,
+            0.0,
+            BTreeMap::new(),
+        )
+        .expect("balanced config")
     }
 
     #[test]
@@ -208,15 +209,16 @@ mod tests {
     #[test]
     fn koch_segment_count() {
         for (iters, expected) in [(0u32, 3usize), (1, 12), (2, 48), (3, 192), (4, 768)] {
-            let cfg = GenerationConfig {
-                dimensions: Dimensions::TwoD,
-                axiom: "F++F++F".to_string(),
-                iterations: iters,
-                angle: 60.0,
-                step: 1.0,
-                initial_heading: 0.0,
-                rules: BTreeMap::from([('F', "F-F++F-F".to_string())]),
-            };
+            let cfg = GenerationConfig::new(
+                Dimensions::TwoD,
+                "F++F++F".to_string(),
+                iters,
+                60.0,
+                1.0,
+                0.0,
+                BTreeMap::from([('F', "F-F++F-F".to_string())]),
+            )
+            .expect("balanced config");
             let segments: Vec<[Vec2; 2]> = crate::generate(&cfg).collect();
             assert_eq!(segments.len(), expected, "iter {iters}");
         }
@@ -299,15 +301,16 @@ mod tests {
         // catching delta length drift independently of endpoint closure.
         let rules = BTreeMap::from([('F', "F-F++F-F".to_string())]);
         for iters in 4u32..=6 {
-            let config = GenerationConfig {
-                dimensions: Dimensions::TwoD,
-                axiom: "F++F++F".to_string(),
-                iterations: iters,
-                angle: 60.0,
-                step: 1.0,
-                initial_heading: 0.0,
-                rules: rules.clone(),
-            };
+            let config = GenerationConfig::new(
+                Dimensions::TwoD,
+                "F++F++F".to_string(),
+                iters,
+                60.0,
+                1.0,
+                0.0,
+                rules.clone(),
+            )
+            .expect("balanced config");
             let segments: Vec<[Vec2; 2]> = crate::generate(&config).collect();
             let end = segments.last().expect("non-empty")[1];
             assert!(
@@ -344,15 +347,16 @@ mod tests {
     fn non_default_heading_and_step() {
         // Validates that delta is correctly initialized from a non-default
         // initial heading and step, not just the 0°/1.0 default.
-        let config = GenerationConfig {
-            dimensions: Dimensions::TwoD,
-            axiom: "F".to_string(),
-            iterations: 0,
-            angle: 90.0,
-            step: 2.0,
-            initial_heading: 45.0,
-            rules: BTreeMap::new(),
-        };
+        let config = GenerationConfig::new(
+            Dimensions::TwoD,
+            "F".to_string(),
+            0,
+            90.0,
+            2.0,
+            45.0,
+            BTreeMap::new(),
+        )
+        .expect("balanced config");
         let segments: Vec<[Vec2; 2]> = crate::generate(&config).collect();
         assert_eq!(segments.len(), 1);
         let [a, b] = segments[0];
@@ -391,18 +395,19 @@ mod tests {
 
     #[test]
     fn plant_fold_matches_repeated_next_with_depths() {
-        let config = GenerationConfig {
-            dimensions: Dimensions::TwoD,
-            axiom: "X".to_string(),
-            iterations: 4,
-            angle: 23.4,
-            step: 1.0,
-            initial_heading: 90.0,
-            rules: BTreeMap::from([
+        let config = GenerationConfig::new(
+            Dimensions::TwoD,
+            "X".to_string(),
+            4,
+            23.4,
+            1.0,
+            90.0,
+            BTreeMap::from([
                 ('X', "F+[[X]-X]-F[-FX]+X".to_string()),
                 ('F', "FF".to_string()),
             ]),
-        };
+        )
+        .expect("balanced config");
         let folded = crate::generate_with_topological_depth(&config).fold(
             Vec::new(),
             |mut segments, segment| {

--- a/crates/lsystem-core/src/turtle/turtle3d.rs
+++ b/crates/lsystem-core/src/turtle/turtle3d.rs
@@ -210,15 +210,16 @@ mod tests {
 
     #[test]
     fn generate_3d_uses_config_initial_heading() {
-        let cfg = GenerationConfig {
-            dimensions: Dimensions::ThreeD,
-            axiom: "F".to_string(),
-            iterations: 0,
-            angle: 90.0,
-            step: 1.0,
-            initial_heading: 90.0,
-            rules: BTreeMap::new(),
-        };
+        let cfg = GenerationConfig::new(
+            Dimensions::ThreeD,
+            "F".to_string(),
+            0,
+            90.0,
+            1.0,
+            90.0,
+            BTreeMap::new(),
+        )
+        .expect("balanced config");
 
         let segments: Vec<[Vec3; 2]> = crate::generate_3d(&cfg).collect();
         assert_eq!(segments.len(), 1);
@@ -251,15 +252,16 @@ mod tests {
 
     #[test]
     fn hilbert_fold_matches_repeated_next_with_depths() {
-        let config = GenerationConfig {
-            dimensions: Dimensions::ThreeD,
-            axiom: "X".to_string(),
-            iterations: 3,
-            angle: 90.0,
-            step: 1.0,
-            initial_heading: 0.0,
-            rules: BTreeMap::from([('X', r"^\XF^\XFX-F^//XFX&F+//XFX-F/X-/".to_string())]),
-        };
+        let config = GenerationConfig::new(
+            Dimensions::ThreeD,
+            "X".to_string(),
+            3,
+            90.0,
+            1.0,
+            0.0,
+            BTreeMap::from([('X', r"^\XF^\XFX-F^//XFX&F+//XFX-F/X-/".to_string())]),
+        )
+        .expect("balanced config");
         let folded = crate::generate_3d_with_topological_depth(&config).fold(
             Vec::new(),
             |mut segments, segment| {
@@ -303,15 +305,16 @@ mod tests {
 
     #[test]
     fn topological_depth_starts_at_zero_and_increments_per_drawn_segment() {
-        let cfg = GenerationConfig {
-            dimensions: Dimensions::ThreeD,
-            axiom: "FF".to_string(),
-            iterations: 0,
-            angle: 90.0,
-            step: 1.0,
-            initial_heading: 0.0,
-            rules: BTreeMap::new(),
-        };
+        let cfg = GenerationConfig::new(
+            Dimensions::ThreeD,
+            "FF".to_string(),
+            0,
+            90.0,
+            1.0,
+            0.0,
+            BTreeMap::new(),
+        )
+        .expect("balanced config");
         let depths: Vec<u32> = crate::generate_3d_with_topological_depth(&cfg)
             .map(|segment| segment.topological_depth)
             .collect();
@@ -321,15 +324,16 @@ mod tests {
 
     #[test]
     fn topological_depth_restores_across_branches() {
-        let cfg = GenerationConfig {
-            dimensions: Dimensions::ThreeD,
-            axiom: "F[+F]F".to_string(),
-            iterations: 0,
-            angle: 90.0,
-            step: 1.0,
-            initial_heading: 0.0,
-            rules: BTreeMap::new(),
-        };
+        let cfg = GenerationConfig::new(
+            Dimensions::ThreeD,
+            "F[+F]F".to_string(),
+            0,
+            90.0,
+            1.0,
+            0.0,
+            BTreeMap::new(),
+        )
+        .expect("balanced config");
         let depths: Vec<u32> = crate::generate_3d_with_topological_depth(&cfg)
             .map(|segment| segment.topological_depth)
             .collect();
@@ -339,15 +343,16 @@ mod tests {
 
     #[test]
     fn nested_branches_restore_topological_depth() {
-        let cfg = GenerationConfig {
-            dimensions: Dimensions::ThreeD,
-            axiom: "F[+F[+F]F]F".to_string(),
-            iterations: 0,
-            angle: 90.0,
-            step: 1.0,
-            initial_heading: 0.0,
-            rules: BTreeMap::new(),
-        };
+        let cfg = GenerationConfig::new(
+            Dimensions::ThreeD,
+            "F[+F[+F]F]F".to_string(),
+            0,
+            90.0,
+            1.0,
+            0.0,
+            BTreeMap::new(),
+        )
+        .expect("balanced config");
         let depths: Vec<u32> = crate::generate_3d_with_topological_depth(&cfg)
             .map(|segment| segment.topological_depth)
             .collect();
@@ -357,15 +362,16 @@ mod tests {
 
     #[test]
     fn moves_and_rotations_do_not_increment_topological_depth() {
-        let cfg = GenerationConfig {
-            dimensions: Dimensions::ThreeD,
-            axiom: r"Ff&^/\F".to_string(),
-            iterations: 0,
-            angle: 90.0,
-            step: 1.0,
-            initial_heading: 0.0,
-            rules: BTreeMap::new(),
-        };
+        let cfg = GenerationConfig::new(
+            Dimensions::ThreeD,
+            r"Ff&^/\F".to_string(),
+            0,
+            90.0,
+            1.0,
+            0.0,
+            BTreeMap::new(),
+        )
+        .expect("balanced config");
         let depths: Vec<u32> = crate::generate_3d_with_topological_depth(&cfg)
             .map(|segment| segment.topological_depth)
             .collect();

--- a/crates/lsystem-renderer/benches/offscreen_render.rs
+++ b/crates/lsystem-renderer/benches/offscreen_render.rs
@@ -72,14 +72,17 @@ fn bench_offscreen_render(c: &mut Criterion) {
                 },
             },
         },
-        &|iterations| GenerationConfig {
-            dimensions: Dimensions::TwoD,
-            axiom: "FX".to_string(),
-            iterations,
-            angle: 90.0,
-            step: 1.0,
-            initial_heading: 0.0,
-            rules: BTreeMap::from([('X', "X+YF+".to_string()), ('Y', "-FX-Y".to_string())]),
+        &|iterations| {
+            GenerationConfig::new(
+                Dimensions::TwoD,
+                "FX".to_string(),
+                iterations,
+                90.0,
+                1.0,
+                0.0,
+                BTreeMap::from([('X', "X+YF+".to_string()), ('Y', "-FX-Y".to_string())]),
+            )
+            .expect("balanced config")
         },
     );
     bench_render_case(
@@ -96,18 +99,21 @@ fn bench_offscreen_render(c: &mut Criterion) {
                 },
             },
         },
-        &|iterations| GenerationConfig {
-            dimensions: Dimensions::ThreeD,
-            axiom: "X".to_string(),
-            iterations,
-            angle: 30.0,
-            step: 1.0,
-            initial_heading: 90.0,
-            rules: BTreeMap::from([
-                ('X', "Y[+X][-X][&X][^X]".to_string()),
-                ('Y', "FFFZ".to_string()),
-                ('Z', "FZ".to_string()),
-            ]),
+        &|iterations| {
+            GenerationConfig::new(
+                Dimensions::ThreeD,
+                "X".to_string(),
+                iterations,
+                30.0,
+                1.0,
+                90.0,
+                BTreeMap::from([
+                    ('X', "Y[+X][-X][&X][^X]".to_string()),
+                    ('Y', "FFFZ".to_string()),
+                    ('Z', "FZ".to_string()),
+                ]),
+            )
+            .expect("balanced config")
         },
     );
 }

--- a/crates/lsystem-renderer/src/animation_export.rs
+++ b/crates/lsystem-renderer/src/animation_export.rs
@@ -307,15 +307,16 @@ mod gpu_tests {
     fn trivial_config() -> lsystem_core::Config {
         lsystem_core::Config {
             name: "test".to_string(),
-            generation: GenerationConfig {
-                dimensions: Dimensions::TwoD,
-                axiom: "F".to_string(),
-                iterations: 0,
-                angle: 90.0,
-                step: 1.0,
-                initial_heading: 0.0,
-                rules: BTreeMap::new(),
-            },
+            generation: GenerationConfig::new(
+                Dimensions::TwoD,
+                "F".to_string(),
+                0,
+                90.0,
+                1.0,
+                0.0,
+                BTreeMap::new(),
+            )
+            .expect("balanced config"),
             colors: lsystem_core::ColorConfig {
                 background: lsystem_core::Rgb::new(0, 0, 0),
                 line: lsystem_core::LineColorConfig::Solid(lsystem_core::Rgb::new(255, 255, 255)),

--- a/crates/lsystem-renderer/src/lsystem_bridge.rs
+++ b/crates/lsystem-renderer/src/lsystem_bridge.rs
@@ -556,15 +556,16 @@ mod tests {
     }
 
     fn cfg(axiom: &str) -> GenerationConfig {
-        GenerationConfig {
-            dimensions: Dimensions::TwoD,
-            axiom: axiom.to_string(),
-            iterations: 0,
-            angle: 90.0,
-            step: 1.0,
-            initial_heading: 0.0,
-            rules: BTreeMap::new(),
-        }
+        GenerationConfig::new(
+            Dimensions::TwoD,
+            axiom.to_string(),
+            0,
+            90.0,
+            1.0,
+            0.0,
+            BTreeMap::new(),
+        )
+        .expect("balanced config")
     }
 
     #[test]
@@ -593,15 +594,16 @@ mod tests {
     #[test]
     fn empty_depth_geometry_3d_uses_fallback_bounds_and_zero_max_depth() {
         let data = geometry_to_depth_segments_3d(lsystem_core::generate_3d_with_topological_depth(
-            &GenerationConfig {
-                dimensions: Dimensions::ThreeD,
-                axiom: "A".to_string(),
-                iterations: 0,
-                angle: 90.0,
-                step: 1.0,
-                initial_heading: 0.0,
-                rules: BTreeMap::new(),
-            },
+            &GenerationConfig::new(
+                Dimensions::ThreeD,
+                "A".to_string(),
+                0,
+                90.0,
+                1.0,
+                0.0,
+                BTreeMap::new(),
+            )
+            .expect("balanced config"),
         ));
 
         assert!(data.segments.is_empty());
@@ -654,15 +656,16 @@ mod tests {
     #[test]
     fn topological_depth_segments_3d_preserve_depth_and_compute_max() {
         let data = geometry_to_depth_segments_3d(lsystem_core::generate_3d_with_topological_depth(
-            &GenerationConfig {
-                dimensions: Dimensions::ThreeD,
-                axiom: "F[+F]F".to_string(),
-                iterations: 0,
-                angle: 90.0,
-                step: 1.0,
-                initial_heading: 0.0,
-                rules: BTreeMap::new(),
-            },
+            &GenerationConfig::new(
+                Dimensions::ThreeD,
+                "F[+F]F".to_string(),
+                0,
+                90.0,
+                1.0,
+                0.0,
+                BTreeMap::new(),
+            )
+            .expect("balanced config"),
         ));
 
         assert_eq!(data.segments.len(), 3);

--- a/crates/lsystem-renderer/src/png_export.rs
+++ b/crates/lsystem-renderer/src/png_export.rs
@@ -199,15 +199,16 @@ mod gpu_tests {
     fn trivial_config() -> lsystem_core::Config {
         lsystem_core::Config {
             name: "test".to_string(),
-            generation: GenerationConfig {
-                dimensions: Dimensions::TwoD,
-                axiom: "F".to_string(),
-                iterations: 0,
-                angle: 90.0,
-                step: 1.0,
-                initial_heading: 0.0,
-                rules: BTreeMap::new(),
-            },
+            generation: GenerationConfig::new(
+                Dimensions::TwoD,
+                "F".to_string(),
+                0,
+                90.0,
+                1.0,
+                0.0,
+                BTreeMap::new(),
+            )
+            .expect("balanced config"),
             colors: lsystem_core::ColorConfig {
                 background: Rgb::new(0, 0, 0),
                 line: LineColorConfig::Solid(Rgb::new(255, 255, 255)),
@@ -283,8 +284,16 @@ mod gpu_tests {
 
     fn depth_gradient_config(dimensions: Dimensions) -> lsystem_core::Config {
         let mut config = trivial_config();
-        config.generation.dimensions = dimensions;
-        config.generation.axiom = "F[+F]F".to_string();
+        config.generation = GenerationConfig::new(
+            dimensions,
+            "F[+F]F".to_string(),
+            0,
+            90.0,
+            1.0,
+            0.0,
+            BTreeMap::new(),
+        )
+        .expect("balanced config");
         config.colors.line = LineColorConfig::Gradient {
             start: Rgb::new(255, 0, 0),
             end: Rgb::new(0, 0, 255),

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -66,6 +66,11 @@ than caching resolved values inside the editor document.
 - `turtle/turtle2d.rs` yields 2D line segments from expanded symbols.
 - `turtle/turtle3d.rs` yields 3D line segments using quaternion orientation.
 - `config.rs` defines validated runtime config and color types.
+  `GenerationConfig::new` is the only way to build a generation config; it
+  enforces single-letter rule keys and bracket balance on the axiom and every
+  rule RHS, so every expansion is balanced and downstream code (turtle stack
+  handling, templates) relies on that invariant instead of re-validating.
+  The axiom and rules are read-only after construction.
 - `svg_export.rs` exports resolved 2D configs when the `svg` feature is enabled.
 
 3D turtle orientation is stored as a `glam::Quat`. Heading, left, and up vectors


### PR DESCRIPTION
## Summary

- Add `GenerationConfig::new`, the single validated constructor: it enforces bracket balance on the axiom and every rule RHS, and rejects rule keys that are not letters — a rule keyed on `[` or `]` could rewrite a bracket away and unbalance the expansion even though every individual string is balanced. Together these guarantee every expansion is balanced.
- Make `axiom` and `rules` private with read-only accessors (`axiom()`, `rules()`), so the invariant cannot be broken by field mutation after construction. Numeric/enum fields carry no invariant and stay public.
- Migrate all construction sites (mostly test and bench fixtures across the workspace) to the constructor; the editor `resolve()` path already validates its inputs and asserts on the result.
- Document the invariant in `docs/architecture.md`.

## Motivation

The type documented itself as validated ("Validated inputs", "bracket balance is validated, so `]` cannot appear alone") and the turtle debug-asserts every `]` is matched, but only the TOML path actually validated balance — programmatic construction could produce unbalanced configs. Making the invariant structural lets downstream consumers (expansion, turtle stack handling, and the upcoming template builders) rely on balance instead of re-checking it.

## Behavior

- Non-ASCII letter rule keys (e.g. `ä`) remain valid; the grammar assigns them dedicated byte IDs during compilation.
- No change to the TOML parse/validate path or to generation output for valid configs.